### PR TITLE
Druid Fixes, Unused Content Integration, and fixing Roguetest spawns

### DIFF
--- a/_maps/map_files/roguetest/roguetest.dmm
+++ b/_maps/map_files/roguetest/roguetest.dmm
@@ -1121,11 +1121,19 @@
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors)
+"qG" = (
+/obj/effect/landmark/observer_start,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors)
 "rh" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods)
 "ss" = (
 /turf/open/transparent/openspace,
+/area/rogue/outdoors)
+"sK" = (
+/obj/effect/landmark/shuttle_import,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors)
 "vV" = (
 /obj/structure/ladder,
@@ -1134,9 +1142,23 @@
 "vW" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/warehouse)
+"xh" = (
+/obj/effect/landmark/start,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors)
+"Fo" = (
+/obj/effect/landmark/start/lady,
+/turf/open/floor/rogue/carpet/lord/left,
+/area/rogue/indoors)
 "QR" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods)
+"Ty" = (
+/obj/effect/landmark/start/lord{
+	dir = 8
+	},
+/turf/open/floor/rogue/carpet/lord/right,
+/area/rogue/indoors)
 "Uv" = (
 /turf/closed,
 /area/rogue)
@@ -7003,7 +7025,7 @@ cN
 ab
 aj
 cU
-cU
+Fo
 cU
 cM
 qw
@@ -7265,7 +7287,7 @@ cV
 aJ
 aJ
 aJ
-aJ
+qG
 al
 aL
 al
@@ -7517,7 +7539,7 @@ cN
 ab
 aj
 cW
-cX
+Ty
 cX
 aJ
 aJ
@@ -8813,7 +8835,7 @@ aJ
 cI
 aJ
 aJ
-aJ
+sK
 aJ
 aJ
 cm
@@ -9069,7 +9091,7 @@ aJ
 aJ
 aJ
 aJ
-aJ
+xh
 aJ
 aJ
 aJ

--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -26,7 +26,7 @@
 	boons = "None... yet."
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	t1 = /obj/effect/proc_holder/spell/invoked/blindness
-	t2 = null
+	t2 = /obj/effect/proc_holder/spell/invoked/invisibility
 	t3 = null
 
 /datum/patron/divine/dendor
@@ -38,7 +38,7 @@
 	sins = "Deforestation, Overhunting, Disrespecting Nature"
 	boons = "Immunity to kneestingers."
 	added_traits = list(TRAIT_KNEESTINGER_IMMUNITY)
-	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
+	t0 = /obj/effect/proc_holder/spell/targeted/blesscrop
 	t1 = /obj/effect/proc_holder/spell/self/beastsense
 	t2 = /obj/effect/proc_holder/spell/targeted/beasttame
 	t3 = /obj/effect/proc_holder/spell/targeted/conjure_kneestingers

--- a/code/modules/jobs/job_types/roguetown/church/monk.dm
+++ b/code/modules/jobs/job_types/roguetown/church/monk.dm
@@ -68,7 +68,7 @@
 			shoes = /obj/item/clothing/shoes/roguetown/sandals
 			armor = /obj/item/clothing/suit/roguetown/shirt/robe/phys
 		if("Dendor")
-			head = /obj/item/clothing/mask/rogue/druid
+			head = /obj/item/clothing/head/roguetown/padded/briarthorns
 			neck = /obj/item/clothing/neck/roguetown/psycross/silver/dendor
 			shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/green
 			shoes = /obj/item/clothing/shoes/roguetown/sandals


### PR DESCRIPTION
Why the hell did the test map spawn you in random rooms with locked doors? cant tell ya

## About The Pull Request

Changes Druid spells, they now get blesscrops instead of lesser miracle.
Rougetest is now playable. (adds spawns for the king and queen, aswell as generic spawns)
Replaces the Druid mask Dendor spawn with the Briar thorn helm once more

## Why It's Good For The Game

Druids on farms is awesome and gives farmers more interaction.
less church replacing doctors altogether like iv'e heard complaints about.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
