### PR TITLE
Changes floor tile turf check

### DIFF
--- a/code/modules/roguetown/roguecrafting/turfs.dm
+++ b/code/modules/roguetown/roguecrafting/turfs.dm
@@ -10,10 +10,9 @@
 /datum/crafting_recipe/roguetown/turfs/woodfloor/TurfCheck(mob/user, turf/T)
 	if(isclosedturf(T))
 		return
-	if(!istype(T, /turf/open/floor/rogue/dirt))
+	if(!istype(T, /turf/open/floor/rogue))
 		if(!istype(T, /turf/open/transparent/openspace))
-			if(!istype(T, /turf/open/floor/rogue/grass))
-				return
+			return
 	return TRUE
 
 /datum/crafting_recipe/roguetown/turfs/woodwall
@@ -60,10 +59,9 @@
 /datum/crafting_recipe/roguetown/turfs/stonefloor/TurfCheck(mob/user, turf/T)
 	if(isclosedturf(T))
 		return
-	if(!istype(T, /turf/open/floor/rogue/dirt))
+	if(!istype(T, /turf/open/floor/rogue))
 		if(!istype(T, /turf/open/transparent/openspace))
-			if(!istype(T, /turf/open/floor/rogue/grass))
-				return
+			return
 	return TRUE
 
 /datum/crafting_recipe/roguetown/turfs/stonewall


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
Makes it so wooden and stone floors can be built on any `/turf/open/floor/rogue` or openspace.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
I'm assuming the original coder wanted to fix building floors on top of floors, but the original code drastically limits where you can build them. Unless someone can convince me this "problem" is worth it, this PR will allow player creativity in choosing what they want their floors to be, plus now you can replace floors.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
