### PR TITLE
Jester Z-Level Jump Trait Readded

### DIFF
--- a/code/modules/jobs/job_types/roguetown/peasants/jester.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/jester.dm
@@ -51,7 +51,7 @@
 		H.mind?.adjust_skillrank(/datum/skill/misc/stealing, pick(1,2,3,4,5), TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/lockpicking, pick(1,2,3,4,5), TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/climbing, pick(4,5), TRUE) // Pirouette, but falling and hurting yourself IS pretty funny.
-		H.mind?.adjust_skillrank(/datum/skill/misc/athletics, pick(1,2,3,4,5), TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/misc/athletics, pick(4,4,4,4,5), TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/music, pick(1,2,3,4,5,6), TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/craft/cooking, pick(1,2,3,4,5,6), TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/firearms, pick(1,2,3,4,5,6), TRUE)

--- a/code/modules/jobs/job_types/roguetown/peasants/jester.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/jester.dm
@@ -83,6 +83,7 @@
 	H.verbs |= /mob/living/carbon/human/proc/ear_trick
 	ADD_TRAIT(H, TRAIT_EMPATH, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_NUTCRACKER, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_ZJUMP, TRAIT_GENERIC)
 
 //Ventriloquism! Make things speak!
 

--- a/code/modules/jobs/job_types/roguetown/peasants/jester.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/jester.dm
@@ -85,6 +85,7 @@
 	ADD_TRAIT(H, TRAIT_NUTCRACKER, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_ZJUMP, TRAIT_GENERIC)
 
+
 //Ventriloquism! Make things speak!
 
 /mob/living/carbon/human/proc/ventriloquate()

--- a/code/modules/jobs/job_types/roguetown/peasants/jester.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/jester.dm
@@ -85,7 +85,6 @@
 	ADD_TRAIT(H, TRAIT_NUTCRACKER, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_ZJUMP, TRAIT_GENERIC)
 
-
 //Ventriloquism! Make things speak!
 
 /mob/living/carbon/human/proc/ventriloquate()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

Gives the Jester his famed z-level high-jump back. 

Tweaks his levels to generally roll for 4 athletics, but rarely gets 5. This is done because (iirc) if he falls from a height without athletics, he'll get hurt bad.

## Why It's Good For The Game

Jester was apparently meant to have this trait. Somewhere along the lines it got removed. A few people requested it back, so we'll see if this turns into a giant crock of shit. 

It could turn into an issue since Jester's skill/stat rolls are incredibly variable, but then again, if a Jester rolls high strength and unarmed people are pretty fucked already.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
