### PR TITLE
Makes the Kings Sword the Lord's Rapier

### DIFF
--- a/_maps/custom/roguehamlet.dmm
+++ b/_maps/custom/roguehamlet.dmm
@@ -581,7 +581,7 @@
 	})
 "aHC" = (
 /obj/structure/displaycase,
-/obj/item/rogueweapon/sword/sabre/lord,
+/obj/item/rogueweapon/sword/rapier/dec/lord,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/vault)
 "aHN" = (

--- a/_maps/custom/roguehamlet1.dmm
+++ b/_maps/custom/roguehamlet1.dmm
@@ -549,7 +549,7 @@
 	})
 "aHC" = (
 /obj/structure/displaycase,
-/obj/item/rogueweapon/sword/sabre/lord,
+/obj/item/rogueweapon/sword/rapier/dec/lord,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/vault)
 "aHN" = (

--- a/_maps/map_files/dakkatown/dakkatown.dmm
+++ b/_maps/map_files/dakkatown/dakkatown.dmm
@@ -11829,7 +11829,7 @@
 /area/rogue/under/town/sewer)
 "SY" = (
 /obj/structure/rack/rogue,
-/obj/item/rogueweapon/sword/sabre/lord,
+/obj/item/rogueweapon/sword/rapier/dec/lord,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
 "SZ" = (

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -12128,7 +12128,7 @@
 	icon_state = "longtable"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/rogueweapon/sword/sabre/lord,
+/obj/item/rogueweapon/sword/rapier/dec/lord,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},

--- a/_maps/map_files/old_maps/roguetown3.dmm
+++ b/_maps/map_files/old_maps/roguetown3.dmm
@@ -6018,7 +6018,7 @@
 /area/rogue)
 "asM" = (
 /obj/structure/fluff/statue/gargoyle,
-/obj/item/rogueweapon/sword/sabre/lord,
+/obj/item/rogueweapon/sword/rapier/dec/lord,
 /turf/open/floor/rogue/tile{
 	icon_state = "chess"
 	},

--- a/_maps/map_files/roguetown/roguetown.dmm
+++ b/_maps/map_files/roguetown/roguetown.dmm
@@ -9617,7 +9617,7 @@
 "kEn" = (
 /obj/structure/closet/crate/roguecloset/lord,
 /obj/item/clothing/suit/roguetown/armor/gambeson/arming,
-/obj/item/rogueweapon/sword/sabre/lord,
+/obj/item/rogueweapon/sword/rapier/dec/lord,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},

--- a/_maps/roguehamlet/roguehamlet.dmm
+++ b/_maps/roguehamlet/roguehamlet.dmm
@@ -577,7 +577,7 @@
 	})
 "aHC" = (
 /obj/structure/displaycase,
-/obj/item/rogueweapon/sword/sabre/lord,
+/obj/item/rogueweapon/sword/rapier/dec/lord,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/vault)
 "aHN" = (

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -281,15 +281,6 @@
 	minstr = 6
 	wbalance = HARD_TO_DODGE
 
-//................ Kings Sword ............... //
-/obj/item/rogueweapon/sword/sabre/lord
-	force = DAMAGE_SWORD_WIELD
-	name = "Kings Sword"
-	desc = "Passed down through the ages, a weapon that once carved a kingdom out now relegated to a decorative piece."
-	icon_state = "lord_rapier"
-	sellprice = 200
-	max_blade_int = 400
-
 //................ Shalal Sabre ............... //
 /obj/item/rogueweapon/sword/sabre/shalal
 	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/strike)
@@ -466,6 +457,14 @@
 	desc = "A rapier decorated with gold inlaid on its hilt. A regal weapon fit for nobility."
 	sellprice = 140
 
+//................ Lord's Rapier ............... //
+/obj/item/rogueweapon/sword/rapier/dec/lord
+	force = DAMAGE_SWORD_WIELD
+	name = "Lord's Rapier"
+	desc = "Passed down through the ages, a weapon that once carved a kingdom out now relegated to a decorative piece."
+	icon_state = "lord_rapier"
+	sellprice = 200
+	max_blade_int = 400
 
 /obj/item/rogueweapon/sword/rapier/silver
 	force = DAMAGE_SWORD-2


### PR DESCRIPTION
## About The Pull Request

Changes the Kings Sword into the Lord's Rapier.
Makes the Lord's Rapier a subtype of a Rapier instead of a Sabre.
Fixes the no sprite issue by proxy since Sabres used 32 sprites while the Rapiers use 64 sprites like the Lord's Rapier was made to.
Remaps it.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
