### PR TITLE
Adept - Allows all races to roll for Adept

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/adept.dm
+++ b/code/modules/jobs/job_types/roguetown/church/adept.dm
@@ -12,6 +12,9 @@
 		"Half-Elf",
 		"Dwarf",
 		"Dark Elf",
+		"Tiefling",
+		"Aasimar",
+		"Half-Orc"
 	)
 	allowed_sexes = list(MALE, FEMALE)
 	tutorial = "You were a convicted criminal, the lowest scum of Rockhill. Your master, the Inquisitor, saved you from the gallows and has given you true purpose in service to Psydon. You will not let him down."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

Allows Tiefling, Horc and Aasimar to roll for Adept.

## Why It's Good For The Game

It makes no sense that the Adept, someone sprung from death row to work in service of Psydon, can only be 60% of the races - including drow, but excluding horc and tiefling.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
