### PR TITLE
Alters the crafting recipe of old mantraps to better fit. Renames "rusty" on Mantraps to "old".

### DIFF
--- a/code/game/objects/items/beartraps.dm
+++ b/code/game/objects/items/beartraps.dm
@@ -21,8 +21,8 @@
 	throw_speed = 1
 	throw_range = 1
 	icon_state = "beartrap"
-	desc = "A crude and rusty spring trap, used to snare interlopers, or prey on a hunt. Looks almost like falling apart."
-	var/rusty = TRUE // Is it an old trap? Will most likely be destroyed if not handled right
+	desc = "A crude and old spring trap, used to snare interlopers, or prey on a hunt. Looks almost like falling apart."
+	var/old = TRUE // Is it an old trap? Will most likely be destroyed if not handled right
 	var/armed = FALSE // Is it armed?
 	var/trap_damage = 90 // How much brute damage the trap will do to its victim
 	var/used_time = 12 SECONDS // How many seconds it takes to disarm the trap
@@ -128,8 +128,8 @@
 				L.mind?.adjust_experience(/datum/skill/craft/traps, L.STAINT * boon, FALSE) // We learn how to set them better, little by little.
 				to_chat(user, "<span class='notice'>I arm |the [src].</span>")
 			else
-				if(rusty)
-					user.visible_message("<span class='warning'>The rusty [src.name] breaks under stress!</span>")
+				if(old)
+					user.visible_message("<span class='warning'>The old [src.name] breaks under stress!</span>")
 					playsound(src.loc, 'sound/foley/breaksound.ogg', 100, TRUE, -1)
 					qdel(src)
 				else
@@ -189,6 +189,6 @@
 
 // When craftable beartraps get added, make these the ones crafted.
 /obj/item/restraints/legcuffs/beartrap/crafted
-	rusty = FALSE
+	old = FALSE
 	desc = "Curious is the trapmaker's art. Their efficacy unwitnessed by their own eyes."
 	smeltresult = /obj/item/ingot/iron

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -293,12 +293,11 @@
 
 /datum/crafting_recipe/roguetown/mantrap
 	name = "mantrap"
-	result = list(/obj/item/restraints/legcuffs/beartrap,
-				/obj/item/restraints/legcuffs/beartrap)
-	reqs = list(/obj/item/grown/log/tree/small = 1,
-				/obj/item/natural/fibers = 2,
-				/obj/item/ingot/iron = 1)
-	req_table = TRUE
+	result = list(/obj/item/restraints/legcuffs/beartrap) // Intentionally old. Don't change.
+	reqs = list(/obj/item/grown/log/tree/stake = 1,
+				/obj/item/natural/fibers = 1,
+				/obj/item/rope = 1)
+	req_table = FALSE
 	skillcraft = /datum/skill/craft/traps
 	craftdiff = 1
 	verbage = "put together"


### PR DESCRIPTION
## About The Pull Request

Changes the Mantrap recipe to a stake, a fiber, and a rope since the old one didn't fit with the makeshiftness. Also renames rusty to old because it fits a bit better given this new primarily organic mantrap version. Officially Approved by KiwiBird (TM).

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
