### PR TITLE
Make the mayor not a hobo

### DIFF
--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -4445,7 +4445,7 @@
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
 	},
-/obj/effect/landmark/start/villager,
+/obj/effect/landmark/start/woodsman,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "dMm" = (
@@ -9768,13 +9768,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"iqL" = (
-/obj/structure/chair/stool/rogue,
-/obj/effect/landmark/start/woodsman{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "irf" = (
 /obj/structure/flora/roguegrass/bush_meagre,
 /turf/open/floor/rogue/dirt,
@@ -131185,7 +131178,7 @@ toB
 toB
 toB
 iUF
-iqL
+aCo
 jZz
 jZz
 jZz


### PR DESCRIPTION
## About The Pull Request

Moved the mayor's spawn to the first penthouse on the fourth z level of the town, so that they can actually have a home instead of being a homeless glorified beggar.

## Why It's Good For The Game

One of the fourth power of the city, being a hobo is bad, make them have atleast a home.

## Pre-Merge Checklist

It just work.
