### PR TITLE
Move through kneestingers

### DIFF
--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -2,7 +2,7 @@
 
 /obj/structure/kneestingers
 	name = "kneestingers"
-	desc = ""
+	desc = "They're said to glow with Dendor's wrath."
 	anchored = TRUE
 	opacity = 0
 	density = FALSE
@@ -15,27 +15,8 @@
 
 /obj/structure/kneestingers/fire_act(added, maxstacks)
 	visible_message(span_warning("[src] catches fire!"))
-	var/turf/T = get_turf(src)
+	new /obj/effect/hotspot(get_turf(src))
 	qdel(src)
-	new /obj/effect/hotspot(T)
-
-/obj/structure/kneestingers/CanPass(atom/movable/mover, turf/target)
-	if(isliving(mover) && mover.z == z)
-//		var/throwdir = get_dir(src, mover)
-		var/mob/living/L = mover
-
-		if(HAS_TRAIT(L, TRAIT_KNEESTINGER_IMMUNITY)) //Dendor kneestinger immunity
-			return TRUE
-
-		if(L.electrocute_act(30, src))
-			L.consider_ambush()
-			if(L.throwing)
-				L.throwing.finalize(FALSE)
-//			if(mover.loc != loc && L.stat == CONSCIOUS)
-//				L.throw_at(get_step(L, throwdir), 1, 1, L, spin = FALSE)
-			return FALSE
-	. = ..()
-
 
 /obj/structure/kneestingers/Crossed(AM as mob|obj)
 	if(isliving(AM))
@@ -46,6 +27,8 @@
 					L.emote("painscream")
 					L.update_sneak_invis(TRUE)
 					L.consider_ambush()
+					if(L.throwing)
+						L.throwing.finalize(FALSE)
 	. = ..()
 
 /obj/structure/kneestingers/attackby(obj/item/W, mob/user, params)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
You now get shocked when you move onto kneestingers instead of before, allowing you to pass through them after the shock.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
Requested by Aberra, probably better for gameplay.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
