### PR TITLE
Inquisitor fixes and additions

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/inquisitor.dm
+++ b/code/modules/jobs/job_types/roguetown/church/inquisitor.dm
@@ -230,7 +230,6 @@
 							held_confession.antag = "worshiper of nothing"
 					has_confessed = TRUE
 					held_confession.info = "THE GUILTY PARTY ADMITS THEIR SINFUL NATURE AS <font color='red'>[held_confession.bad_type]</font>. THEY WILL SERVE ANY PUNISHMENT OR SERVICE AS REQUIRED BY THE ORDER OF THE PSYCROSS UNDER PENALTY OF DEATH.<br/><br/>SIGNED,<br/><font color='red'><i>[held_confession.signed]</i></font>"
-					held_confession.name = "[real_name]'s Confession"
 					held_confession.update_icon_state()
 					return
 	say(pick(innocent_lines), spans = list("torture"))

--- a/code/modules/jobs/job_types/roguetown/church/inquisitor.dm
+++ b/code/modules/jobs/job_types/roguetown/church/inquisitor.dm
@@ -44,7 +44,6 @@
 	shoes = /obj/item/clothing/shoes/roguetown/nobleboot
 	pants = /obj/item/clothing/under/roguetown/trou/leather
 	cloak = /obj/item/clothing/cloak/cape/puritan
-	beltr = /obj/item/storage/belt/rogue/pouch/coins/rich
 	head = /obj/item/clothing/head/roguetown/helmet/leather/inquisitor
 	gloves = /obj/item/clothing/gloves/roguetown/angle
 	wrists = /obj/item/clothing/neck/roguetown/psycross/silver
@@ -86,7 +85,7 @@
 		H.change_stat("endurance", 1)
 		if(!H.has_language(/datum/language/oldpsydonic))
 			H.grant_language(/datum/language/oldpsydonic)
-			to_chat(H, "<span class='info'>I can speak Old Psydonic with ,m before my speech.</span>")
+			
 		if(H.mind.has_antag_datum(/datum/antagonist))
 			return
 		var/datum/antagonist/new_antag = new /datum/antagonist/purishep()
@@ -97,6 +96,11 @@
 	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_KNOWBANDITS, TRAIT_GENERIC)
 	H.verbs |= /mob/living/carbon/human/proc/torture_victim
+	to_chat(H,"<span class='info'>\
+		-I can speak Old Psydonic with ,m before my speech.\n\
+		-The Holy Bishop of the Inquisition has sent you here on a task to root out evil within this town. Make him proud!\n\
+		-You've also been gaven 10 favors to use at the mail machines, you can get more favor by sending signed confessions to The Holy Bishop. Spend your favors wisely.</span>"
+		)
 
 /mob/living/carbon/human/proc/torture_victim()
 	set name = "Extract Confession"
@@ -107,10 +111,13 @@
 	if(istype(I))
 		if(ishuman(I.grabbed))
 			H = I.grabbed
-			/*if(H == src)
-				to_chat(src, "<span class='warning'>I already torture myself.</span>")
+			if(H == src)
+				to_chat(src, "<span class='warning'>I won't torture myself!</span>")
 				return
-			*/
+			if(H.has_confessed==TRUE) // This is to check if the victim has already confessed, if so just inform the torturer and return. This is so that the Inquisitor cannot get infinite confession points and get all of the things upon getting thier first heretic.
+				to_chat(src, "<span class='warning'>[src.name] has already signed a confession! The holy bishop wouldn't want me to send him another...</span>")
+				to_chat(H, "<span class='warning'>[src.name] tries to get me to confess- but i've already signed one.</span>")
+				return
 			var/painpercent = H.get_complex_pain() / (H.STAEND * 10)
 			painpercent = painpercent * 100
 			var/mob/living/carbon/C = H
@@ -222,7 +229,9 @@
 						if("Science")
 							held_confession.bad_type = "A DAMNED ANTI-THEIST"
 							held_confession.antag = "worshiper of nothing"
+					has_confessed = TRUE
 					held_confession.info = "THE GUILTY PARTY ADMITS THEIR SINFUL NATURE AS <font color='red'>[held_confession.bad_type]</font>. THEY WILL SERVE ANY PUNISHMENT OR SERVICE AS REQUIRED BY THE ORDER OF THE PSYCROSS UNDER PENALTY OF DEATH.<br/><br/>SIGNED,<br/><font color='red'><i>[held_confession.signed]</i></font>"
+					held_confession.name = "[held_confession.signed]'s Confession"
 					held_confession.update_icon_state()
 					return
 	say(pick(innocent_lines), spans = list("torture"))

--- a/code/modules/jobs/job_types/roguetown/church/inquisitor.dm
+++ b/code/modules/jobs/job_types/roguetown/church/inquisitor.dm
@@ -98,7 +98,7 @@
 	H.verbs |= /mob/living/carbon/human/proc/torture_victim
 	to_chat(H,"<span class='info'>\
 		-I can speak Old Psydonic with ,m before my speech.\n\
-		-The Holy Bishop of the Inquisition has sent you here on a task to root out evil within this town. Make him proud!\n\
+		-The Holy Bishop of the Inquisition has sent you here on a task to root out evil within this town. Make The Holy Bishop proud!\n\
 		-You've also been gaven 10 favors to use at the mail machines, you can get more favor by sending signed confessions to The Holy Bishop. Spend your favors wisely.</span>"
 		)
 
@@ -116,7 +116,6 @@
 				return
 			if(H.has_confessed==TRUE) // This is to check if the victim has already confessed, if so just inform the torturer and return. This is so that the Inquisitor cannot get infinite confession points and get all of the things upon getting thier first heretic.
 				to_chat(src, "<span class='warning'>[src.name] has already signed a confession! The holy bishop wouldn't want me to send him another...</span>")
-				to_chat(H, "<span class='warning'>[src.name] tries to get me to confess- but i've already signed one.</span>")
 				return
 			var/painpercent = H.get_complex_pain() / (H.STAEND * 10)
 			painpercent = painpercent * 100

--- a/code/modules/jobs/job_types/roguetown/church/inquisitor.dm
+++ b/code/modules/jobs/job_types/roguetown/church/inquisitor.dm
@@ -62,7 +62,6 @@
 	H.name = "[honorary] [prev_name]"
 	H.confession_points = 10 // Starting with 10 points
 	H.purchase_history = list() // Initialize as an empty list to track purchases
-
 	if(H.mind)
 		H.mind?.adjust_skillrank(/datum/skill/misc/sewing, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
@@ -85,7 +84,6 @@
 		H.change_stat("endurance", 1)
 		if(!H.has_language(/datum/language/oldpsydonic))
 			H.grant_language(/datum/language/oldpsydonic)
-			
 		if(H.mind.has_antag_datum(/datum/antagonist))
 			return
 		var/datum/antagonist/new_antag = new /datum/antagonist/purishep()
@@ -113,9 +111,6 @@
 			H = I.grabbed
 			if(H == src)
 				to_chat(src, "<span class='warning'>I won't torture myself!</span>")
-				return
-			if(H.has_confessed==TRUE) // This is to check if the victim has already confessed, if so just inform the torturer and return. This is so that the Inquisitor cannot get infinite confession points and get all of the things upon getting thier first heretic.
-				to_chat(src, "<span class='warning'>[src.name] has already signed a confession! The holy bishop wouldn't want me to send him another...</span>")
 				return
 			var/painpercent = H.get_complex_pain() / (H.STAEND * 10)
 			painpercent = painpercent * 100
@@ -184,8 +179,13 @@
 		if(length(confessions))
 			if(torture == TRUE) // Only scream your confession if it's due to torture.
 				say(pick(confessions), spans = list("torture"))
+			
+			
 			if(user.is_holding_item_of_type(/obj/item/paper/confession)) // This code is to process gettin a signed confession through torture.
 				testing("User is holding a confession.")
+				if(has_confessed==TRUE) // This is to check if the victim has already confessed, if so just inform the torturer and return. This is so that the Inquisitor cannot get infinite confession points and get all of the things upon getting thier first heretic.
+					to_chat(user, "<span class='warning'>[src.name] has already signed a confession! The holy bishop wouldn't want me to send him another...</span>")
+					return
 				var/obj/item/paper/confession/held_confession = user.is_holding_item_of_type(/obj/item/paper/confession)
 				if(!held_confession.signed) // Check to see if the confession is already signed.
 					held_confession.signed = real_name
@@ -230,7 +230,7 @@
 							held_confession.antag = "worshiper of nothing"
 					has_confessed = TRUE
 					held_confession.info = "THE GUILTY PARTY ADMITS THEIR SINFUL NATURE AS <font color='red'>[held_confession.bad_type]</font>. THEY WILL SERVE ANY PUNISHMENT OR SERVICE AS REQUIRED BY THE ORDER OF THE PSYCROSS UNDER PENALTY OF DEATH.<br/><br/>SIGNED,<br/><font color='red'><i>[held_confession.signed]</i></font>"
-					held_confession.name = "[held_confession.signed]'s Confession"
+					held_confession.name = "[real_name]'s Confession"
 					held_confession.update_icon_state()
 					return
 	say(pick(innocent_lines), spans = list("torture"))

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -126,6 +126,7 @@
 
 	var/confession_points = 0 // Used to track how many confessions the Inquisitor has gotten signed. Used to buy items at mailboxes.
 	var/purchase_history = null // Used to track what the Inquisitor has bought from the mailbox.
+	var/has_confessed = FALSE // Used to track if they have confessed it was written onto a confession paper
 
 	var/merctype = 0 // Used for mercenary backgrounds - check mail.dm
 	var/tokenclaimed = FALSE // Check for one-time tri reward.

--- a/code/modules/roguetown/roguejobs/alchemist/container.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/container.dm
@@ -76,6 +76,13 @@
 
 /obj/item/reagent_containers/glass/bottle/vial/genderpot
 	list_reagents = list(/datum/reagent/medicine/gender_potion = 5)
+
+/obj/item/reagent_containers/glass/vial/rogue/strongpoison
+	list_reagents = list(/datum/reagent/strongpoison = 30)
+
+/obj/item/reagent_containers/glass/vial/rogue/antidote
+	list_reagents = list(/datum/reagent/medicine/antidote = 30)
+
 //////////////////////////
 /// ALCOHOLIC BOTTLES ///	- add fancy var to retain custom descriptions when corking
 //////////////////////////

--- a/code/modules/roguetown/roguemachine/mail.dm
+++ b/code/modules/roguetown/roguemachine/mail.dm
@@ -365,7 +365,8 @@
 			if(I.mind && (I.mind.assigned_role == "Inquisitor" || I.mind.assigned_role == "Adept") && !(I.stat == DEAD))
 				if(I.mind.assigned_role == "Inquisitor")
 					I.confession_points += 5 // Increase the Inquisitor's confession count.
-				I.visible_message("<span class='warning'>A sense of grim satisfaction fills your heart. One down, a million remain.</span>")
+					to_chat(I, "<span class='warning'>-I have gained more favors.</span>")
+				to_chat(I, "<span class='warning'>A sense of grim satisfaction fills your heart. One confession down, a million remain.</span>")
 				I.adjust_triumphs(1)
 
 /obj/structure/roguemachine/mail/proc/show_inquisitor_shop(mob/living/carbon/human/user)
@@ -387,48 +388,91 @@
 
 	// Define the available items, their costs, and max purchases
 	var/list/items = list(
-		"Puffer Pistol (8)" = list(
+		// Weapons
+		"Puffer Pistol- 3 Lead Balls- Powder Flask  (10)" = list(
 			list(type = /obj/item/gun/ballistic/revolver/grenadelauncher/pistol, count = 1),
 			list(type = /obj/item/storage/belt/rogue/pouch/bullets, count = 1),
 			list(type = /obj/item/reagent_containers/glass/bottle/rogue/aflask, count = 1),
 			cost = 8,
 			max_purchases = 1
 		),
+		"Three Spare Lead Balls (5)" = list(
+			list(type = /obj/item/ammo_casing/caseless/rogue/bullet, count = 3),
+			cost = 5,
+			max_purchases = 1
+		),
+		"Spare Powder Flask (2)" = list(
+			list(type = /obj/item/reagent_containers/glass/bottle/rogue/aflask, count = 1),
+			cost = 2,
+			max_purchases = 1
+		),
+		"Battle Bomb (3)" = list(
+			list(type = /obj/item/bomb, count = 1),
+			cost = 3,
+			max_purchases = 2
+		),
+		"Silver Dagger (5)" = list(
+			list(type = /obj/item/rogueweapon/knife/dagger/silver, count = 1),
+			cost = 5,
+			max_purchases = 2
+		),
+		"Spiked Mace (2)" = list(
+			list(type = /obj/item/rogueweapon/mace/spiked, count = 1),
+			cost = 2,
+			max_purchases = 3
+		),
+		// Tools
 		"Surgery Bag (3)" = list(
 			list(type = /obj/item/storage/backpack/rogue/satchel/surgbag, count = 1),
 			cost = 3,
 			max_purchases = 1
 		),
-		"Lockpick Ring (2)" = list(
+		"Three Lockpicks On A Ring (2)" = list(
 			list(type = /obj/item/lockpickring/mundane, count = 1),
 			cost = 2,
 			max_purchases = 5
 		),
-		"Bag of Coins (3)" = list(
+		"Head Sack (1)" = list(
+			list(type = /obj/item/clothing/head/roguetown/sack, count = 1),
+			cost = 1,
+			max_purchases = 5
+		),
+		"Bag of Silver Coins (3)" = list(
 			list(type = /obj/item/storage/belt/rogue/pouch/coins/rich, count = 1),
 			cost = 3,
-			max_purchases = 5
+			max_purchases = 3
+		),
+		"Vial Of Strong Poison (5)" = list(
+			list(type = /obj/item/reagent_containers/glass/vial/rogue/strongpoison, count = 1),
+			cost = 5,
+			max_purchases = 1
+		),
+		"Vial Of Antidote (2)" = list(
+			list(type = /obj/item/reagent_containers/glass/vial/rogue/antidote, count = 1),
+			cost = 2,
+			max_purchases = 1
+		),
+		// Clothing
+		"Silver Psycross (2)" = list(
+			list(type = /obj/item/clothing/neck/roguetown/psycross/silver, count = 1),
+			cost = 2,
+			max_purchases = 4
 		),
 		"Valorian Cloak (2)" = list(
 			list(type = /obj/item/clothing/cloak/cape/inquisitor, count = 1),
 			cost = 2,
-			max_purchases = 2
-		),
-		"Powder Flask (4)" = list(
-			list(type = /obj/item/reagent_containers/glass/bottle/rogue/aflask, count = 1),
-			cost = 4,
 			max_purchases = 1
 		),
-		"Silver Psycross (2)" = list(
-			list(type = /obj/item/clothing/neck/roguetown/psycross/silver, count = 1),
-			cost = 2,
-			max_purchases = 3
-		),
-		"Silver Dagger (4)" = list(
-			list(type = /obj/item/rogueweapon/knife/dagger/silver, count = 1),
+		"Plate Vambraces (2)" = list(
+			list(type = /obj/item/clothing/wrists/roguetown/bracers, count = 1),
 			cost = 2,
 			max_purchases = 4
-		)
+		),
+		"Chain Gauntlets (3)" = list(
+			list(type = /obj/item/clothing/gloves/roguetown/chain, count = 2),
+			cost = 3,
+			max_purchases = 4
+		),
 	)
 	testing("Items defined: [items]")
 
@@ -450,7 +494,7 @@
 			testing("[name] available for purchase at [item_cost] confessions")
 
 	// Ask the user to select an item
-	var/selection = input(user, "Select an item to request") in options
+	var/selection = input(user, "Select an item to request", "I have [user.confession_points] favors left...") as null | anything in options
 	testing("User selected: [selection]")
 	if(!selection)
 		return
@@ -463,6 +507,10 @@
 
 	testing("Selected item: [selection], cost: [item_cost], purchase_count: [purchase_count], max_purchases: [max_purchases]")
 
+	// Check if we are still next to the mailer.
+	if(!Adjacent(user))
+		return
+
 	// Check if the item is sold out
 	if(purchase_count >= max_purchases)
 		testing("[selection] is SOLD OUT after selection")
@@ -474,7 +522,7 @@
 	testing("User confession points: [current_points]")
 	if(current_points < item_cost)
 		testing("User does not have enough confession points: [current_points] < [item_cost]")
-		to_chat(user, "<span class='warning'>You do not have enough confession points.</span>")
+		to_chat(user, "<span class='warning'>You do not have enough favors.</span>")
 		return
 
 	// Deduct the points and give the items
@@ -497,5 +545,7 @@
 						I.forceMove(get_turf(user)) // If not, drop it at the user's location
 
 	visible_message("<span class='warning'>The mailbox spits out its contents.</span>")
+	say("HERE IS THE REQUESTED ITEM. WE HOPE IT SERVES YOU WELL.",language = /datum/language/oldpsydonic)
+	playsound(src, 'sound/misc/machinelong.ogg', 100, FALSE, -1)
 	testing("Finished processing user selection and item dispensing")
 	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

- Inquisitors can no longer make as many confessions for the same crime over and over again on the same person.
- Major improvements to the points menu on the mail machine.
- Added several items to the points menu.
- Removed the Inquisitors pouch of money, if you REALLY need some use your favors.
- Made it REALLY OBVIOUS to the Inquisitor that that the point shop shop actually exists and how to use it aswell as how to get more points.

## Why It's Good For The Game
- The existing exploits were BAD, you could buy everything in the point shop with just one heretic.
- Having more options in terms of gear is good for Inquisitors.
- The fact that there is a confession and point shop being made REALLY OBVIOUS to the player is a good thing.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
