### PR TITLE
Fix Inquisition confessions, ports antag vs patron interrogations

### DIFF
--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -103,6 +103,9 @@
 	toggle_icon_state = TRUE
 	experimental_onhip = TRUE
 
+/obj/item/clothing/mask/rogue/facemask/prisoner
+	clothing_flags = NONE //they're used to this being stuck on their face
+
 /obj/item/clothing/mask/rogue/facemask/prisoner/Initialize()
 	. = ..()
 	name = "cursed mask"

--- a/code/modules/jobs/job_types/roguetown/church/adept.dm
+++ b/code/modules/jobs/job_types/roguetown/church/adept.dm
@@ -80,6 +80,7 @@
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_KNOWBANDITS, TRAIT_GENERIC)
+	H.mind?.teach_crafting_recipe(/datum/crafting_recipe/roguetown/confessional)
 
 // Reformed Thief, a class balanced to rogue. Axe and crossbow focus.
 /datum/advclass/adept/rthief

--- a/code/modules/jobs/job_types/roguetown/church/inquisitor.dm
+++ b/code/modules/jobs/job_types/roguetown/church/inquisitor.dm
@@ -196,7 +196,7 @@
 	)
 	var/resist_chance
 	if(resist)
-		to_chat(span_boldwarning("I attempt to resist the torture!"))
+		to_chat(src, span_boldwarning("I attempt to resist the torture!"))
 		resist_chance = (STAINT + STAEND) + 10
 		if(confession_type == "antag")
 			resist_chance += 25

--- a/code/modules/jobs/job_types/roguetown/church/inquisitor.dm
+++ b/code/modules/jobs/job_types/roguetown/church/inquisitor.dm
@@ -15,7 +15,7 @@
 	)
 	allowed_sexes = list(MALE, FEMALE)
 
-	tutorial = "A recent arrival from Grenzelhoft, the Inquisitor is a member of the secretive lodges that have held to the service of Psydon since the Apotheosis War. They have formed an alliance with the local Priest against the increasing number of heretics and monsters infiltrating the town."
+	tutorial = "A recent arrival from Grenzelhoft, you are a member of the secretive lodges that have held to the service of Psydon since the Apotheosis War. You have been sent by your leader, the Holy Bishop, to assign the local Priest in combatting the increasing number of heretics and monsters infiltrating Vanderlin."
 	whitelist_req = FALSE
 
 	outfit = /datum/outfit/job/roguetown/inquisitor
@@ -94,11 +94,13 @@
 	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_KNOWBANDITS, TRAIT_GENERIC)
 	H.verbs |= /mob/living/carbon/human/proc/torture_victim
-	to_chat(H,"<span class='info'>\
+	H.verbs |= /mob/living/carbon/human/proc/faith_test
+	to_chat(H,span_info("\
 		-I can speak Old Psydonic with ,m before my speech.\n\
 		-The Holy Bishop of the Inquisition has sent you here on a task to root out evil within this town. Make The Holy Bishop proud!\n\
-		-You've also been gaven 10 favors to use at the mail machines, you can get more favor by sending signed confessions to The Holy Bishop. Spend your favors wisely.</span>"
+		-You've also been gaven 10 favors to use at the mail machines, you can get more favor by sending signed confessions to The Holy Bishop. Spend your favors wisely.")
 		)
+	H.mind?.teach_crafting_recipe(/datum/crafting_recipe/roguetown/confessional)
 
 /mob/living/carbon/human/proc/torture_victim()
 	set name = "Extract Confession"
@@ -106,54 +108,84 @@
 
 	var/obj/item/grabbing/I = get_active_held_item()
 	var/mob/living/carbon/human/H
-	if(istype(I))
-		if(ishuman(I.grabbed))
-			H = I.grabbed
-			if(H == src)
-				to_chat(src, "<span class='warning'>I won't torture myself!</span>")
-				return
-			var/painpercent = H.get_complex_pain() / (H.STAEND * 10)
-			painpercent = painpercent * 100
-			var/mob/living/carbon/C = H
-			if(C.add_stress(/datum/stressevent/tortured))
-				if(!H.stat)
-					say(pick("CONFESS!",
-								"TELL ME YOUR SECRETS!",
-								"SPEAK!",
-								"YOU WILL SPEAK!",
-								"TELL ME!",
-								"THE PAIN HAS ONLY BEGUN, CONFESS!"), spans = list("torture"))
-					testing(painpercent)
-					if((painpercent > 40) || (!H.cmode))
-						H.emote("painscream")
-						testing("Confession time, [painpercent] pain.")
-						H.confession_time(src)
-						return
-			to_chat(src, "<span class='warning'>Not ready to speak yet.</span>")
-
-/mob/living/carbon/human/proc/confession_time(mob/living/carbon/human/user)
-	if(istype(src.buckled, /obj/structure/fluff/walldeco/chains)) // If the victim is on hanging chains, they cannot resist.
-		confess_sins(resist=FALSE, user=user)
+	if(!istype(I) || !ishuman(I.grabbed))
 		return
-	var/timerid = addtimer(CALLBACK(src, PROC_REF(confess_sins), FALSE, user), 6 SECONDS, TIMER_STOPPABLE)
-	var/responsey = alert(src, "Resist torture? (1 TRI)","Time for Pain","Yes","No")
+	H = I.grabbed
+	if(H == src)
+		to_chat(src, span_warning("I won't torture myself!"))
+		return
+	var/painpercent = H.get_complex_pain() / (H.STAEND * 10)
+	painpercent = painpercent * 100
+	var/mob/living/carbon/C = H
+	if(C.add_stress(/datum/stressevent/tortured))
+		if(!H.stat)
+			var/static/list/torture_lines = list(
+				"CONFESS YOUR WRONGDOINGS!",
+				"TELL ME YOUR SECRETS!",
+				"SPEAK THE TRUTH!",
+				"YOU WILL SPEAK!",
+				"TELL ME!",
+				"THE PAIN HAS ONLY BEGUN, CONFESS!",
+			)
+			say(pick(torture_lines), spans = list("torture"))
+			testing(painpercent)
+			if(painpercent >= 100)
+				H.emote("painscream")
+				testing("Confession time, [painpercent] pain.")
+				H.confession_time("antag", src)
+				return
+	to_chat(src, span_warning("Not ready to speak yet."))
+
+/mob/living/carbon/human/proc/faith_test()
+	set name = "Test Faith"
+	set category = "Inquisition"
+
+	var/obj/item/grabbing/I = get_active_held_item()
+	var/mob/living/carbon/human/H
+	if(!istype(I) || !ishuman(I.grabbed))
+		return
+	H = I.grabbed
+	if(H == src)
+		to_chat(src, span_warning("I won't torture myself!"))
+		return
+	var/painpercent = (H.get_complex_pain() / (H.STAEND * 10)) * 100
+	if(H.add_stress(/datum/stressevent/tortured))
+		if(!H.stat)
+			var/static/list/faith_lines = list(
+				"DO YOU DENY PSYDON AND THE TEN?",
+				"WHO IS YOUR GOD?",
+				"ARE YOU FAITHFUL?",
+				"TO WHICH SHEPHERD DO YOU FLOCK TO?",
+			)
+			say(pick(faith_lines), spans = list("torture"))
+			if(painpercent >= 100)
+				H.emote("painscream")
+				H.confession_time("patron", src)
+				return
+	to_chat(src, span_warning("Not ready to speak yet."))
+
+/mob/living/carbon/human/proc/confession_time(confession_type = "antag", mob/living/carbon/human/user)
+	if(istype(src.buckled, /obj/structure/fluff/walldeco/chains)) // If the victim is on hanging chains, they cannot resist.
+		confess_sins(confession_type, resist=FALSE, user=user)
+		return
+	var/timerid = addtimer(CALLBACK(src, PROC_REF(confess_sins), confession_type, FALSE, user), 6 SECONDS, TIMER_STOPPABLE)
+	var/responsey = alert(src, "Resist torture?","TEST OF PAIN","Yes","No")
 	testing("Sent resist request to [src].")
 	testing(" User is [user]. confession_time")
 	if(SStimer.timer_id_dict[timerid])
 		deltimer(timerid)
 	else
-		to_chat(src, "<span class='warning'>Too late...</span>")
+		to_chat(src, span_warning("Too late..."))
 		testing("Torture timer ran out.")
 		return
-	if(responsey == "No")
-		testing("[src] gave into torture.")
-		confess_sins(resist=FALSE, user=user)
 	if(responsey == "Yes")
-		adjust_triumphs(-1)
 		testing("[src] resisted torture.")
-		confess_sins(resist=TRUE, user=user)
+		confess_sins(confession_type, resist=TRUE, user=user)
+	else
+		testing("[src] gave into torture.")
+		confess_sins(confession_type, resist=FALSE, user=user)
 
-/mob/living/carbon/human/proc/confess_sins(resist, mob/living/carbon/human/user, torture=TRUE)
+/mob/living/carbon/human/proc/confess_sins(confession_type = "antag", resist, mob/living/carbon/human/user, torture=TRUE)
 	var/static/list/innocent_lines = list(
 		"I DON'T KNOW!",
 		"STOP THE PAIN!!",
@@ -162,34 +194,45 @@
 		"I HAVE NOTHING TO SAY...!",
 		"WHY ME?!",
 	)
-	if(!resist)
+	var/resist_chance
+	if(resist)
+		to_chat(span_boldwarning("I attempt to resist the torture!"))
+		resist_chance = (STAINT + STAEND) + 10
+		if(confession_type == "antag")
+			resist_chance += 25
+	if(!resist || (resist_chance && prob(resist_chance)))
 		var/list/confessions = list()
 		var/antag_type = null
 		testing(" User is [user]. confess_sins")
-		for(var/datum/antagonist/antag in mind?.antag_datums)
-			if(length(antag.confess_lines))
-				confessions = antag.confess_lines
-				antag_type = antag.name
-				testing("Antag type: [antag_type]")
-				break // Only need one antag type
-		if(length(patron.confess_lines) && !length(confessions)) // The antag confession lines take precedence over the heretic lines. If there are antag lines, the heretic ones will not show.
-			confessions = patron.confess_lines
-			testing("Patron type: [patron.name]")
-			antag_type = patron.name
+		switch(confession_type)
+			if("antag")
+				for(var/datum/antagonist/antag in mind?.antag_datums)
+					if(!length(antag.confess_lines))
+						continue
+					confessions += antag.confess_lines
+					antag_type = antag.name
+					testing("Antag type: [antag_type]")
+					break // Only need one antag type
+			if("patron")
+				if(length(patron?.confess_lines))
+					confessions += patron.confess_lines
+					testing("Patron type: [patron.name]")
+					antag_type = patron.name
 		if(length(confessions))
 			if(torture == TRUE) // Only scream your confession if it's due to torture.
 				say(pick(confessions), spans = list("torture"))
-			
-			
+			else
+				say(pick(confessions))
+
 			if(user.is_holding_item_of_type(/obj/item/paper/confession)) // This code is to process gettin a signed confession through torture.
 				testing("User is holding a confession.")
 				if(has_confessed==TRUE) // This is to check if the victim has already confessed, if so just inform the torturer and return. This is so that the Inquisitor cannot get infinite confession points and get all of the things upon getting thier first heretic.
-					to_chat(user, "<span class='warning'>[src.name] has already signed a confession! The holy bishop wouldn't want me to send him another...</span>")
+					to_chat(user, span_warning("[src.name] has already signed a confession! The Holy Bishop wouldn't want me to send a duplicate..."))
 					return
 				var/obj/item/paper/confession/held_confession = user.is_holding_item_of_type(/obj/item/paper/confession)
 				if(!held_confession.signed) // Check to see if the confession is already signed.
-					held_confession.signed = real_name
-					held_confession.bad_type = "AN EVILDOER" // In case new antags are added with confession lines but have yet to be added here.
+					// held_confession.bad_type = "AN EVILDOER" // In case new antags are added with confession lines but have yet to be added here.
+					//this is no longer reliable as all patrons have confess lines now
 					switch(antag_type)
 						if("Bandit")
 							held_confession.bad_type = "AN OUTLAW OF THE THIEF-LORD"
@@ -198,7 +241,7 @@
 							held_confession.bad_type = "AN OUTLAW OF THE THIEF-LORD"
 							held_confession.antag = "worshiper of" + antag_type
 						if("Maniac")
-							held_confession.bad_type = "A MANIAC IMMUNE TO PAIN"
+							held_confession.bad_type = "A MANIAC DELUDED BY MADNESS"
 							held_confession.antag = antag_type
 						if("Assassin")
 							held_confession.bad_type = "A DEATH CULTIST"
@@ -220,17 +263,25 @@
 							held_confession.antag = antag_type
 						if("Vampire Lord")
 							held_confession.bad_type = "THE BLOOD-LORD OF ENIGMA"
+							held_confession.antag = antag_type
 						if("Graggar")
 							held_confession.bad_type = "A FOLLOWER OF THE DARK SUN"
 							held_confession.antag = "worshiper of" + antag_type
-						if("Peasant Rebel")
-							return // Inquisitors don't care about peasant revolts targeting the King of Rockhill.
 						if("Science")
 							held_confession.bad_type = "A DAMNED ANTI-THEIST"
 							held_confession.antag = "worshiper of nothing"
+						if("Peasant Rebel")
+							return // Inquisitors don't care about peasant revolts targeting the King
+						else
+							return // good job you tortured an innocent person
 					has_confessed = TRUE
+					held_confession.signed = real_name
 					held_confession.info = "THE GUILTY PARTY ADMITS THEIR SINFUL NATURE AS <font color='red'>[held_confession.bad_type]</font>. THEY WILL SERVE ANY PUNISHMENT OR SERVICE AS REQUIRED BY THE ORDER OF THE PSYCROSS UNDER PENALTY OF DEATH.<br/><br/>SIGNED,<br/><font color='red'><i>[held_confession.signed]</i></font>"
 					held_confession.update_icon_state()
 					return
+		else
+			say(pick(innocent_lines), spans = list("torture"))
+			return
+	to_chat(src, span_good("I resist the torture!"))
 	say(pick(innocent_lines), spans = list("torture"))
 	return

--- a/code/modules/jobs/job_types/roguetown/serfs/tailor.dm
+++ b/code/modules/jobs/job_types/roguetown/serfs/tailor.dm
@@ -33,7 +33,6 @@
 	H.mind?.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
 	H.mind?.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
 	H.mind?.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
-	H.mind?.adjust_skillrank(/datum/skill/craft/tanning, 3, TRUE)
 	H.mind?.adjust_skillrank(/datum/skill/craft/carpentry, 1, TRUE)
 	ADD_TRAIT(H, TRAIT_SEEPRICES, TRAIT_GENERIC)
 	if(H.gender == MALE)

--- a/code/modules/jobs/job_types/roguetown/serfs/tailor.dm
+++ b/code/modules/jobs/job_types/roguetown/serfs/tailor.dm
@@ -33,6 +33,7 @@
 	H.mind?.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
 	H.mind?.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
 	H.mind?.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
+	H.mind?.adjust_skillrank(/datum/skill/craft/tanning, 3, TRUE)
 	H.mind?.adjust_skillrank(/datum/skill/craft/carpentry, 1, TRUE)
 	ADD_TRAIT(H, TRAIT_SEEPRICES, TRAIT_GENERIC)
 	if(H.gender == MALE)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -50,7 +50,7 @@
 	icon_state = "paper"
 	throwforce = 0
 	w_class = WEIGHT_CLASS_TINY
-	throw_range = 1
+	throw_range = 2
 	throw_speed = 1
 	slot_flags = ITEM_SLOT_HEAD
 	body_parts_covered = HEAD

--- a/code/modules/paperwork/rogue.dm
+++ b/code/modules/paperwork/rogue.dm
@@ -189,17 +189,23 @@
 	name = "confession"
 	icon_state = "confession"
 	desc = "A drab piece of parchment stained with the magical ink of the Order lodges. Looking at it fills you with profound guilt."
-	info = "THE GUILTY PARTY ADMITS THEIR SINFUL NATURE AS  . THEY WILL SERVE ANY PUNISHMENT OR SERVICE AS REQUIRED BY THE ORDER OF THE PSYCROSS UNDER PENALTY OF DEATH.<br/><br/>SIGNED,"
+	info = "THE GUILTY PARTY ADMITS THEIR SINFUL NATURE AS ___. THEY WILL SERVE ANY PUNISHMENT OR SERVICE AS REQUIRED BY THE ORDER OF THE PSYCROSS UNDER PENALTY OF DEATH.<br/><br/>SIGNED,"
 	var/signed = null
 	var/antag = null // The literal name of the antag, like 'Bandit' or 'worshiper of Zizo'
 	var/bad_type = null // The type of the antag, like 'OUTLAW OF THE THIEF-LORD'
 	textper = 108
 	maxlen = 2000
+	var/confession_type = "antag" //for voluntary confessions
 
 /obj/item/paper/confession/attackby(obj/item/P, mob/living/carbon/human/user, params)
 	if(istype(P, /obj/item/natural/feather))
-		to_chat(user, "<span class='warning'>The paper resists my attempts to write upon it!</span>")
-		return
+		var/response = alert(user, "What voluntary confession do I want?","","Villainy", "Faith")
+		if(!response)
+			return
+		if(response == "Villainy")
+			confession_type = "antag"
+		else
+			confession_type = "patron"
 
 /obj/item/paper/confession/update_icon_state()
 	if(mailer)
@@ -218,16 +224,21 @@
 	testing("paper confession offer. target is [M], user is [user].")
 	if(signed)
 		return ..()
-	if(!M.stat)
-		to_chat(user, "<span class='info'>I courteously offer the confession to [M].</span>")
-		if(alert(M, "Sign the confession of your true nature?", "CONFESSION OF SIN", "Yes", "No") != "Yes")
-			return
-		if(M.stat)
-			return
-		if(signed)
-			return
-		testing("[M] is signing the confession.")
-		M.confess_sins(resist=FALSE, user=user, torture=FALSE)
+	if(M.stat >= UNCONSCIOUS) //unconscious cannot talk to confess, but soft crit can
+		return
+	to_chat(user, "<span class='info'>I courteously offer the confession to [M].</span>")
+	var/input = alert(M, "Sign the confession of your true nature?", "CONFESSION OF [confession_type == "antag" ? "VILLAINY" : "FAITH"]", "Yes", "No")
+	if(M.stat >= UNCONSCIOUS)
+		return
+	if(signed)
+		return
+	testing("[M] is signing the confession.")
+	if(input == "Yes")
+		to_chat(user, span_info("[M] has agreed to confess their true nature."))
+		M.confess_sins(confession_type, resist=FALSE, user=user, torture=FALSE)
+	else
+		to_chat(user, span_warning("[M] refused to sign the confession!"))
+	return
 
 /obj/item/paper/confession/read(mob/user)
 	if(!user.client || !user.hud_used)
@@ -304,7 +315,7 @@
 
 /obj/item/paper/scroll/frumentarii
 	name = "List of Known Agents"
-	desc = "A list of the hand's fingers."
+	desc = "A list of the Hand's fingers."
 
 	var/list/real_names = list()
 	var/list/removed_names = list()
@@ -326,7 +337,7 @@
 	if(!attacked_target.client)
 		return
 
-	var/choice = input(attacked_target,"Do you list to become one of the hands fingers?","Binding Contract",null) as null|anything in list("Yes", "No")
+	var/choice = input(attacked_target,"Do you list to become one of the Hand's fingers?","Binding Contract",null) as null|anything in list("Yes", "No")
 
 	if(choice != "Yes")
 		return

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -507,3 +507,13 @@
 	result = /obj/item/rogueweapon/hammer/wood
 	reqs = list(/obj/item/grown/log/tree/small = 1)
 	craftdiff = 0
+
+/datum/crafting_recipe/roguetown/confessional
+	name = "confession"
+	result = /obj/item/paper/confession
+	reqs = list(/obj/item/paper = 1)
+	tools = list(/obj/item/natural/feather)
+	skillcraft = /datum/skill/misc/reading
+	always_availible = FALSE
+	craftsound = null
+	craftdiff = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
- Fixes confession signing since all patrons have confession lines now
- Ports Ratwood's antag and patron interrogations
- Inquisitor and Adept can craft more confessions
- Prisoner masker lets you sleep

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
Bug fix. Prisoners having to knock themselves out to sleep is silly.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
