### PR TITLE
Actually fixes eyes, also typo in descriptions

### DIFF
--- a/code/datums/mob_descriptors/mob_descriptor.dm
+++ b/code/datums/mob_descriptors/mob_descriptor.dm
@@ -45,7 +45,7 @@
 	return "%THEY% [get_coalesce_text(described)]"
 
 /datum/mob_descriptor/proc/get_coalesce_text(mob/living/described, list/used_verbage)
-	return "[should_add_verbage(described, used_verbage) ? "[get_verbage(described)] " : ""][get_pre_string(described)][get_description(described)][post_string]."
+	return "[should_add_verbage(described, used_verbage) ? "[get_verbage(described)] " : ""][get_pre_string(described)][get_description(described)][post_string]"
 
 /datum/mob_descriptor/proc/get_description(mob/living/described)
 	return describe

--- a/code/modules/mob/living/living_descriptors.dm
+++ b/code/modules/mob/living/living_descriptors.dm
@@ -101,6 +101,7 @@
 		if(used_verb)
 			used_verbage |= used_verb
 	string = treat_mob_descriptor_string(string, described)
+	string += "."
 	return string
 
 /proc/treat_mob_descriptor_string(string, mob/living/described)

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -23,32 +23,34 @@
 	var/see_in_dark = 8
 	var/tint = 0
 	var/eye_icon_state = "eyes"
-	var/old_eye_color = "fff"
 	var/flash_protect = FLASH_PROTECTION_NONE
 	var/see_invisible = SEE_INVISIBLE_LIVING
 	var/lighting_alpha
 	var/no_glasses
 	var/damaged	= FALSE	//damaged indicates that our eyes are undergoing some level of negative effect
 
-	var/eye_color = "#FFFFFF"
+	var/old_eye_color = "fff" //cache owners original eye color before inserting new eyes
+	var/eye_color = ""//set to a hex code to override a mob's eye color
 	var/heterochromia = FALSE
 	var/second_color = "#FFFFFF"
 
 
 /obj/item/organ/eyes/update_overlays()
 	. = ..()
-	if(eye_color && (icon_state == "eyeball"))
+	if(initial(eye_color) && (icon_state == "eyeball"))
 		var/mutable_appearance/iris_overlay = mutable_appearance(src.icon, "eyeball-iris")
 		iris_overlay.color = "#" + eye_color
 		. += iris_overlay
 
 /obj/item/organ/eyes/update_accessory_colors()
 	var/list/colors_list = list()
-	colors_list += eye_color
-	if(heterochromia)
-		colors_list += second_color
-	else
+	if(initial(eye_color))
 		colors_list += eye_color
+	if(initial(second_color))
+		if(heterochromia)
+			colors_list += second_color
+		else
+			colors_list += eye_color
 	accessory_colors = color_list_to_string(colors_list)
 
 /obj/item/organ/eyes/imprint_organ_dna(datum/organ_dna/organ_dna)
@@ -63,7 +65,7 @@
 	if(ishuman(owner))
 		var/mob/living/carbon/human/HMN = owner
 		old_eye_color = HMN.eye_color
-		if(eye_color)
+		if(initial(eye_color))
 			HMN.eye_color = eye_color
 			HMN.regenerate_icons()
 		else
@@ -77,7 +79,7 @@
 
 /obj/item/organ/eyes/Remove(mob/living/carbon/M, special = 0)
 	. = ..()
-	if(ishuman(M) && eye_color)
+	if(ishuman(M))
 		var/mob/living/carbon/human/HMN = M
 		HMN.eye_color = old_eye_color
 		HMN.regenerate_icons()
@@ -140,6 +142,7 @@
 /obj/item/organ/eyes/night_vision/zombie
 	name = "undead eyes"
 	desc = ""
+	eye_color = "#FFFFFF"
 
 /obj/item/organ/eyes/night_vision/werewolf
 	name = "moonlight eyes"
@@ -149,6 +152,7 @@
 	name = "burning red eyes"
 	desc = ""
 	icon_state = "burning_eyes"
+	eye_color = BLOODCULT_EYE
 
 /obj/item/organ/eyes/night_vision/mushroom
 	name = "fung-eye"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
Removing eyes no longer sets eyes_color to white. `/obj/item/organ/eyes` will now by default inherit owner's eye color unless `eye_color` is set. Also fixs description typo.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
Bug fix good. Hopefully doesn't break anything.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
