### PR TITLE
Fixes Corsair

### DIFF
--- a/code/modules/jobs/job_types/roguetown/other/merc_classes/corsair.dm
+++ b/code/modules/jobs/job_types/roguetown/other/merc_classes/corsair.dm
@@ -13,7 +13,7 @@
 /datum/outfit/job/roguetown/adventurer/corsair
 	head = /obj/item/clothing/head/roguetown/helmet/leather/headscarf
 	pants = /obj/item/clothing/under/roguetown/tights/sailor
-	belt = /obj/item/storage/belt/rogue/leather
+	belt = /obj/item/storage/belt/rogue/leather/mercenary
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/jacket/sea
 	backl = /obj/item/storage/backpack/rogue/satchel
 	backpack_contents = list(/obj/item/natural/worms/leech = 2, /obj/item/storage/belt/rogue/pouch/coins/mid)
@@ -28,7 +28,7 @@
 
 		H.mind?.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
-		H.mind?.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE) // Swords / Nonlethal.
+		H.mind?.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE) // Swords / Nonlethal.
 		H.mind?.adjust_skillrank(/datum/skill/labor/fishing, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/swimming, 4, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/climbing, 5, TRUE) // For jumping off roofs. Don't lower.
@@ -40,6 +40,6 @@
 
 	shirt = pick(/obj/item/clothing/suit/roguetown/shirt/undershirt/sailor, /obj/item/clothing/suit/roguetown/shirt/undershirt/sailor/red)
 	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
-	H.change_stat("endurance", 1)
-	H.change_stat("perception", -3) // We don't want them using ranged weapons, period.
+	H.change_stat("endurance", 3)
+	H.change_stat("perception", -2) // We don't want them using ranged weapons, period.
 	H.change_stat("speed", 2) // Hit-And-Run.


### PR DESCRIPTION
## About The Pull Request

Cool class, like the style, but its extremely bad so, adjusted stats a little and gave + 1 wrestling and A KEY TO THEIR OWN SPAWN.

Whats wrong with it?
Well, easiest way to explain it is checking corsair vs the most similar merc class, the anthrax who also get dodge expert.
Average statblock Anthrax (M)
STR 9
PER 9
INT 11
CON 10
END = 13
SPD = 14
FOR = 10

Average statblock Corsair (M)
STR 10
PER 9
INT 11
CON 9
END = 11
SPD = 13 
FOR = 9

Add to that the extremely good night vision dark elves got.
You can check any other merc class, corsair stablock is the suckiest by far, old formula used as a rule of thumb was + 2 for each point of STR or SPD, +1 for each point of the rest. Any metric you choose tho corsair is currently gimped.

Post change they look like this
STR 10
PER 10
INT 11
CON 9
END = 13
SPD = 13 
FOR = 9

So a worse anthrax that traded night vision for fire resist. Slot in any other mer class you like and corsairs still probably the weakest. After this adjustment theyre in the same league as the rest of non-dark elf mercs and wont be stuck in spawn with no way out. You´re still not wise to pick it over anthrax honestly but thats due to the race balancing mostly.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
