### PR TITLE
Dark Elf NV goggles tuned down

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfd.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfd.dm
@@ -40,7 +40,7 @@
 	dam_icon_f = 'icons/roguetown/mob/bodies/dam/dam_female.dmi'
 	hairyness = "t3"
 	mutant_bodyparts = list("ears")
-	mutanteyes = /obj/item/organ/eyes/elf
+	mutanteyes = /obj/item/organ/eyes/elf/less
 	use_f = TRUE
 	soundpack_m = /datum/voicepack/male/elf
 	soundpack_f = /datum/voicepack/female/elf


### PR DESCRIPTION
## About The Pull Request

Theres a couple core managment systems in RogueTown code.
Bleeding is a big one, as is Debuffs via sleep, hunger, thirst. A third core one is darkness/light managment.
This stuff is so core and affects so many things indirectly that its not good design to essentially allow players to opt out of them.
Powerful Nightvision should be something for spells, potions, antags, purely for game balance.

Basically if you´re Adventurer, Merc, Bandit, you´re gimping yourself right now if you aren´t playing dark elf. See screenshot below for normal vision/elf vision/darkelf vision. Its the same room, same objects, human barely sees a thing, elf can at least spot the dude and the barrel, dark elf sees the entire room almost perfectly.
![nightvisions](https://github.com/user-attachments/assets/99ab76f0-bbfd-45bb-bfe9-4ecfe28874df)

This PR corrects the mistake of buffing Delf NV to this degree and gives them normal elf NV, its good enough to be of use without busting one the core game principles.
 

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
