### PR TITLE
Adds extra data to be sent to /datum/world_topic/status (+ version = "VANDERLIN")

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -20,6 +20,7 @@
 GLOBAL_VAR_INIT(tod, FALSE)
 GLOBAL_VAR_INIT(forecast, FALSE)
 GLOBAL_VAR_INIT(todoverride, FALSE)
+/// The current day of the week, range from 1-7 (Moon's Dae - Sun's Dae)
 GLOBAL_VAR_INIT(dayspassed, FALSE)
 
 /proc/settod()

--- a/code/_globalvars/configuration.dm
+++ b/code/_globalvars/configuration.dm
@@ -4,7 +4,7 @@ GLOBAL_DATUM(revdata, /datum/getrev)
 
 GLOBAL_VAR(host)
 GLOBAL_VAR(station_name)
-GLOBAL_VAR_INIT(game_version, "/tg/ Station 13")
+GLOBAL_VAR_INIT(game_version, "VANDERLIN")
 GLOBAL_VAR_INIT(changelog_hash, "")
 GLOBAL_VAR_INIT(hub_visibility, FALSE)
 

--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -144,9 +144,8 @@
 	.["respawn"] = config ? !CONFIG_GET(flag/norespawn) : FALSE
 	.["enter"] = GLOB.enter_allowed
 	.["vote"] = CONFIG_GET(flag/allow_vote_mode)
-	.["ai"] = CONFIG_GET(flag/allow_ai)
 	.["host"] = world.host ? world.host : null
-	.["round_id"] = GLOB.round_id
+	.["round_id"] = GLOB.rogue_round_id
 	.["players"] = GLOB.clients.len
 	.["revision"] = GLOB.revdata.commit
 	.["revision_date"] = GLOB.revdata.date
@@ -180,3 +179,6 @@
 	.["extreme_popcap"] = CONFIG_GET(number/extreme_popcap) || 0
 	.["popcap"] = max(CONFIG_GET(number/soft_popcap), CONFIG_GET(number/hard_popcap), CONFIG_GET(number/extreme_popcap)) //generalized field for this concept for use across ss13 codebases
 
+	//round state
+	.["timeofday"] = GLOB.tod
+	.["dayspassed"] = GLOB.dayspassed

--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -144,6 +144,7 @@
 	.["respawn"] = config ? !CONFIG_GET(flag/norespawn) : FALSE
 	.["enter"] = GLOB.enter_allowed
 	.["vote"] = CONFIG_GET(flag/allow_vote_mode)
+	.["ai"] = CONFIG_GET(flag/allow_ai)
 	.["host"] = world.host ? world.host : null
 	.["round_id"] = GLOB.rogue_round_id
 	.["players"] = GLOB.clients.len


### PR DESCRIPTION
## About this PR
* /world_topic/status will now send the current time of day, as well as how many days have passed
* status now sends `GLOB.rogue_round_id`
* GLOB.game_version has been changed to "VANDERLIN"

## Why It's Good For The Game

Allows services to better represent VANDERLIN's status when querying (currently the only usable information is player count and admin count)

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
