### PR TITLE
fix: don't run shutdown twice

### DIFF
--- a/code/controllers/subsystem/plexora.dm
+++ b/code/controllers/subsystem/plexora.dm
@@ -133,7 +133,7 @@ SUBSYSTEM_DEF(plexora)
 		default_headers
 	).begin_async()
 
-/datum/controller/subsystem/plexora/Shutdown(hard = FALSE, requestedby)
+/datum/controller/subsystem/plexora/proc/_Shutdown(hard = FALSE, requestedby)
 	http_basicasync("serverupdates", list(
 		"type" = "servershutdown",
 		"timestamp" = rustg_unix_timestamp(),

--- a/code/controllers/subsystem/plexora.dm
+++ b/code/controllers/subsystem/plexora.dm
@@ -133,7 +133,7 @@ SUBSYSTEM_DEF(plexora)
 		default_headers
 	).begin_async()
 
-/datum/controller/subsystem/plexora/_Shutdown(hard = FALSE, requestedby)
+/datum/controller/subsystem/plexora/Shutdown(hard = FALSE, requestedby)
 	http_basicasync("serverupdates", list(
 		"type" = "servershutdown",
 		"timestamp" = rustg_unix_timestamp(),

--- a/code/controllers/subsystem/plexora.dm
+++ b/code/controllers/subsystem/plexora.dm
@@ -133,7 +133,7 @@ SUBSYSTEM_DEF(plexora)
 		default_headers
 	).begin_async()
 
-/datum/controller/subsystem/plexora/Shutdown(hard = FALSE, requestedby)
+/datum/controller/subsystem/plexora/_Shutdown(hard = FALSE, requestedby)
 	http_basicasync("serverupdates", list(
 		"type" = "servershutdown",
 		"timestamp" = rustg_unix_timestamp(),

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -347,9 +347,9 @@ GLOBAL_PROTECT(tracy_init_reason)
 			log_admin("[key_name(usr)] Has requested an immediate world restart via client side debugging tools")
 			message_admins("[key_name_admin(usr)] Has requested an immediate world restart via client side debugging tools")
 		to_chat(world, span_boldannounce("Rebooting World immediately due to host request."))
-		SSplexora.Shutdown(PLEXORA_SHUTDOWN_HARDEST, usr ? key_name(usr) : null)
+		SSplexora._Shutdown(PLEXORA_SHUTDOWN_HARDEST, usr ? key_name(usr) : null)
 	else
-		SSplexora.Shutdown(PLEXORA_SHUTDOWN_HARD, usr ? key_name(usr) : null)
+		SSplexora._Shutdown(PLEXORA_SHUTDOWN_HARD, usr ? key_name(usr) : null)
 		to_chat(world, "Please be patient as the server restarts. You will be automatically reconnected in about 60 seconds.")
 		Master.Shutdown() //run SS shutdowns
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

Renames Shutdown to _Shutdown because otherwise when the restart gets called, it runs subsystem shutdowns, and the proc for that on a subsystem is Shutdown. before Subsystem shutdowns are ran, we call `SSplexora.Shutdown`. 
yeah you get it. please merge.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
