### PR TITLE
(BALANCE/FIX) Gives Dwarven Bombardiers Maille Training.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/dbomb.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/dbomb.dm
@@ -31,6 +31,7 @@
 	H.mind?.adjust_skillrank(/datum/skill/misc/reading, 2, TRUE)
 	H.change_stat("strength", 1)
 	H.change_stat("endurance", 1)
+	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 	switch(pick(1,2))
 		if (1)
 			shoes = /obj/item/clothing/shoes/roguetown/boots/leather


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

Gives Dwarf Bombers Maille Training. Requested by Dromkii.

## Why It's Good For The Game

They started with Maille and lacked the relevant trait. It's either this or give them leather armor.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
