### PR TITLE
Soilson Farm QOL changes

### DIFF
--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -526,19 +526,9 @@
 /turf/open/floor/rogue/ruinedwood/turned/darker,
 /area/rogue/indoors/town/garrison)
 "auu" = (
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/item/rogueweapon/knife/cleaver{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/kitchen/rollingpin{
-	pixel_x = 5;
-	pixel_y = -5
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town/church)
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/rtfield/safe)
 "auy" = (
 /obj/structure/fluff/railing/border{
 	dir = 6;
@@ -1100,11 +1090,6 @@
 "aJF" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/soilsons)
-"aJG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/landmark/start/carpenter,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
 "aJU" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/metal/barograte,
@@ -2770,10 +2755,6 @@
 	icon_state = "iron_end"
 	},
 /area/rogue/under/town/basement)
-"bTE" = (
-/obj/effect/landmark/start/physicker,
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/clinic_large)
 "bTR" = (
 /obj/structure/flora/newleaf{
 	dir = 1
@@ -4274,6 +4255,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/magician)
+"cVl" = (
+/obj/machinery/light/rogue/torchholder/l,
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/structure/fluff/nest,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/rtfield/safe)
 "cVZ" = (
 /turf/open/floor/rogue/rooftop{
 	dir = 4
@@ -4308,11 +4295,6 @@
 "cYY" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town/manorgate)
-"cZd" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/landmark/start/miner,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
 "cZn" = (
 /turf/closed/wall/mineral/rogue/roofwall/innercorner,
 /area/rogue/indoors/town)
@@ -5148,9 +5130,7 @@
 /obj/machinery/light/rogue/oven/south{
 	pixel_y = -32
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church)
 "dIc" = (
 /obj/structure/roguewindow/openclose{
@@ -5610,6 +5590,14 @@
 "dXj" = (
 /turf/closed/wall/mineral/rogue/decostone/center,
 /area/rogue/indoors/town/manor)
+"dXk" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
+	},
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/rtfield/safe)
 "dXy" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	icon_state = "endwooddark";
@@ -5862,11 +5850,6 @@
 	},
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
-"egD" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/landmark/start/miner,
-/turf/open/floor/rogue/ruinedwood/turned/darker,
-/area/rogue/indoors/town)
 "egH" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/grass,
@@ -6566,9 +6549,8 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/clocktower)
 "eES" = (
-/obj/structure/fluff/nest,
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/turf/open/floor/rogue/dirt/road,
+/mob/living/simple_animal/hostile/retaliate/rogue/trufflepig,
+/turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield/safe)
 "eFy" = (
 /obj/structure/table/wood/plain_alt,
@@ -7356,6 +7338,16 @@
 	icon_state = "linoleum"
 	},
 /area/rogue/indoors/town/vault)
+"fhh" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "priest";
+	locked = 1
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town/church)
 "fhB" = (
 /obj/structure/fluff/clock,
 /obj/structure/fluff/walldeco/stone{
@@ -8466,6 +8458,10 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
+"gaE" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/rtfield/safe)
 "gbp" = (
 /obj/effect/landmark/start/sapprentice{
 	dir = 1
@@ -9153,10 +9149,6 @@
 /obj/item/key/tower,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/magician)
-"gzU" = (
-/obj/effect/landmark/start/minor_noble,
-/turf/open/floor/carpet/stellar,
-/area/rogue/indoors/town/manor)
 "gAe" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
@@ -9226,14 +9218,12 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "gDf" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
-	},
-/obj/structure/fluff/millstone{
-	pixel_y = 10
-	},
 /obj/machinery/light/rogue/oven/south{
 	pixel_y = -32
+	},
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/tile{
 	icon_state = "chess"
@@ -9246,13 +9236,6 @@
 	name = "Tailor Shop"
 	},
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/town)
-"gEg" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/obj/effect/landmark/start/miner,
-/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "gEi" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
@@ -9354,11 +9337,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"gGe" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/landmark/start/bard,
-/turf/open/floor/rogue/ruinedwood/turned/darker,
-/area/rogue/indoors/town)
 "gGy" = (
 /obj/structure/handcart,
 /obj/machinery/light/rogue/wallfire/candle,
@@ -9421,14 +9399,9 @@
 /turf/open/floor/rogue/ruinedwood/turned/darker,
 /area/rogue/indoors/town)
 "gIt" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "priest";
-	locked = 1
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town/church)
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/rtfield/safe)
 "gIG" = (
 /obj/machinery/light/rogue/hearth,
 /obj/structure/fluff/railing/border{
@@ -9683,6 +9656,16 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"gSd" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/obj/structure/fluff/railing/wood{
+	dir = 1
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/rtfield/safe)
 "gSl" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
@@ -9913,9 +9896,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "gZZ" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/obj/structure/fluff/nest,
-/turf/open/floor/rogue/dirt/road,
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/roguegrass/bush_meagre,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/safe)
 "har" = (
 /obj/effect/landmark/start/villager{
@@ -11158,6 +11141,11 @@
 /obj/structure/fluff/railing/wood{
 	dir = 1
 	},
+/obj/machinery/light/rogue/firebowl/stump,
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
+	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield/safe)
 "hXO" = (
@@ -11378,7 +11366,7 @@
 	pixel_y = 0;
 	pixel_x = -32
 	},
-/turf/open/floor/rogue/dirt,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/safe)
 "ihg" = (
 /obj/structure/fluff/railing/border{
@@ -11564,6 +11552,10 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/carpet/green,
 /area/rogue/indoors/town)
+"ipQ" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/goat,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/rtfield/safe)
 "iqd" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/town/cell)
@@ -12354,10 +12346,6 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church)
-"iOQ" = (
-/obj/effect/landmark/start/cheesemaker,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
 "iPg" = (
 /obj/structure/closet/crate/chest/wicker,
 /obj/item/neuFarm/seed/cabbage,
@@ -12690,12 +12678,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"jat" = (
-/obj/effect/landmark/start/bard{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
 "jaw" = (
 /turf/open/floor/rogue/ruinedwood/darker,
 /area/rogue/indoors/town/magician)
@@ -13000,15 +12982,6 @@
 "jkj" = (
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/manor)
-"jko" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/obj/effect/landmark/start/bard{
-	dir = 1
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
 "jkM" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -13255,6 +13228,11 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town)
+"jtK" = (
+/obj/structure/flora/roguegrass,
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/safe)
 "jtP" = (
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/manorgate)
@@ -14907,10 +14885,6 @@
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/shop)
-"kBZ" = (
-/obj/effect/landmark/start/bard,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
 "kCA" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	lockid = "priest"
@@ -16518,6 +16492,10 @@
 /obj/structure/rack/rogue/shelf/biggest,
 /turf/open/floor/rogue/ruinedwood/turned/darker,
 /area/rogue/indoors/town)
+"lTn" = (
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/rtfield/safe)
 "lTY" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -16921,12 +16899,11 @@
 	},
 /area/rogue/under/town/basement)
 "mob" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
+/obj/structure/mineral_door/bars{
+	locked = 1;
+	lockid = "butcher"
 	},
-/mob/living/simple_animal/hostile/retaliate/rogue/trufflepig,
-/turf/open/floor/rogue/dirt/road,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/safe)
 "mog" = (
 /obj/structure/flora/roguegrass,
@@ -18068,10 +18045,6 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
-"ndh" = (
-/obj/effect/landmark/start/minor_noble,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "ndk" = (
 /obj/structure/table/wood/plain_alt,
 /obj/item/paper,
@@ -19389,10 +19362,7 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/shop)
 "ocn" = (
-/obj/structure/roguemachine/atm{
-	pixel_y = 0;
-	pixel_x = 32
-	},
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield/safe)
 "ocA" = (
@@ -20619,6 +20589,7 @@
 "oZq" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/roguegrass,
+/obj/structure/bars/cemetery,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield/safe)
 "oZB" = (
@@ -20677,6 +20648,13 @@
 /obj/machinery/light/rogue/lanternpost/fixed,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/sewer)
+"pbd" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
+	},
+/turf/closed/wall/mineral/rogue/wooddark/horizontal,
+/area/rogue/outdoors/rtfield/safe)
 "pbn" = (
 /obj/structure/chair/bench/coucha,
 /turf/open/floor/rogue/hexstone,
@@ -20713,6 +20691,11 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/under/town/sewer)
+"pbU" = (
+/obj/structure/roguemachine/scomm,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/safe)
 "pec" = (
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/blocks,
@@ -20826,6 +20809,11 @@
 /obj/structure/closet/crate/chest/crafted,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"piA" = (
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/safe)
 "piR" = (
 /obj/machinery/light/rogue/chand,
 /turf/open/transparent/openspace,
@@ -21374,7 +21362,6 @@
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
 	},
-/obj/effect/landmark/start/carpenter,
 /turf/open/floor/rogue/ruinedwood/turned/darker,
 /area/rogue/indoors/town)
 "pEL" = (
@@ -21748,6 +21735,7 @@
 /area/rogue/indoors/town/church/inquisition)
 "pVi" = (
 /obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield/safe)
 "pVA" = (
@@ -21906,6 +21894,18 @@
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"qcd" = (
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/item/rogueweapon/knife/cleaver{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/kitchen/rollingpin{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/church)
 "qcx" = (
 /obj/item/natural/feather{
 	pixel_x = -15;
@@ -22270,8 +22270,8 @@
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town/magician)
 "qpx" = (
-/obj/machinery/light/rogue/firebowl/stump,
-/turf/open/floor/rogue/dirt/road,
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/safe)
 "qpP" = (
 /obj/structure/table/wood{
@@ -22781,11 +22781,6 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/under/town/basement)
-"qLi" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/landmark/start/bard,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
 "qLx" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/tile/tilerg,
@@ -22834,6 +22829,10 @@
 	},
 /turf/open/floor/rogue/grass/yel,
 /area/rogue/outdoors/town)
+"qOg" = (
+/obj/structure/fluff/nest,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/rtfield/safe)
 "qOm" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
@@ -23507,11 +23506,7 @@
 /obj/structure/fluff/railing/wood{
 	dir = 4
 	},
-/obj/structure/fluff/nest,
 /mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/obj/structure/fluff/railing/wood{
-	dir = 1
-	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield/safe)
 "rpp" = (
@@ -23834,6 +23829,15 @@
 	},
 /turf/open/floor/rogue/ruinedwood/darker,
 /area/rogue/indoors/town/theatre)
+"rBr" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/rtfield/safe)
 "rBu" = (
 /turf/open/lava,
 /area/rogue/under/cavelava)
@@ -24420,8 +24424,8 @@
 /turf/closed/wall/mineral/rogue/roofwall/outercorner,
 /area/rogue/indoors/town/manor)
 "rWm" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/dirt,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield/safe)
 "rWu" = (
 /obj/structure/mineral_door/wood/deadbolt{
@@ -25423,10 +25427,6 @@
 /obj/item/natural/cloth,
 /turf/open/floor/rogue/ruinedwood/turned/darker,
 /area/rogue/indoors/town)
-"sHR" = (
-/obj/effect/landmark/start/carpenter,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
 "sHT" = (
 /obj/structure/closet/crate/chest/wicker,
 /obj/item/reagent_containers/glass/bottle/vial,
@@ -26109,6 +26109,11 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"tgT" = (
+/obj/structure/flora/roguegrass,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/safe)
 "thb" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /obj/structure/bars,
@@ -26283,12 +26288,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church)
 "tms" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/fluff/nest,
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/turf/open/floor/rogue/dirt,
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield/safe)
 "tmw" = (
 /obj/structure/fluff/railing/wood{
@@ -27340,9 +27341,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "tVL" = (
-/obj/structure/flora/roguegrass,
-/obj/machinery/light/rogue/firebowl/stump,
-/turf/open/floor/rogue/grass,
+/obj/structure/mineral_door/bars{
+	locked = 1;
+	lockid = "soilson"
+	},
+/turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield/safe)
 "tWt" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -28340,15 +28343,6 @@
 "uET" = (
 /turf/open/floor/rogue/rooftop,
 /area/rogue/outdoors/town)
-"uFl" = (
-/obj/structure/chair/stool/rogue,
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4;
-	icon_state = "churchslate"
-	},
-/obj/effect/landmark/start/physicker,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/clinic_large)
 "uFp" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -28934,13 +28928,9 @@
 /turf/open/floor/rogue/ruinedwood/spiralfade,
 /area/rogue/indoors/town/manorgate)
 "vdC" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
-	},
+/obj/structure/rack/rogue/shelf/biggest,
 /obj/structure/fluff/nest,
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/turf/open/floor/rogue/dirt,
+/turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield/safe)
 "vdE" = (
 /turf/open/floor/rogue/metal{
@@ -28983,9 +28973,8 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/soilsons)
 "veS" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
+/obj/structure/plough,
+/turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield/safe)
 "vfc" = (
 /obj/structure/flora/roguegrass,
@@ -30226,6 +30215,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
+"wee" = (
+/obj/structure/roguemachine/atm,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/rtfield/safe)
 "wep" = (
 /obj/structure/closet/crate/chest/neu,
 /turf/open/floor/rogue/wood,
@@ -30581,7 +30574,6 @@
 	dir = 8;
 	icon_state = "churchslate"
 	},
-/obj/effect/landmark/start/physicker,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/clinic_large)
 "wqL" = (
@@ -30652,6 +30644,10 @@
 "wtv" = (
 /turf/closed/wall/mineral/rogue/wooddark/end,
 /area/rogue/outdoors/town)
+"wtx" = (
+/obj/structure/composter/halffull,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/safe)
 "wtI" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -31026,7 +31022,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "wFL" = (
-/obj/machinery/light/rogue/torchholder/l,
+/obj/structure/rack/rogue/shelf/biggest,
 /obj/structure/fluff/nest,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield/safe)
@@ -32118,10 +32114,7 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
 "xyA" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/goat,
-/obj/structure/fluff/railing/wood{
-	dir = 1
-	},
+/obj/structure/mineral_door/swing_door,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield/safe)
 "xyY" = (
@@ -32278,6 +32271,17 @@
 /mob/living/carbon/human/species/skeleton/npc/ambush,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/town/sewer)
+"xEi" = (
+/obj/structure/table/wood{
+	icon_state = "longtable"
+	},
+/obj/structure/fluff/millstone{
+	pixel_y = 10
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town/church)
 "xEm" = (
 /obj/structure/stairs{
 	dir = 4
@@ -32574,10 +32578,6 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
-"xPp" = (
-/obj/effect/landmark/start/miner,
-/turf/open/floor/rogue/ruinedwood/turned/darker,
-/area/rogue/indoors/town)
 "xPF" = (
 /obj/structure/curtain/bounty{
 	color = "grey"
@@ -99651,7 +99651,7 @@ mTm
 oNj
 wLR
 wLR
-bTE
+wLR
 eDE
 bgm
 aPS
@@ -100055,7 +100055,7 @@ mTm
 eSf
 aPS
 ybp
-bTE
+wLR
 eDE
 bgm
 aPS
@@ -101067,7 +101067,7 @@ xYa
 mTm
 uGy
 aPS
-uFl
+kTY
 kTY
 unJ
 mTm
@@ -130414,7 +130414,7 @@ ssk
 ocA
 loh
 qEb
-aJG
+lox
 aMu
 qEb
 elp
@@ -130782,7 +130782,7 @@ iGx
 oFJ
 iGx
 iGx
-jat
+iGx
 fvJ
 nDY
 gVo
@@ -131612,7 +131612,7 @@ acx
 acx
 fdp
 qEb
-sHR
+iGx
 iGx
 fEH
 bRC
@@ -131828,7 +131828,7 @@ tZj
 esI
 tJr
 qEb
-iOQ
+iGx
 iGx
 qEb
 iBK
@@ -131920,13 +131920,13 @@ rDr
 guQ
 xGB
 xcY
-gzU
+qdn
 qdn
 qdn
 blM
 xGB
 aaS
-ndh
+faL
 faL
 faL
 blM
@@ -131994,7 +131994,7 @@ pQS
 dSF
 iGx
 iGx
-jko
+kBM
 pQS
 nDY
 lAp
@@ -134243,7 +134243,7 @@ emB
 uET
 dZq
 qEb
-kBZ
+iGx
 hHg
 qEb
 hrB
@@ -135237,16 +135237,16 @@ qQe
 nDY
 nDY
 aJu
-xPp
+ocA
 uMe
 ocA
 fKk
 aJu
-cZd
+lox
 iGx
 iGx
 aJu
-qLi
+lox
 iGx
 qQh
 cjt
@@ -135446,7 +135446,7 @@ ocA
 jFO
 iGx
 lox
-gEg
+kBM
 qEb
 hHg
 iGx
@@ -135643,7 +135643,7 @@ nDY
 aNw
 vxh
 vxh
-egD
+esI
 sHG
 erd
 bAj
@@ -135654,7 +135654,7 @@ lIK
 wXO
 iyY
 erd
-gGe
+esI
 ocA
 esI
 erd
@@ -135878,7 +135878,7 @@ goV
 fcr
 oPF
 aIA
-iOQ
+iGx
 iGx
 gnw
 qEb
@@ -136461,7 +136461,7 @@ acx
 xIJ
 nDY
 erd
-gGe
+esI
 ocA
 xwd
 bLg
@@ -145725,10 +145725,10 @@ eTF
 ukJ
 nlp
 nlp
-nlp
+ukJ
 nlp
 igW
-ukJ
+nZK
 wMs
 wMs
 aWD
@@ -145926,17 +145926,17 @@ iWd
 nZK
 nlp
 fYR
-fYR
+rWm
 nlp
-fYR
-nlp
+aWD
+aWD
 ucW
 iSf
 iSf
 nEW
 aWD
 uzX
-aWD
+qpx
 oZq
 dUI
 nNC
@@ -146128,20 +146128,20 @@ iWd
 nlp
 nlp
 nlp
-vGv
-nlp
-nlp
-nlp
-nlp
-ucW
-ucW
-ucW
-ucW
-ucW
-nZK
 aWD
 aWD
-pVJ
+aWD
+aWD
+aWD
+ucW
+ucW
+ucW
+ucW
+auu
+jtK
+aWD
+aWD
+nlp
 hXa
 uFp
 oPu
@@ -146164,7 +146164,7 @@ uyW
 uyW
 oTX
 gnI
-nlp
+lTn
 fYR
 fYR
 kMP
@@ -146329,21 +146329,21 @@ sjr
 iWd
 nlp
 fYR
-fYR
-fYR
-nlp
-fYR
-nlp
-fYR
-nlp
-nlp
-fYR
-fYR
-ucW
-ucW
-ucW
-ucW
 aWD
+eTF
+gIt
+tms
+gIt
+tms
+tVL
+tVL
+tms
+tms
+auu
+ucW
+ucW
+ucW
+uzX
 amf
 xlX
 oPu
@@ -146529,15 +146529,15 @@ nLC
 brU
 iWd
 iWd
+eTF
+nZK
+gZZ
+nEW
+gIt
+pVJ
 nlp
-nlp
-nlp
-nlp
-nlp
-nlp
-nlp
-nlp
-nlp
+ukJ
+ukJ
 nlp
 nlp
 nlp
@@ -146729,16 +146729,16 @@ hMp
 hMp
 nLC
 vlf
-sjr
-iWd
+fhh
+swo
+nLu
+swo
+nLu
+nLu
+mJO
+fYR
 ukJ
-nlp
-fYR
-fYR
-fYR
-fYR
-nlp
-fYR
+rWm
 fYR
 fYR
 fYR
@@ -146931,22 +146931,22 @@ hFN
 kze
 mJO
 mJO
-gIt
-swo
-nLu
-swo
-nLu
-nLu
+aDq
+qcd
+uxx
+aJp
+wCQ
+xEi
 mJO
-tVL
-nlp
+gGy
+ucW
 nlp
 nlp
 vGv
 nlp
 nlp
 aWD
-uzX
+aWD
 cxv
 nlp
 ucW
@@ -146971,12 +146971,12 @@ hPu
 hPu
 gzH
 iae
-aWD
-eTF
-nEW
-aWD
-fYR
-nEW
+qpx
+qpx
+mob
+mob
+tms
+qpx
 vgJ
 vgJ
 eyC
@@ -147133,25 +147133,25 @@ equ
 equ
 nmq
 mJO
+aDq
+aDq
 mVj
-auu
-uxx
-aJp
+mVj
 mVj
 gDf
 vlf
-aUi
-nEW
+erI
+ucW
 nlp
 fYR
 fYR
 nlp
 fYR
 fYR
-nlp
+fYR
 nZK
 ucW
-aWD
+wtx
 hXa
 edj
 edj
@@ -147173,7 +147173,7 @@ hsj
 hPu
 vwl
 iae
-mAU
+nlp
 cxv
 aWD
 fYR
@@ -147335,25 +147335,25 @@ kov
 equ
 aDq
 dSO
-mVj
-mVj
-mVj
+aDq
+aDq
+aDq
 mVj
 mVj
 jMJ
 nLu
 veS
+ucW
+aWD
 nlp
 nlp
 nlp
 nlp
 nlp
-nlp
-ukJ
-uzX
+fYR
 aWD
 aWD
-aWD
+wtx
 aJF
 jMV
 kPZ
@@ -147537,22 +147537,22 @@ equ
 equ
 nmq
 mJO
-wCQ
-mVj
-mVj
-mVj
-mVj
+rhl
+aDq
+aDq
+aDq
+aDq
 dHB
 vlf
+pSu
+ucW
+aWD
+aWD
+fYR
+nlp
+fYR
+ukJ
 rWm
-ocn
-fYR
-nlp
-nlp
-fYR
-nlp
-aWD
-aWD
 ucW
 ucW
 pVi
@@ -147746,15 +147746,15 @@ aDq
 aDq
 rHf
 vlf
-cnl
-cnl
-nlp
-nlp
-ukJ
-nlp
-aWD
-aWD
+bgn
 ucW
+eTF
+aWD
+rWm
+ukJ
+fYR
+nlp
+rWm
 ucW
 ucW
 ukJ
@@ -147951,16 +147951,16 @@ mJO
 mJO
 mJO
 mJO
-gGy
-ucW
-ucW
-ucW
-ucW
-ucW
+tgT
+fYR
+ukJ
+fYR
+nlp
+fYR
 ucW
 ucW
 aWD
-aWD
+uzX
 nZK
 dxA
 nlp
@@ -147970,16 +147970,16 @@ wMs
 wMs
 wMs
 wMs
-wMs
 nkg
+dXk
 vdC
-fYR
-nlp
+cVl
 wFL
-tmw
+cyW
+fYR
 fYR
 nlp
-tmw
+cyW
 fYR
 gtP
 nlp
@@ -148153,13 +148153,13 @@ mJO
 hMp
 hMp
 mJO
-erI
-ucW
-ucW
-ucW
-ucW
-ucW
-aWD
+pbU
+fYR
+fYR
+fYR
+nlp
+nlp
+nlp
 ucW
 ucW
 aWD
@@ -148172,16 +148172,16 @@ wMs
 wMs
 wMs
 wMs
-wMs
 tNQ
 fYR
 fYR
 fYR
 nlp
-tNQ
+xyA
+fYR
 fYR
 nlp
-tNQ
+xyA
 cIp
 fYR
 nlp
@@ -148355,13 +148355,13 @@ jOI
 hMp
 hMp
 kTP
-ucW
-ucW
-ucW
-ucW
-ucW
-ucW
-ucW
+ukJ
+nlp
+fYR
+nlp
+nlp
+aWD
+aWD
 fYR
 ucW
 ucW
@@ -148374,16 +148374,16 @@ wMs
 wMs
 wMs
 wMs
-wMs
 tNQ
-eES
+ocn
+fYR
+qOg
+fYR
+cyW
+nlp
 fYR
 fYR
-fYR
-tNQ
-fYR
-fYR
-tmw
+cyW
 fYR
 fYR
 nlp
@@ -148557,13 +148557,13 @@ mJO
 hMp
 hMp
 mJO
-pSu
-ucW
-ucW
-ucW
-ucW
+wee
 nlp
-aWD
+fYR
+nlp
+nZK
+nZK
+nEW
 nlp
 ucW
 ucW
@@ -148572,17 +148572,17 @@ ucW
 ucW
 aWD
 aWD
-wMs
 wMs
 wMs
 wMs
 wMs
 tmw
+qOg
 fYR
-fYR
-gZZ
+ocn
 nlp
 tmw
+nlp
 fYR
 fYR
 tNQ
@@ -148759,12 +148759,12 @@ eLl
 mJO
 mJO
 mJO
-bgn
-ucW
-ucW
-aWD
-ucW
-ucW
+gaE
+fYR
+fYR
+fYR
+nEW
+nZK
 aWD
 fYR
 aWD
@@ -148774,21 +148774,21 @@ ucW
 ucW
 ucW
 aWD
+aWD
 wMs
 wMs
 wMs
-wMs
-wMs
+gSd
 roZ
-tms
 lSD
 lSD
 xwQ
 tNQ
 fYR
-qpx
+fYR
+fYR
 hXN
-xwQ
+rBr
 lSD
 xwQ
 xwQ
@@ -148962,21 +148962,21 @@ vlf
 dxA
 dMG
 nlp
+fYR
+aWD
+fYR
+aUi
+aWD
 nlp
 aWD
-pVJ
-fYR
-ucW
-fYR
 nEW
 aWD
-aWD
 nlp
 pVJ
 ucW
 ucW
 ucW
-wMs
+aWD
 wMs
 wMs
 wMs
@@ -149163,12 +149163,12 @@ vic
 nLu
 nlp
 nZK
-nZK
-nEW
+piA
+aWD
+nlp
+fYR
 nlp
 nlp
-ucW
-ucW
 fYR
 aWD
 nZK
@@ -149367,11 +149367,11 @@ nEW
 aWD
 dnU
 aWD
+pVJ
+fYR
 nlp
-ucW
-xFd
-ucW
 nlp
+pVJ
 nEW
 aWD
 nlp
@@ -149390,15 +149390,15 @@ nlp
 ucW
 aWD
 uzX
-nkg
+pbd
 wtX
 lAc
 wtX
 kzi
-mob
+wtX
 wtX
 lAc
-tmw
+cyW
 fYR
 mAU
 vgJ
@@ -149570,9 +149570,9 @@ nZK
 aWD
 ukJ
 aWD
-fYR
-ucW
-fYR
+nlp
+nlp
+nlp
 ukJ
 nlp
 dnU
@@ -149600,8 +149600,8 @@ tNQ
 nlp
 nlp
 fYR
-tmw
-jpK
+eQP
+fYR
 vgJ
 vgJ
 vgJ
@@ -149773,8 +149773,8 @@ nlp
 mAU
 aUi
 nlp
-nlp
-aWD
+ucW
+ucW
 aWD
 aWD
 aWD
@@ -149794,7 +149794,7 @@ nlp
 aWD
 aWD
 bsJ
-tmw
+cyW
 uCt
 nlp
 fYR
@@ -149802,8 +149802,8 @@ tmw
 lMD
 nlp
 fYR
-tmw
-mAU
+cyW
+nlp
 vgJ
 vgJ
 vgJ
@@ -149974,9 +149974,9 @@ vgJ
 nEW
 aWD
 cxv
-aWD
-eTF
-nEW
+ucW
+xFd
+ucW
 nZK
 aWD
 aUi
@@ -150176,9 +150176,9 @@ vgJ
 vgJ
 nZK
 nZK
-aWD
-nZK
-aWD
+fYR
+ucW
+fYR
 aWD
 mAU
 vgJ
@@ -150204,7 +150204,7 @@ fYR
 nlp
 tNQ
 fYR
-nlp
+eES
 nlp
 tmw
 nEW
@@ -150402,7 +150402,7 @@ hTk
 cyW
 tmw
 nlp
-nlp
+ipQ
 fYR
 tNQ
 nlp

--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -4308,6 +4308,14 @@
 "cZn" = (
 /turf/closed/wall/mineral/rogue/roofwall/innercorner,
 /area/rogue/indoors/town)
+"cZw" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 8;
+	icon_state = "churchslate"
+	},
+/obj/structure/fermenting_barrel/random/water,
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/clinic_large)
 "cZI" = (
 /obj/item/reagent_containers/glass/cup/silver,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -31868,6 +31876,7 @@
 	},
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /obj/structure/fluff/walldeco/church/line,
+/obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/clinic_large)
 "xiQ" = (
@@ -140532,7 +140541,7 @@ acx
 pyS
 cWn
 ybp
-clJ
+cZw
 xiv
 ybp
 bwy

--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -6243,7 +6243,7 @@
 /area/rogue/outdoors/river)
 "esY" = (
 /obj/structure/roguemachine/vendor{
-	keycontrol = "tavern"
+	keycontrol = "butcher"
 	},
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	icon_state = "endwooddark";
@@ -8088,7 +8088,7 @@
 /area/rogue/indoors/town/shop)
 "fJi" = (
 /obj/structure/roguemachine/vendor{
-	keycontrol = "tavern"
+	keycontrol = "soilson"
 	},
 /turf/closed/wall/mineral/rogue/wood/window,
 /area/rogue/outdoors/rtfield/safe)

--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -479,10 +479,9 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "arX" = (
-/obj/structure/chair/wood/rogue,
-/obj/effect/landmark/start/farmer,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/soilsons)
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/rtfield/safe)
 "aso" = (
 /obj/machinery/light/rogue/torchholder/c,
 /obj/structure/bed/rogue/shit,
@@ -526,8 +525,8 @@
 /turf/open/floor/rogue/ruinedwood/turned/darker,
 /area/rogue/indoors/town/garrison)
 "auu" = (
-/obj/structure/bars/cemetery,
-/turf/open/floor/rogue/cobble/mossy,
+/obj/structure/roguemachine/atm,
+/turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield/safe)
 "auy" = (
 /obj/structure/fluff/railing/border{
@@ -1745,6 +1744,18 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"bjw" = (
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/item/rogueweapon/knife/cleaver{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/kitchen/rollingpin{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/church)
 "bjz" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/water,
@@ -1815,6 +1826,11 @@
 /obj/structure/fluff/walldeco/stone,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/town/sewer)
+"bmw" = (
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/safe)
 "bmI" = (
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/cobble/mossy,
@@ -2049,9 +2065,9 @@
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/under/town/sewer)
 "bvO" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/soilsons)
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/rtfield/safe)
 "bvW" = (
 /obj/structure/chair/wood/rogue/chair_noble/red,
 /turf/open/floor/rogue/tile,
@@ -3784,7 +3800,7 @@
 	dir = 8;
 	icon_state = "stairs"
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/ruinedwood/darker,
 /area/rogue/indoors/soilsons)
 "cEA" = (
 /obj/effect/landmark/start/nightman{
@@ -4255,12 +4271,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/magician)
-"cVl" = (
-/obj/machinery/light/rogue/torchholder/l,
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/structure/fluff/nest,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield/safe)
 "cVZ" = (
 /turf/open/floor/rogue/rooftop{
 	dir = 4
@@ -4998,13 +5008,11 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/steward)
 "dEl" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 1;
-	icon_state = "wooddir"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/obj/structure/closet/crate/chest/wicker,
+/obj/item/cooking/pan,
+/obj/item/reagent_containers/food/snacks/produce/wheat,
+/obj/item/reagent_containers/food/snacks/produce/wheat,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/soilsons)
 "dEp" = (
 /obj/structure/roguethrone{
@@ -5590,14 +5598,6 @@
 "dXj" = (
 /turf/closed/wall/mineral/rogue/decostone/center,
 /area/rogue/indoors/town/manor)
-"dXk" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
-	},
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield/safe)
 "dXy" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	icon_state = "endwooddark";
@@ -6419,6 +6419,11 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"ezb" = (
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/roguegrass/bush_meagre,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/safe)
 "ezn" = (
 /obj/structure/bed/rogue/wool,
 /obj/item/bedsheet/rogue/cloth,
@@ -6549,9 +6554,9 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/clocktower)
 "eES" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/trufflepig,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield/safe)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/soilsons)
 "eFy" = (
 /obj/structure/table/wood/plain_alt,
 /obj/item/candle/yellow,
@@ -6935,6 +6940,13 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town/magician)
+"eSo" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
+	},
+/turf/closed/wall/mineral/rogue/wooddark/horizontal,
+/area/rogue/outdoors/rtfield/safe)
 "eTs" = (
 /obj/structure/closet/dirthole/grave,
 /turf/open/floor/rogue/dirt,
@@ -6955,6 +6967,11 @@
 	},
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town/manor)
+"eUt" = (
+/obj/item/roguebin/water,
+/obj/item/natural/cloth,
+/turf/open/floor/rogue/wood,
+/area/rogue/outdoors/mountains)
 "eUE" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/natural/cloth,
@@ -7338,16 +7355,6 @@
 	icon_state = "linoleum"
 	},
 /area/rogue/indoors/town/vault)
-"fhh" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "priest";
-	locked = 1
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town/church)
 "fhB" = (
 /obj/structure/fluff/clock,
 /obj/structure/fluff/walldeco/stone{
@@ -7532,6 +7539,10 @@
 "foL" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/clinic_large)
+"fpc" = (
+/obj/item/natural/cloth,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/butchershop)
 "fps" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /obj/structure/flora/roguegrass/water/reeds,
@@ -7853,9 +7864,8 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/town)
 "fBT" = (
-/obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
-	dir = 1
+/obj/structure/mineral_door/wood/deadbolt{
+	name = "bathroom"
 	},
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/soilsons)
@@ -7999,6 +8009,16 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
+"fHP" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/obj/structure/fluff/railing/wood{
+	dir = 1
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/rtfield/safe)
 "fIh" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/under/roguetown/loincloth,
@@ -8458,10 +8478,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"gaE" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield/safe)
 "gbp" = (
 /obj/effect/landmark/start/sapprentice{
 	dir = 1
@@ -9399,9 +9415,9 @@
 /turf/open/floor/rogue/ruinedwood/turned/darker,
 /area/rogue/indoors/town)
 "gIt" = (
-/obj/structure/bars/cemetery,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield/safe)
+/obj/machinery/light/rogue/oven/east,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/soilsons)
 "gIG" = (
 /obj/machinery/light/rogue/hearth,
 /obj/structure/fluff/railing/border{
@@ -9656,16 +9672,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
-"gSd" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/obj/structure/fluff/railing/wood{
-	dir = 1
-	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield/safe)
 "gSl" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
@@ -9764,6 +9770,11 @@
 /obj/item/reagent_containers/food/snacks/produce/oat,
 /turf/open/floor/rogue/tile/kitchen,
 /area/rogue/outdoors/mountains)
+"gVE" = (
+/obj/structure/flora/roguegrass,
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/safe)
 "gVQ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -9897,8 +9908,7 @@
 /area/rogue/outdoors/town)
 "gZZ" = (
 /obj/structure/flora/roguegrass,
-/obj/structure/flora/roguegrass/bush_meagre,
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield/safe)
 "har" = (
 /obj/effect/landmark/start/villager{
@@ -10359,6 +10369,13 @@
 "hvw" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/shop)
+"hvz" = (
+/obj/structure/mineral_door/bars{
+	locked = 1;
+	lockid = "soilson"
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/rtfield/safe)
 "hvL" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -11552,10 +11569,6 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/carpet/green,
 /area/rogue/indoors/town)
-"ipQ" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/goat,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield/safe)
 "iqd" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/town/cell)
@@ -12873,6 +12886,9 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"jeq" = (
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/mountains)
 "jeB" = (
 /obj/structure/flora/roguegrass/herb/atropa,
 /turf/open/floor/rogue/grass,
@@ -13093,6 +13109,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/darker,
 /area/rogue/indoors/town/theatre)
+"joy" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/ruinedwood/darker,
+/area/rogue/indoors/soilsons)
 "joz" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/soilsons)
@@ -13228,11 +13248,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town)
-"jtK" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/bars/cemetery,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/safe)
 "jtP" = (
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/manorgate)
@@ -13744,6 +13759,12 @@
 /obj/effect/spawner/roguemap/loot/coin/low,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"jOt" = (
+/obj/machinery/light/rogue/torchholder/l,
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/structure/fluff/nest,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/rtfield/safe)
 "jOI" = (
 /obj/structure/stairs/stone{
 	dir = 1;
@@ -13941,6 +13962,11 @@
 "jSN" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/manor)
+"jSW" = (
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/structure/fluff/nest,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/rtfield/safe)
 "jTr" = (
 /obj/structure/closet/crate/chest/old_crate,
 /obj/machinery/light/rogue/wallfire/candle{
@@ -14646,6 +14672,10 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
+"krK" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/goat,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/rtfield/safe)
 "krR" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "linoleum"
@@ -14976,6 +15006,16 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/orphanage)
+"kGw" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "priest";
+	locked = 1
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town/church)
 "kGO" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/bath)
@@ -16492,10 +16532,6 @@
 /obj/structure/rack/rogue/shelf/biggest,
 /turf/open/floor/rogue/ruinedwood/turned/darker,
 /area/rogue/indoors/town)
-"lTn" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield/safe)
 "lTY" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -16899,11 +16935,12 @@
 	},
 /area/rogue/under/town/basement)
 "mob" = (
-/obj/structure/mineral_door/bars{
-	locked = 1;
-	lockid = "butcher"
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_y = -1
 	},
-/turf/open/floor/rogue/grass,
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield/safe)
 "mog" = (
 /obj/structure/flora/roguegrass,
@@ -19362,8 +19399,8 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/shop)
 "ocn" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
-/turf/open/floor/rogue/dirt/road,
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield/safe)
 "ocA" = (
 /turf/open/floor/rogue/ruinedwood/turned/darker,
@@ -19396,6 +19433,10 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/manor)
+"oet" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/rtfield/safe)
 "oeZ" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -19640,6 +19681,11 @@
 	},
 /turf/open/floor/rogue/ruinedwood/darker,
 /area/rogue/indoors/town/orphanage)
+"omx" = (
+/obj/structure/roguemachine/scomm,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/safe)
 "omB" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
@@ -20298,6 +20344,7 @@
 /obj/machinery/light/rogue/torchholder{
 	dir = 1
 	},
+/obj/item/natural/cloth,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/butchershop)
 "oOf" = (
@@ -20648,13 +20695,6 @@
 /obj/machinery/light/rogue/lanternpost/fixed,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/sewer)
-"pbd" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
-	},
-/turf/closed/wall/mineral/rogue/wooddark/horizontal,
-/area/rogue/outdoors/rtfield/safe)
 "pbn" = (
 /obj/structure/chair/bench/coucha,
 /turf/open/floor/rogue/hexstone,
@@ -20691,9 +20731,8 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/under/town/sewer)
-"pbU" = (
-/obj/structure/roguemachine/scomm,
-/obj/structure/flora/roguegrass,
+"pcL" = (
+/obj/structure/composter/halffull,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/safe)
 "pec" = (
@@ -20809,11 +20848,6 @@
 /obj/structure/closet/crate/chest/crafted,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
-"piA" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/newtree,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/safe)
 "piR" = (
 /obj/machinery/light/rogue/chand,
 /turf/open/transparent/openspace,
@@ -21894,18 +21928,6 @@
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
-"qcd" = (
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/item/rogueweapon/knife/cleaver{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/kitchen/rollingpin{
-	pixel_x = 5;
-	pixel_y = -5
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/church)
 "qcx" = (
 /obj/item/natural/feather{
 	pixel_x = -15;
@@ -22270,7 +22292,8 @@
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town/magician)
 "qpx" = (
-/obj/structure/bars/cemetery,
+/obj/structure/flora/roguegrass,
+/obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/safe)
 "qpP" = (
@@ -22829,10 +22852,6 @@
 	},
 /turf/open/floor/rogue/grass/yel,
 /area/rogue/outdoors/town)
-"qOg" = (
-/obj/structure/fluff/nest,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield/safe)
 "qOm" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
@@ -23114,6 +23133,13 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiralfade,
 /area/rogue/indoors/town)
+"qUM" = (
+/obj/structure/mineral_door/bars{
+	locked = 1;
+	lockid = "butcher"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/safe)
 "qVd" = (
 /obj/structure/table/wood/plain_alt,
 /obj/item/rogueweapon/tongs,
@@ -23829,15 +23855,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/darker,
 /area/rogue/indoors/town/theatre)
-"rBr" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1
-	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield/safe)
 "rBu" = (
 /turf/open/lava,
 /area/rogue/under/cavelava)
@@ -23921,19 +23938,30 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/magician)
 "rFn" = (
-/obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+/obj/structure/table/wood/plain,
+/obj/item/kitchen/spoon{
+	pixel_y = -6;
+	pixel_x = -9
 	},
-/obj/item/clothing/mask/cigarette/pipe/westman{
-	pixel_x = -6;
-	pixel_y = 6
+/obj/item/kitchen/spoon{
+	pixel_x = 7;
+	pixel_y = 7
 	},
-/turf/open/floor/rogue/wood,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -5;
+	pixel_y = -5
+	},
+/turf/open/floor/rogue/ruinedwood/darker,
 /area/rogue/indoors/soilsons)
 "rFo" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
+"rFC" = (
+/obj/effect/landmark/start/farmer,
+/obj/structure/chair/wood/rogue,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/soilsons)
 "rFI" = (
 /obj/structure/fluff/statue/knight/interior{
 	layer = 4.2
@@ -24424,9 +24452,13 @@
 /turf/closed/wall/mineral/rogue/roofwall/outercorner,
 /area/rogue/indoors/town/manor)
 "rWm" = (
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield/safe)
+/obj/structure/stairs{
+	dir = 8;
+	icon_state = "stairs"
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood/darker,
+/area/rogue/indoors/soilsons)
 "rWu" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8;
@@ -25368,6 +25400,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/theatre)
+"sGB" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/rtfield/safe)
 "sGK" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/dirt/road,
@@ -26109,11 +26145,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
-"tgT" = (
-/obj/structure/flora/roguegrass,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/safe)
 "thb" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /obj/structure/bars,
@@ -26288,9 +26319,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church)
 "tms" = (
-/obj/structure/bars/cemetery,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield/safe)
+/turf/open/floor/rogue/rooftop/green{
+	dir = 8
+	},
+/area/rogue/outdoors/town/roofs)
 "tmw" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1
@@ -26622,6 +26654,17 @@
 	dir = 4
 	},
 /area/rogue/outdoors/town/roofs)
+"txi" = (
+/obj/structure/table/wood{
+	icon_state = "longtable"
+	},
+/obj/structure/fluff/millstone{
+	pixel_y = 10
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "chess"
+	},
+/area/rogue/indoors/town/church)
 "txw" = (
 /obj/structure/fluff/railing/border{
 	dir = 4;
@@ -27014,6 +27057,13 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"tKI" = (
+/obj/structure/roguewindow/openclose{
+	dir = 8;
+	icon_state = "woodwindowdir"
+	},
+/turf/open/floor/rogue/woodturned/nosmooth,
+/area/rogue/indoors/soilsons)
 "tKK" = (
 /obj/structure/table/wood/plain_alt,
 /obj/item/candle/yellow,
@@ -27341,11 +27391,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "tVL" = (
-/obj/structure/mineral_door/bars{
-	locked = 1;
-	lockid = "soilson"
-	},
-/turf/open/floor/rogue/dirt,
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield/safe)
 "tWt" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -27394,6 +27441,9 @@
 /obj/structure/closet/crate/chest/neu,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/orphanage)
+"tXs" = (
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/rtfield/safe)
 "tXE" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/blocks,
@@ -27928,6 +27978,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/magician)
+"upi" = (
+/obj/structure/table/wood{
+	icon_state = "longtable";
+	dir = 1
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/soilsons)
 "upD" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -28169,6 +28226,10 @@
 /obj/effect/spawner/roguemap/hauntz_random,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/town)
+"uzE" = (
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/safe)
 "uzI" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -28336,6 +28397,15 @@
 "uEs" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town)
+"uEt" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/rtfield/safe)
 "uEx" = (
 /obj/structure/chair/bench/ultimacouch,
 /turf/open/floor/rogue/herringbone,
@@ -30215,10 +30285,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
-"wee" = (
-/obj/structure/roguemachine/atm,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield/safe)
 "wep" = (
 /obj/structure/closet/crate/chest/neu,
 /turf/open/floor/rogue/wood,
@@ -30644,10 +30710,6 @@
 "wtv" = (
 /turf/closed/wall/mineral/rogue/wooddark/end,
 /area/rogue/outdoors/town)
-"wtx" = (
-/obj/structure/composter/halffull,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield/safe)
 "wtI" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -30854,6 +30916,12 @@
 "wBa" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/caverogue)
+"wBr" = (
+/obj/structure/mineral_door/wood/deadbolt{
+	name = "bath"
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/soilsons)
 "wBz" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8
@@ -31022,10 +31090,15 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "wFL" = (
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/structure/fluff/nest,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield/safe)
+/obj/structure/table/wood{
+	icon_state = "longtable";
+	dir = 1
+	},
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/soilsons)
 "wFU" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/blocks,
@@ -32117,6 +32190,13 @@
 /obj/structure/mineral_door/swing_door,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield/safe)
+"xyP" = (
+/obj/structure/table/wood{
+	icon_state = "longtable"
+	},
+/obj/structure/fluff/millstone,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/soilsons)
 "xyY" = (
 /turf/closed/mineral/rogue,
 /area/rogue/outdoors/town)
@@ -32271,17 +32351,6 @@
 /mob/living/carbon/human/species/skeleton/npc/ambush,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/town/sewer)
-"xEi" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
-	},
-/obj/structure/fluff/millstone{
-	pixel_y = 10
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/indoors/town/church)
 "xEm" = (
 /obj/structure/stairs{
 	dir = 4
@@ -32693,6 +32762,10 @@
 /obj/structure/trap/wall_projectile,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/town/sewer)
+"xUE" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/trufflepig,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/rtfield/safe)
 "xVe" = (
 /obj/structure/closet/crate/roguecloset/dark,
 /obj/item/clothing/mask/rogue/phys,
@@ -32979,6 +33052,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/church)
+"yff" = (
+/obj/structure/fluff/nest,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/rtfield/safe)
 "yfh" = (
 /obj/structure/mineral_door/wood{
 	lockid = "apartment12";
@@ -105747,7 +105824,7 @@ vgJ
 vgJ
 eCc
 lIF
-mux
+jKC
 vnF
 vnF
 vnF
@@ -144524,13 +144601,13 @@ iSk
 iSk
 wMs
 wMs
-wMs
-wMs
-wMs
-wMs
-wMs
-wMs
-wMs
+dUI
+joL
+nNC
+nNC
+nNC
+plm
+dUI
 wMs
 wMs
 wMs
@@ -144726,13 +144803,13 @@ iSk
 iSk
 wMs
 wMs
-wMs
-wMs
-wMs
-aWD
-nEW
-wMs
-wMs
+hXa
+xyP
+cZU
+gIt
+mFw
+wIn
+hXa
 wMs
 wMs
 wMs
@@ -144928,13 +145005,13 @@ iSk
 iSk
 wMs
 nEW
-dUI
-joL
-nNC
-nNC
-nNC
-plm
-dUI
+aJF
+veJ
+cZU
+cZU
+rFC
+veJ
+hgf
 wMs
 wMs
 wMs
@@ -145130,13 +145207,13 @@ iSk
 iSk
 wMs
 aWD
-hXa
-ppU
+aJF
+upi
 dEl
 cZU
-bvO
-wIn
-hXa
+cZU
+wFL
+aJF
 wMs
 wMs
 wMs
@@ -145336,8 +145413,8 @@ aJF
 dUI
 dUI
 qPi
-arX
-veJ
+cZU
+eES
 hgf
 wMs
 wMs
@@ -145536,9 +145613,9 @@ wMs
 aWD
 aJF
 cEy
-lEn
-cZU
-cZU
+rWm
+qLU
+qLU
 rFn
 prn
 wMs
@@ -145737,11 +145814,11 @@ iSk
 wMs
 eTF
 prn
-cZU
-cZU
-cZU
-cZU
-mFw
+qLU
+qLU
+qLU
+qLU
+joy
 dUI
 wMs
 wMs
@@ -145926,7 +146003,7 @@ iWd
 nZK
 nlp
 fYR
-rWm
+gZZ
 nlp
 aWD
 aWD
@@ -145936,7 +146013,7 @@ iSf
 nEW
 aWD
 uzX
-qpx
+uzE
 oZq
 dUI
 nNC
@@ -146137,8 +146214,8 @@ ucW
 ucW
 ucW
 ucW
-auu
-jtK
+tVL
+gVE
 aWD
 aWD
 nlp
@@ -146148,7 +146225,7 @@ oPu
 qLU
 aJF
 eTF
-wMs
+tXs
 wMs
 wMs
 wMs
@@ -146164,7 +146241,7 @@ uyW
 uyW
 oTX
 gnI
-lTn
+bvO
 fYR
 fYR
 kMP
@@ -146331,15 +146408,15 @@ nlp
 fYR
 aWD
 eTF
-gIt
-tms
-gIt
-tms
+ocn
+arX
+ocn
+arX
+hvz
+hvz
+arX
+arX
 tVL
-tVL
-tms
-tms
-auu
 ucW
 ucW
 ucW
@@ -146531,9 +146608,9 @@ iWd
 iWd
 eTF
 nZK
-gZZ
+ezb
 nEW
-gIt
+ocn
 pVJ
 nlp
 ukJ
@@ -146729,7 +146806,7 @@ hMp
 hMp
 nLC
 vlf
-fhh
+kGw
 swo
 nLu
 swo
@@ -146738,7 +146815,7 @@ nLu
 mJO
 fYR
 ukJ
-rWm
+gZZ
 fYR
 fYR
 fYR
@@ -146932,11 +147009,11 @@ kze
 mJO
 mJO
 aDq
-qcd
+bjw
 uxx
 aJp
 wCQ
-xEi
+txi
 mJO
 gGy
 ucW
@@ -146971,12 +147048,12 @@ hPu
 hPu
 gzH
 iae
-qpx
-qpx
-mob
-mob
-tms
-qpx
+uzE
+uzE
+qUM
+qUM
+arX
+uzE
 vgJ
 vgJ
 eyC
@@ -147151,7 +147228,7 @@ fYR
 fYR
 nZK
 ucW
-wtx
+pcL
 hXa
 edj
 edj
@@ -147353,7 +147430,7 @@ nlp
 fYR
 aWD
 aWD
-wtx
+pcL
 aJF
 jMV
 kPZ
@@ -147552,7 +147629,7 @@ fYR
 nlp
 fYR
 ukJ
-rWm
+gZZ
 ucW
 ucW
 pVi
@@ -147750,11 +147827,11 @@ bgn
 ucW
 eTF
 aWD
-rWm
+gZZ
 ukJ
 fYR
 nlp
-rWm
+gZZ
 ucW
 ucW
 ukJ
@@ -147951,7 +148028,7 @@ mJO
 mJO
 mJO
 mJO
-tgT
+qpx
 fYR
 ukJ
 fYR
@@ -147971,10 +148048,10 @@ wMs
 wMs
 wMs
 nkg
-dXk
+mob
 vdC
-cVl
-wFL
+jOt
+jSW
 cyW
 fYR
 fYR
@@ -148153,7 +148230,7 @@ mJO
 hMp
 hMp
 mJO
-pbU
+omx
 fYR
 fYR
 fYR
@@ -148375,9 +148452,9 @@ wMs
 wMs
 wMs
 tNQ
-ocn
+oet
 fYR
-qOg
+yff
 fYR
 cyW
 nlp
@@ -148557,7 +148634,7 @@ mJO
 hMp
 hMp
 mJO
-wee
+auu
 nlp
 fYR
 nlp
@@ -148577,9 +148654,9 @@ wMs
 wMs
 wMs
 tmw
-qOg
+yff
 fYR
-ocn
+oet
 nlp
 tmw
 nlp
@@ -148759,7 +148836,7 @@ eLl
 mJO
 mJO
 mJO
-gaE
+sGB
 fYR
 fYR
 fYR
@@ -148778,7 +148855,7 @@ aWD
 wMs
 wMs
 wMs
-gSd
+fHP
 roZ
 lSD
 lSD
@@ -148788,7 +148865,7 @@ fYR
 fYR
 fYR
 hXN
-rBr
+uEt
 lSD
 xwQ
 xwQ
@@ -149163,7 +149240,7 @@ vic
 nLu
 nlp
 nZK
-piA
+bmw
 aWD
 nlp
 fYR
@@ -149390,7 +149467,7 @@ nlp
 ucW
 aWD
 uzX
-pbd
+eSo
 wtX
 lAc
 wtX
@@ -150204,7 +150281,7 @@ fYR
 nlp
 tNQ
 fYR
-eES
+xUE
 nlp
 tmw
 nEW
@@ -150402,7 +150479,7 @@ hTk
 cyW
 tmw
 nlp
-ipQ
+krK
 fYR
 tNQ
 nlp
@@ -184925,13 +185002,13 @@ acx
 acx
 acx
 acx
-acx
-acx
-acx
-acx
-acx
-acx
-acx
+tms
+tms
+tms
+tms
+tms
+tms
+tms
 acx
 acx
 acx
@@ -185127,13 +185204,13 @@ acx
 acx
 acx
 acx
-acx
-acx
-acx
-acx
-acx
-acx
-acx
+tms
+tms
+tms
+tms
+tms
+tms
+tms
 acx
 acx
 acx
@@ -186548,8 +186625,8 @@ cuX
 cuX
 hzI
 joz
-uVx
-uVx
+joz
+joz
 uVx
 uVx
 uVx
@@ -186749,9 +186826,9 @@ joz
 cZU
 cZU
 cZU
+wBr
+ppU
 joz
-uVx
-uVx
 uVx
 uVx
 uVx
@@ -187762,7 +187839,7 @@ cZU
 joz
 joz
 joz
-joz
+tKI
 ufg
 bBJ
 bBJ
@@ -187774,7 +187851,7 @@ uFq
 uFq
 uFq
 uFq
-uFq
+fpc
 bBJ
 uVx
 uVx
@@ -187962,8 +188039,8 @@ gRj
 pRl
 cZU
 fBT
-uVx
-uVx
+eUt
+jeq
 uVx
 uVx
 uVx
@@ -188164,8 +188241,8 @@ joz
 joz
 joz
 joz
-uVx
-uVx
+jeq
+jeq
 uVx
 uVx
 uVx

--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -483,9 +483,11 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield/safe)
 "aso" = (
-/obj/machinery/light/rogue/torchholder/c,
-/obj/structure/bed/rogue/shit,
-/turf/open/floor/rogue/twig,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/transparent/openspace,
 /area/rogue/indoors/butchershop)
 "atD" = (
 /obj/structure/fluff/railing/border{
@@ -2065,9 +2067,13 @@
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/under/town/sewer)
 "bvO" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield/safe)
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/obj/structure/table/wood,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/butchershop)
 "bvW" = (
 /obj/structure/chair/wood/rogue/chair_noble/red,
 /turf/open/floor/rogue/tile,
@@ -5673,6 +5679,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/town)
+"dZE" = (
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/butchershop)
 "dZG" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/tile/kitchen,
@@ -6231,6 +6241,15 @@
 /obj/structure/roguerock,
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/river)
+"esY" = (
+/obj/structure/roguemachine/vendor{
+	keycontrol = "tavern"
+	},
+/turf/closed/wall/mineral/rogue/wooddark/end{
+	icon_state = "endwooddark";
+	dir = 4
+	},
+/area/rogue/indoors/butchershop)
 "etd" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/ruinedwood/spiralfade,
@@ -6339,6 +6358,13 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/safe)
+"ewb" = (
+/obj/structure/mineral_door/wood/window{
+	locked = 1;
+	lockid = "soilson"
+	},
+/turf/open/floor/rogue/ruinedwood/turned/darker,
+/area/rogue/indoors/soilsons)
 "ewc" = (
 /obj/effect/landmark/start/matron{
 	dir = 1
@@ -6563,7 +6589,7 @@
 /area/rogue/indoors/town/clocktower)
 "eES" = (
 /obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/soilsons)
 "eFy" = (
 /obj/structure/table/wood/plain_alt,
@@ -6979,7 +7005,7 @@
 /obj/item/roguebin/water,
 /obj/item/natural/cloth,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/soilsons)
 "eUE" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/natural/cloth,
@@ -7363,6 +7389,10 @@
 	icon_state = "linoleum"
 	},
 /area/rogue/indoors/town/vault)
+"fhm" = (
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/rtfield/safe)
 "fhB" = (
 /obj/structure/fluff/clock,
 /obj/structure/fluff/walldeco/stone{
@@ -7549,6 +7579,10 @@
 /area/rogue/indoors/town/clinic_large)
 "fpc" = (
 /obj/item/natural/cloth,
+/obj/structure/fluff/railing/border{
+	dir = 9;
+	icon_state = "border"
+	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/butchershop)
 "fps" = (
@@ -8052,6 +8086,12 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/shop)
+"fJi" = (
+/obj/structure/roguemachine/vendor{
+	keycontrol = "tavern"
+	},
+/turf/closed/wall/mineral/rogue/wood/window,
+/area/rogue/outdoors/rtfield/safe)
 "fJn" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -8476,8 +8516,7 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/orphanage)
 "gap" = (
-/obj/structure/bed/rogue/shit,
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/soilsons)
 "gaD" = (
 /obj/machinery/light/rogue/wallfire/candle{
@@ -9424,7 +9463,7 @@
 /area/rogue/indoors/town)
 "gIt" = (
 /obj/machinery/light/rogue/oven/east,
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/soilsons)
 "gIG" = (
 /obj/machinery/light/rogue/hearth,
@@ -10281,7 +10320,7 @@
 /area/rogue/indoors/town/dwarfin)
 "hsj" = (
 /obj/effect/landmark/start/beastmonger,
-/turf/open/floor/rogue/woodturned,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/butchershop)
 "hsq" = (
 /obj/structure/fluff/railing/fence{
@@ -11213,17 +11252,9 @@
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/merc_guild)
 "hZf" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/food/snacks/produce/wheat,
-/obj/item/reagent_containers/food/snacks/produce/wheat,
-/obj/item/reagent_containers/food/snacks/produce/wheat,
-/obj/item/reagent_containers/food/snacks/produce/wheat,
-/obj/item/reagent_containers/food/snacks/produce/wheat,
-/obj/item/reagent_containers/food/snacks/produce/wheat,
-/obj/item/natural/chaff/wheat,
-/obj/item/natural/chaff/wheat,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/butchershop)
+/obj/structure/bed/rogue/shit,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/soilsons)
 "hZm" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/blocks/stonered,
@@ -12882,9 +12913,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "jeb" = (
-/obj/structure/bed/rogue/shit,
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/soilsons)
 "jej" = (
 /obj/structure/stairs/stone{
@@ -12895,8 +12925,9 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "jeq" = (
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/mountains)
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/safe)
 "jeB" = (
 /obj/structure/flora/roguegrass/herb/atropa,
 /turf/open/floor/rogue/grass,
@@ -17414,7 +17445,7 @@
 /area/rogue/indoors/town/garrison)
 "mFw" = (
 /obj/machinery/light/rogue/hearth,
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/soilsons)
 "mFy" = (
 /obj/effect/landmark/start/shepherd{
@@ -17709,8 +17740,8 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "mPX" = (
-/turf/closed/wall/mineral/rogue/wooddark,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/ruinedwood/turned/darker,
+/area/rogue/indoors/soilsons)
 "mPZ" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -20510,21 +20541,9 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
 "oTX" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/food/snacks/produce/wheat,
-/obj/item/reagent_containers/food/snacks/produce/wheat,
-/obj/item/reagent_containers/food/snacks/produce/wheat,
-/obj/item/reagent_containers/food/snacks/produce/wheat,
-/obj/item/reagent_containers/food/snacks/produce/wheat,
-/obj/item/reagent_containers/food/snacks/produce/wheat,
-/obj/item/reagent_containers/food/snacks/produce/wheat,
-/obj/item/reagent_containers/food/snacks/produce/wheat,
-/obj/item/reagent_containers/food/snacks/produce/wheat,
-/obj/item/reagent_containers/food/snacks/produce/wheat,
-/obj/item/natural/chaff/wheat,
-/obj/item/natural/chaff/wheat,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/butchershop)
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/safe)
 "oUc" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/dirt,
@@ -21495,11 +21514,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/manor)
 "pJU" = (
-/obj/structure/mineral_door/wood/window{
-	locked = 1;
-	lockid = "soilson"
-	},
-/turf/open/floor/rogue/wood,
+/turf/closed/wall/mineral/rogue/wood/window,
 /area/rogue/indoors/butchershop)
 "pKh" = (
 /obj/structure/mineral_door/wood/violet{
@@ -21682,7 +21697,6 @@
 /turf/open/floor/rogue/ruinedwood/turned/darker,
 /area/rogue/indoors/town)
 "pRl" = (
-/obj/structure/closet/crate/chest/neu,
 /obj/machinery/light/rogue/torchholder{
 	dir = 8;
 	icon_state = "torchwall1"
@@ -22875,7 +22889,7 @@
 /area/rogue/indoors/town/manor)
 "qPi" = (
 /obj/structure/roguemachine/mail,
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/soilsons)
 "qPl" = (
 /obj/structure/fluff/railing/wood{
@@ -23125,7 +23139,7 @@
 	},
 /obj/item/roguecoin/copper/pile,
 /obj/item/roguecoin/copper/pile,
-/turf/open/floor/rogue/dirt/road,
+/turf/open/floor/rogue/ruinedwood/turned/darker,
 /area/rogue/indoors/soilsons)
 "qUG" = (
 /obj/structure/roguemachine/atm{
@@ -23960,7 +23974,7 @@
 	pixel_x = -5;
 	pixel_y = -5
 	},
-/turf/open/floor/rogue/ruinedwood/darker,
+/turf/open/floor/rogue/ruinedwood/turned/darker,
 /area/rogue/indoors/soilsons)
 "rFo" = (
 /turf/open/floor/rogue/twig,
@@ -25808,7 +25822,7 @@
 	icon_state = "longtable";
 	dir = 1
 	},
-/turf/open/floor/rogue/dirt/road,
+/turf/open/floor/rogue/ruinedwood/turned/darker,
 /area/rogue/indoors/soilsons)
 "sUf" = (
 /obj/structure/mineral_door/wood/donjon{
@@ -25873,7 +25887,8 @@
 	dir = 9;
 	icon_state = "border"
 	},
-/turf/open/floor/rogue/woodturned,
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/butchershop)
 "sVs" = (
 /obj/structure/closet/crate/chest,
@@ -27317,16 +27332,11 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet)
 "tRt" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/food/snacks/produce/wheat,
-/obj/item/reagent_containers/food/snacks/produce/wheat,
-/obj/item/reagent_containers/food/snacks/produce/wheat,
-/obj/item/reagent_containers/food/snacks/produce/wheat,
-/obj/item/reagent_containers/food/snacks/produce/wheat,
-/obj/item/natural/chaff/wheat,
-/obj/item/natural/chaff/wheat,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/butchershop)
+/obj/structure/closet/crate/drawer{
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/soilsons)
 "tRO" = (
 /obj/structure/mirror{
 	pixel_x = -32;
@@ -27991,7 +28001,7 @@
 	icon_state = "longtable";
 	dir = 1
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/soilsons)
 "upD" = (
 /obj/structure/fluff/railing/border{
@@ -28425,7 +28435,7 @@
 /obj/structure/table/wood{
 	icon_state = "longtable"
 	},
-/turf/open/floor/rogue/dirt/road,
+/turf/open/floor/rogue/ruinedwood/turned/darker,
 /area/rogue/indoors/soilsons)
 "uFq" = (
 /turf/open/transparent/openspace,
@@ -28919,7 +28929,7 @@
 /obj/item/reagent_containers/food/snacks/produce/wheat,
 /obj/item/reagent_containers/food/snacks/produce/wheat,
 /obj/item/natural/chaff/wheat,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/butchershop)
 "vag" = (
 /obj/machinery/light/rogue/wallfire/candle{
@@ -29048,7 +29058,7 @@
 	icon_state = "longtable_mid";
 	dir = 1
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/soilsons)
 "veS" = (
 /obj/structure/plough,
@@ -30269,7 +30279,7 @@
 /obj/effect/landmark/start/beastmonger{
 	dir = 8
 	},
-/turf/open/floor/rogue/woodturned,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/butchershop)
 "wdA" = (
 /obj/structure/fluff/walldeco/chains,
@@ -30769,6 +30779,15 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"wvz" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/transparent/openspace,
+/area/rogue/indoors/butchershop)
 "wvQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/rogue/oven/east,
@@ -30792,11 +30811,17 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
 "wxd" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/shirt/undershirt/lowcut,
+/obj/item/clothing/suit/roguetown/shirt/undershirt/lowcut,
+/obj/item/clothing/suit/roguetown/shirt/tunic/random,
+/obj/item/clothing/suit/roguetown/shirt/tunic/random,
+/obj/item/clothing/under/roguetown/trou,
+/obj/item/clothing/under/roguetown/tights,
+/obj/item/clothing/under/roguetown/tights,
+/obj/item/clothing/under/roguetown/skirt/random,
 /turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/butchershop)
+/area/rogue/indoors/soilsons)
 "wxf" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -31105,7 +31130,7 @@
 /obj/machinery/light/rogue/torchholder/l{
 	dir = 1
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/soilsons)
 "wFU" = (
 /obj/effect/decal/cleanable/blood,
@@ -31198,7 +31223,7 @@
 	pixel_x = 6;
 	pixel_y = 3
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/soilsons)
 "wIw" = (
 /obj/structure/mineral_door/wood/donjon/stone{
@@ -31954,7 +31979,7 @@
 	pixel_x = 3;
 	pixel_y = 2
 	},
-/turf/open/floor/rogue/dirt/road,
+/turf/open/floor/rogue/ruinedwood/turned/darker,
 /area/rogue/indoors/soilsons)
 "xmx" = (
 /obj/effect/decal/cleanable/dirt/cobweb,
@@ -32030,6 +32055,12 @@
 /obj/structure/chair/bench/church/smallbench,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/river)
+"xqZ" = (
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/transparent/openspace,
+/area/rogue/indoors/butchershop)
 "xrW" = (
 /turf/closed/mineral/rogue,
 /area/rogue/under/cavewet)
@@ -32204,7 +32235,7 @@
 	icon_state = "longtable"
 	},
 /obj/structure/fluff/millstone,
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/soilsons)
 "xyY" = (
 /turf/closed/mineral/rogue,
@@ -144814,7 +144845,7 @@ wMs
 wMs
 hXa
 xyP
-cZU
+gap
 gIt
 mFw
 wIn
@@ -145422,7 +145453,7 @@ aJF
 dUI
 dUI
 qPi
-cZU
+gap
 eES
 hgf
 wMs
@@ -145623,8 +145654,8 @@ aWD
 aJF
 cEy
 rWm
-qLU
-qLU
+mPX
+mPX
 rFn
 prn
 wMs
@@ -145642,9 +145673,9 @@ nDz
 cDw
 hHr
 uyW
-hZf
+uyW
 nDz
-nEW
+nlp
 hGo
 sXF
 sXF
@@ -145818,14 +145849,14 @@ nZK
 wMs
 wMs
 aWD
-nZK
+wvf
 iSk
 wMs
 eTF
 prn
 qLU
 qLU
-qLU
+mPX
 qLU
 joy
 dUI
@@ -145844,9 +145875,9 @@ iae
 eJF
 uyW
 uyW
-tRt
-iae
-aWD
+uyW
+bvO
+fYR
 hGo
 sXF
 hGo
@@ -146019,8 +146050,8 @@ aWD
 ucW
 iSf
 iSf
-nEW
 aWD
+oTX
 uzX
 uzE
 oZq
@@ -146046,9 +146077,9 @@ iae
 eJF
 uyW
 uyW
-uZt
-iae
-nEW
+uyW
+bvO
+fYR
 fYR
 sXF
 hGo
@@ -146222,7 +146253,7 @@ aWD
 ucW
 ucW
 ucW
-ucW
+fhm
 tVL
 gVE
 aWD
@@ -146248,9 +146279,9 @@ gnI
 cDw
 uyW
 uyW
-oTX
-gnI
-bvO
+uyW
+esY
+nlp
 fYR
 fYR
 kMP
@@ -146419,7 +146450,7 @@ aWD
 eTF
 ocn
 arX
-ocn
+fJi
 arX
 hvz
 hvz
@@ -146447,12 +146478,12 @@ cTS
 qIX
 pLZ
 ufg
-ufg
+pJU
 rWu
+pJU
 ufg
 ufg
-ufg
-aWD
+jeq
 nlp
 fYR
 sXF
@@ -146834,10 +146865,10 @@ eTF
 aWD
 ucW
 ucW
-sLU
-edj
-qLU
-qLU
+ewb
+mPX
+mPX
+mPX
 dUI
 hZO
 dsW
@@ -146848,11 +146879,11 @@ dsW
 hZO
 jaW
 hPu
-hPu
+rqQ
 cQZ
 oIQ
-hPu
-hPu
+rqQ
+rqQ
 hPu
 iae
 nZK
@@ -147050,11 +147081,11 @@ vHb
 vHb
 bZm
 hPu
-hPu
-wxd
+rqQ
+jlM
 sVf
-hPu
-hPu
+rqQ
+rqQ
 gzH
 iae
 uzE
@@ -147252,11 +147283,11 @@ duU
 iVO
 ufg
 ktt
-hPu
-hPu
-hPu
+rqQ
+rqQ
+rqQ
 hsj
-hPu
+rqQ
 vwl
 iae
 nlp
@@ -147455,10 +147486,10 @@ wMs
 nDz
 kkY
 wdv
-hPu
-hPu
-hPu
-hPu
+rqQ
+rqQ
+rqQ
+rqQ
 oNM
 iae
 nlp
@@ -185822,8 +185853,8 @@ uVx
 joz
 jgG
 lEn
-cZU
-cZU
+cuX
+cuX
 cZU
 joz
 uVx
@@ -186219,7 +186250,7 @@ uVx
 uVx
 uVx
 uVx
-uVx
+mOk
 acx
 acx
 uVx
@@ -186238,9 +186269,9 @@ uVx
 uVx
 uVx
 bBJ
-gcy
-gcy
+uaX
 aKc
+uaX
 bBJ
 lnm
 lnm
@@ -186440,7 +186471,7 @@ uVx
 uVx
 uVx
 bBJ
-aso
+xii
 gcy
 gcy
 bBJ
@@ -186630,8 +186661,8 @@ uVx
 uVx
 uVx
 joz
-cuX
-cuX
+wep
+wep
 hzI
 joz
 joz
@@ -186644,7 +186675,7 @@ uVx
 bBJ
 ymg
 gcy
-uaX
+gcy
 bBJ
 lnm
 lnm
@@ -186838,11 +186869,11 @@ cZU
 wBr
 ppU
 joz
-uVx
-uVx
-uVx
-uVx
-uVx
+joz
+cCV
+joz
+cCV
+joz
 bBJ
 bBJ
 iaw
@@ -187040,19 +187071,19 @@ cZU
 joz
 joz
 joz
-cCV
+hZf
+wxd
+hZf
+tRt
+hZf
 ufg
-bBJ
-bBJ
-bBJ
-ufg
-rqQ
+hPu
 mVU
 uFq
 vLA
 iKV
 rqQ
-rqQ
+hPu
 bBJ
 uVx
 uVx
@@ -187240,21 +187271,21 @@ cZU
 cZU
 cZU
 joz
+cZU
+gap
+gap
+gap
 gap
 gap
 gap
 bBJ
-xii
-gcy
-aKc
-bBJ
-rqQ
+hPu
 mVU
 uFq
 vLA
 rqQ
 rqQ
-rqQ
+hPu
 xuT
 uVx
 uVx
@@ -187445,18 +187476,18 @@ eIO
 cZU
 cZU
 cZU
-pJU
-gcy
-gcy
-gcy
+cZU
+cZU
+cZU
+cZU
 uaM
-rqQ
+hPu
 lPG
 jlM
 jlM
 rqQ
 rqQ
-rqQ
+hPu
 bBJ
 uVx
 uVx
@@ -187641,24 +187672,24 @@ uVx
 uVx
 joz
 iPg
-wep
+cZU
 cZU
 joz
-gap
+cZU
 jeb
 gap
+gap
+gap
+gap
+gap
 bBJ
-ymg
-uaX
-uaX
-bBJ
-bkU
-bkU
-bkU
-bkU
-bkU
-bkU
-bkU
+aso
+dZE
+uZt
+uZt
+uZt
+uZt
+wvz
 bBJ
 uVx
 uVx
@@ -187848,18 +187879,18 @@ cZU
 joz
 joz
 joz
-tKI
+hZf
+tRt
+hZf
+wxd
+hZf
 ufg
-bBJ
-bBJ
-bBJ
-ufg
-uFq
-uFq
-uFq
-uFq
-uFq
-uFq
+xqZ
+bkU
+bkU
+bkU
+bkU
+bkU
 fpc
 bBJ
 uVx
@@ -188049,12 +188080,12 @@ pRl
 cZU
 fBT
 eUt
-jeq
-uVx
-uVx
-uVx
-mPX
-uVx
+joz
+joz
+tKI
+joz
+tKI
+joz
 bBJ
 uFq
 uFq
@@ -188250,8 +188281,8 @@ joz
 joz
 joz
 joz
-jeq
-jeq
+joz
+joz
 uVx
 uVx
 uVx
@@ -227035,8 +227066,8 @@ tip
 tip
 lnm
 lnm
-uVx
-uVx
+rJx
+rJx
 uVx
 uVx
 uVx
@@ -227237,13 +227268,13 @@ tip
 tip
 lnm
 lnm
-uVx
-uVx
-uVx
-uVx
-uVx
-uVx
-uVx
+rJx
+rJx
+rJx
+rJx
+rJx
+rJx
+rJx
 tip
 tip
 tip
@@ -228449,13 +228480,13 @@ tip
 tip
 lnm
 lnm
-uVx
-uVx
-uVx
-uVx
-uVx
-uVx
-uVx
+aqG
+aqG
+aqG
+aqG
+aqG
+aqG
+aqG
 tip
 tip
 tip
@@ -228651,8 +228682,8 @@ tip
 tip
 lnm
 lnm
-uVx
-uVx
+aqG
+aqG
 uVx
 uVx
 uVx


### PR DESCRIPTION
## About The Pull Request

This PR changes a few things: 

Adds a fence with locked gates on the north and south entrances to the farm and butchery. What happens a lot of the time is people wander onto the farm uncontested to steal from the soilsons.

Extends the church kitchen by one tile to make it more visually appealing, adds an extra hearth for MAXIMUM SOUP GAMING and makes the floor slightly nicer to appease the brain worm that commands my attention.

Adds two half full composters round start. So Soilsons can actually plant stuff and not be forced to forage for like 20 minutes before they can grow grain.

This PR also expands the soilsons "kitchen" area to make it an actual kitchen. And gives the soilsons a millstone and an oven

I moved the toilet upstairs right next to the bedroom, and added a bin for a "bath"

I also added swing doors for all pens in the butchery, for ease of access to taking animals in and out.

![PR](https://github.com/user-attachments/assets/e1c8fa31-e53a-4eea-851a-247667e82571)

![kitchen](https://github.com/user-attachments/assets/92450307-35bc-481a-b01a-d5df3c4abf29)



## Why It's Good For The Game

These changes come from a feeling of necessity, we are starting to breach into 200+ players and if you are by yourself you are constantly having to contend with people wordlessly wandering onto the farm, stealing your carts, and wandering off, AND meeting produce demands. The gates make breaking onto the farm a conscious choice as you can still tree max climb onto the farm. If you manage to get in because the gates are unlocked that's a skill issue on the farmers part.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
