### PR TITLE
Adds keybinds for intent cycling and quick equipping

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -1748,6 +1748,24 @@
 				hud_used.rmb_intent.update_icon()
 				hud_used.rmb_intent.collapse_intents()
 
+/// Cycles through right-mouse-button intents. Loops.
+/mob/living/proc/cycle_rmb_intent()
+    if(!possible_rmb_intents?.len)
+        return
+
+    // Find the index of the current intent
+    var/index = possible_rmb_intents.Find(rmb_intent)
+
+    if(index == -1)
+        rmb_intent = possible_rmb_intents[1]
+    else
+        // Calculate the next index, wrapping around if at the end
+        index = (index % possible_rmb_intents.len) + 1
+        rmb_intent = possible_rmb_intents[index]
+
+    if(hud_used?.rmb_intent)
+        hud_used.rmb_intent.update_icon()
+        hud_used.rmb_intent.collapse_intents()
 
 /atom/movable/screen/time
 	name = "Sir Sun"

--- a/code/datums/keybinding/carbon.dm
+++ b/code/datums/keybinding/carbon.dm
@@ -159,56 +159,102 @@
 	C.mmb_intent_change(QINTENT_STEAL)
 	return TRUE
 
-/*
+//****** RMB Intents ******
 
-/datum/keybinding/carbon/select_help_intent
-	hotkey_keys = null
-	name = "select_help_intent"
-	full_name = "Select help intent"
-	description = ""
+/datum/keybinding/carbon/rmb_intent_1
+    hotkey_keys = list("Shift1")
+    name = "rmb_intent_1"
+    full_name = "Select Feint Intent"
+    description = "Selects the Feint RMB intent."
+    category = CATEGORY_CARBON
+
+/datum/keybinding/carbon/rmb_intent_1/down(client/user)
+    if (!iscarbon(user.mob))
+        return FALSE
+    var/mob/living/carbon/C = user.mob
+    C.swap_rmb_intent(null, 1)
+    return TRUE
+
+/datum/keybinding/carbon/rmb_intent_2
+    hotkey_keys = list("Shift2")
+    name = "rmb_intent_2"
+    full_name = "Select Aimed Intent"
+    description = "Selects the Aimed RMB intent."
+    category = CATEGORY_CARBON
+
+/datum/keybinding/carbon/rmb_intent_2/down(client/user)
+    if (!iscarbon(user.mob))
+        return FALSE
+    var/mob/living/carbon/C = user.mob
+    C.swap_rmb_intent(null, 2)
+    return TRUE
+
+/datum/keybinding/carbon/rmb_intent_3
+    hotkey_keys = list("Shift3")
+    name = "rmb_intent_3"
+    full_name = "Select Strong Intent"
+    description = "Selects the Strong RMB intent."
+    category = CATEGORY_CARBON
+
+/datum/keybinding/carbon/rmb_intent_3/down(client/user)
+    if (!iscarbon(user.mob))
+        return FALSE
+    var/mob/living/carbon/C = user.mob
+    C.swap_rmb_intent(null, 3)
+    return TRUE
+
+/datum/keybinding/carbon/rmb_intent_4
+    hotkey_keys = list("Shift4")
+    name = "rmb_intent_4"
+    full_name = "Select Swift Intent"
+    description = "Selects the Swift RMB intent."
+    category = CATEGORY_CARBON
+
+/datum/keybinding/carbon/rmb_intent_4/down(client/user)
+    if(!iscarbon(user.mob))
+        return FALSE
+    var/mob/living/carbon/C = user.mob
+    C.swap_rmb_intent(null, 4)
+    return TRUE
+
+/datum/keybinding/carbon/rmb_intent_5
+    hotkey_keys = list("Shift5")
+    name = "rmb_intent_5"
+    full_name = "Select Defend Intent"
+    description = "Selects the Defend RMB intent."
+    category = CATEGORY_CARBON
+
+/datum/keybinding/carbon/rmb_intent_5/down(client/user)
+    if(!iscarbon(user.mob))
+        return FALSE
+    var/mob/living/carbon/C = user.mob
+    C.swap_rmb_intent(null, 5)
+    return TRUE
+
+/datum/keybinding/carbon/rmb_intent_6
+    hotkey_keys = list("Shift6")
+    name = "rmb_intent_6"
+    full_name = "Select Weak Intent"
+    description = "Selects the Weak RMB intent."
+    category = CATEGORY_CARBON
+
+/datum/keybinding/carbon/rmb_intent_6/down(client/user)
+    if(!iscarbon(user.mob))
+        return FALSE
+    var/mob/living/carbon/C = user.mob
+    C.swap_rmb_intent(null, 6)
+    return TRUE
+
+/datum/keybinding/carbon/cycle_rmb_intent
+	hotkey_keys = list("N")
+	name = "cycle_rmb_intent"
+	full_name = "Cycle RMB Intent"
+	description = "Cycle through available Right Mouse Button (RMB) intents."
 	category = CATEGORY_CARBON
 
-/datum/keybinding/carbon/select_help_intent/down(client/user)
-	if(iscyborg(user.mob))
+/datum/keybinding/carbon/cycle_rmb_intent/down(client/user)
+	if(!iscarbon(user.mob))
 		return FALSE
-	user.mob?.a_intent_change(INTENT_HELP)
+	var/mob/living/carbon/C = user.mob
+	C.cycle_rmb_intent()
 	return TRUE
-
-
-/datum/keybinding/carbon/select_disarm_intent
-	hotkey_keys = null
-	name = "select_disarm_intent"
-	full_name = "Select disarm intent"
-	description = ""
-	category = CATEGORY_CARBON
-
-/datum/keybinding/carbon/select_disarm_intent/down(client/user)
-	user.mob?.a_intent_change(INTENT_DISARM)
-	return TRUE
-
-
-/datum/keybinding/carbon/select_grab_intent
-	hotkey_keys = null
-	name = "select_grab_intent"
-	full_name = "Select grab intent"
-	description = ""
-	category = CATEGORY_CARBON
-
-/datum/keybinding/carbon/select_grab_intent/down(client/user)
-	user.mob?.a_intent_change(INTENT_GRAB)
-	return TRUE
-
-
-/datum/keybinding/carbon/select_harm_intent
-	hotkey_keys = null
-	name = "select_harm_intent"
-	full_name = "Select harm intent"
-	description = ""
-	category = CATEGORY_CARBON
-
-/datum/keybinding/carbon/select_harm_intent/down(client/user)
-	if(iscyborg(user.mob))
-		return FALSE
-	user.mob?.a_intent_change(INTENT_HARM)
-	return TRUE
-*/

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -40,6 +40,39 @@
 	return TRUE
 */
 
+/datum/keybinding/human/quick_equipbelt
+	hotkey_keys = list("ShiftB")
+	name = "quick_equipbelt"
+	full_name = "Quick equip belt"
+	description = "Put held thing in belt or take out most recent thing from belt"
+
+/datum/keybinding/human/quick_equipbelt/down(client/user)
+	var/mob/living/carbon/human/H = user.mob
+	H.smart_equipbelt()
+	return TRUE
+
+/datum/keybinding/human/bag_equip_backl
+	hotkey_keys = list("ShiftQ")
+	name = "bag_equip_backl"
+	full_name = "Bag Equip Left"
+	description = "Put held item in the left backpack slot or take out the most recent item from the left backpack slot"
+
+/datum/keybinding/human/bag_equip_backl/down(client/user)
+	var/mob/living/carbon/human/H = user.mob
+	H.smart_equipbag(SLOT_BACK_R) // They're reversed to match the UI.
+	return TRUE
+
+/datum/keybinding/human/bag_equip_backr
+	hotkey_keys = list("ShiftE")
+	name = "bag_equip_backr"
+	full_name = "Bag Equip Right"
+	description = "Put held item in the right backpack slot or take out the most recent item from the right backpack slot"
+
+/datum/keybinding/human/bag_equip_backr/down(client/user)
+	var/mob/living/carbon/human/H = user.mob
+	H.smart_equipbag(SLOT_BACK_L) // They're reversed to match the UI.
+	return TRUE
+
 /datum/keybinding/human/fixeye
 	hotkey_keys = list("F")
 	name = "fix_eye"

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -395,16 +395,17 @@
 	for(var/obj/item/I in held_items)
 		qdel(I)
 
-/mob/living/carbon/human/proc/smart_equipbag() // take most recent item out of bag or place held item in bag
+/// Smartly equips / takes an item out / puts it in the left back slot or the right.
+/mob/living/carbon/human/proc/smart_equipbag(slot = SLOT_BACK_L) // take most recent item out of bag or place held item in bag
 	if(incapacitated())
 		return
 	var/obj/item/thing = get_active_held_item()
-	var/obj/item/equipped_back = get_item_by_slot(SLOT_BACK)
+	var/obj/item/equipped_back = get_item_by_slot(slot)
 	if(!equipped_back) // We also let you equip a backpack like this
 		if(!thing)
 			to_chat(src, "<span class='warning'>I have no backpack to take something out of!</span>")
 			return
-		if(equip_to_slot_if_possible(thing, SLOT_BACK))
+		if(equip_to_slot_if_possible(thing, slot))
 			update_inv_hands()
 		return
 	if(!SEND_SIGNAL(equipped_back, COMSIG_CONTAINS_STORAGE)) // not a storage item


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

Adds keybindings for the following intents: SHIFT + (1 - 6)
- Feint shift1
- Aimed shift2
- Strong shift3
- Swift shift4
- Defend shift5
- Weak shift6

Adds keybindings to quick equip to the back slots and belt.

Adds a keybind to cycle through intents.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game

Quality of life.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
