### PR TITLE
Fixes giant ERROR from drug use (Includes overhaul of pipes/cigarettes)

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -21,29 +21,31 @@
 			M.emote(pick("twitch_s","giggle"))
 		else
 			M.emote(pick("twitch_s","chuckle"))
-	M.apply_status_effect(/datum/status_effect/buff/weed)
 	if(M.has_flaw(/datum/charflaw/addiction/smoker))
 		M.sate_addiction()
 	..()
 
+/datum/reagent/drug/space_drugs/on_mob_metabolize(mob/living/M)
+	..()
+	M.set_drugginess(30)
+	M.apply_status_effect(/datum/status_effect/buff/weed)
+	M.overlay_fullscreen("weedsm", /atom/movable/screen/fullscreen/weedsm)
+	M.update_body_parts_head_only()
+
+/*
+	if(M.client)
+		SSdroning.area_entered(get_area(M), M.client)
+*/
+
 /datum/reagent/drug/space_drugs/on_mob_end_metabolize(mob/living/M)
+	M.set_drugginess(0)
 	M.clear_fullscreen("weedsm")
+	M.remove_status_effect(/datum/status_effect/buff/weed)
 	M.update_body_parts_head_only()
 
 /*
 	if(M.client)
 		SSdroning.play_area_sound(get_area(M), M.client)
-*/
-
-/datum/reagent/drug/space_drugs/on_mob_metabolize(mob/living/M)
-	..()
-	M.set_drugginess(30)
-	M.update_body_parts_head_only()
-	M.overlay_fullscreen("weedsm", /atom/movable/screen/fullscreen/weedsm)
-
-/*
-	if(M.client)
-		SSdroning.area_entered(get_area(M), M.client)
 */
 
 /atom/movable/screen/fullscreen/weedsm

--- a/code/modules/reagents/reagent_containers/powderspice.dm
+++ b/code/modules/reagents/reagent_containers/powderspice.dm
@@ -43,7 +43,6 @@
 			M.emote(pick("twitch_s","chuckle"))
 	if(M.has_flaw(/datum/charflaw/addiction/junkie))
 		M.sate_addiction()
-	M.apply_status_effect(/datum/status_effect/buff/druqks)
 	..()
 
 /atom/movable/screen/fullscreen/druqks
@@ -63,20 +62,23 @@
 /datum/reagent/druqks/on_mob_metabolize(mob/living/M)
 	M.overlay_fullscreen("druqk", /atom/movable/screen/fullscreen/druqks)
 	M.set_drugginess(30)
-	M.update_body_parts_head_only()
+	M.apply_status_effect(/datum/status_effect/buff/druqks)
 	if(M.client)
 		ADD_TRAIT(M, TRAIT_DRUQK, "based")
 		SSdroning.area_entered(get_area(M), M.client)
+	M.update_body_parts_head_only()
 //			if(M.client.screen && M.client.screen.len)
 //				var/atom/movable/screen/plane_master/game_world/PM = locate(/atom/movable/screen/plane_master/game_world) in M.client.screen
 //				PM.backdrop(M.client.mob)
 
 /datum/reagent/druqks/on_mob_end_metabolize(mob/living/M)
 	M.clear_fullscreen("druqk")
-	M.update_body_parts_head_only()
+	M.set_drugginess(0)
+	M.remove_status_effect(/datum/status_effect/buff/druqks)
 	if(M.client)
 		REMOVE_TRAIT(M, TRAIT_DRUQK, "based")
 		SSdroning.play_area_sound(get_area(M), M.client)
+	M.update_body_parts_head_only()
 //		if(M.client.screen && M.client.screen.len)
 ///			var/atom/movable/screen/plane_master/game_world/PM = locate(/atom/movable/screen/plane_master/game_world) in M.client.screen
 //			PM.backdrop(M.client.mob)

--- a/code/modules/reagents/reagent_containers/powderspice.dm
+++ b/code/modules/reagents/reagent_containers/powderspice.dm
@@ -36,6 +36,7 @@
 
 /datum/reagent/druqks/on_mob_life(mob/living/carbon/M)
 	M.set_drugginess(30)
+	M.apply_status_effect(/datum/status_effect/buff/druqks)
 	if(prob(5))
 		if(M.gender == FEMALE)
 			M.emote(pick("twitch_s","giggle"))
@@ -62,7 +63,6 @@
 /datum/reagent/druqks/on_mob_metabolize(mob/living/M)
 	M.overlay_fullscreen("druqk", /atom/movable/screen/fullscreen/druqks)
 	M.set_drugginess(30)
-	M.apply_status_effect(/datum/status_effect/buff/druqks)
 	if(M.client)
 		ADD_TRAIT(M, TRAIT_DRUQK, "based")
 		SSdroning.area_entered(get_area(M), M.client)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
- Fixes giant ERROR from drug use (was caused by overlay spam)
- Spice (druqks) and Swampweed (space drugs) slightly altered to fix overlay spam behavior.
- Overhauls cigarettes and pipes.
- Cigarettes and pipes now slowly add reagents to your bloodstream, slightly faster than their depletion rate. They burn as long as the longest lasting reagent in them. By the end of the cigarette/pipe, you should still have a bit of the reagent left over in you.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
Giant ERROR breaks immersion
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

More info:
Found the error from overlay spam:
![image](https://github.com/user-attachments/assets/f0ebdd17-a00f-4ead-8d60-1b280085980d)
Realized pipes and cigarettes were broken as shit, overhauled them.
## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
