### PR TITLE
(MIGRANT) Adds "Deprived" - filler migrant role.

### DIFF
--- a/code/datums/migrants/waves/deprived.dm
+++ b/code/datums/migrants/waves/deprived.dm
@@ -23,6 +23,7 @@
 	if(H.mind)
 		H.mind?.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/axesmaces, 2, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
@@ -33,7 +34,7 @@
 		H.mind?.adjust_skillrank(/datum/skill/craft/tanning, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/sewing, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
-		H.mind?.adjust_skillrank(/datum/skill/labor/fishing, 4, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/labor/fishing, 2, TRUE)
 		H.change_stat("speed", -2)
 	ADD_TRAIT(H, TRAIT_CRITICAL_RESISTANCE, TRAIT_GENERIC) // wouldn't include this normally, but due to heart-bleeding, it's required :/
 	H.cmode_music = 'sound/music/cmode/towner/CombatPrisoner.ogg'

--- a/code/datums/migrants/waves/deprived.dm
+++ b/code/datums/migrants/waves/deprived.dm
@@ -1,0 +1,51 @@
+/datum/migrant_role/deprived
+	name = "Deprived" // challenge run
+	greet_text = "You were once a highwayman, a monster of the road - but you have since ditched your sinful ways, leaving society behind in wake of your regrets. Nothing erases the past, and you can find absolution only in the catharsis of death. Let the wildlife shepherd your soul to Necra."
+	outfit = /datum/outfit/job/roguetown/deprived
+	allowed_races = list(
+		"Humen",
+		"Elf",
+		"Half-Elf",
+		"Dwarf",
+		"Tiefling",
+		"Dark Elf",
+		"Aasimar")
+	grant_lit_torch = TRUE
+
+/datum/outfit/job/roguetown/deprived/pre_equip(mob/living/carbon/human/H)
+	..()
+	head = /obj/item/clothing/head/roguetown/menacing
+	pants = /obj/item/clothing/under/roguetown/trou
+	shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
+	belt = /obj/item/storage/belt/rogue/leather/rope
+	beltl = /obj/item/rogueweapon/knife/villager
+
+	if(H.mind)
+		H.mind?.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/axesmaces, 3, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/bows, 2, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/craft/tanning, 2, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/misc/sewing, 2, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
+		H.change_stat("strength", 1)
+		H.change_stat("constitution", 1)
+		H.change_stat("endurance", 1)
+		H.change_stat("speed", -1)
+	ADD_TRAIT(H, TRAIT_CRITICAL_RESISTANCE, TRAIT_GENERIC) // wouldn't include this normally, but due to heart-bleeding, it's required :/
+	H.cmode_music = 'sound/music/cmode/towner/CombatPrisoner.ogg'
+
+/datum/migrant_wave/deprived
+	name = "The Deprived"
+	max_spawns = 1
+	shared_wave_type = /datum/migrant_wave/deprived
+	weight = 8
+	roles = list(
+		/datum/migrant_role/deprived = 1,
+	)
+	greet_text = "Absolve yourself of sin, cast yourself away from society, and leave the travelers to their toils. Death and isolation grants you absolution."

--- a/code/datums/migrants/waves/deprived.dm
+++ b/code/datums/migrants/waves/deprived.dm
@@ -18,11 +18,11 @@
 	pants = /obj/item/clothing/under/roguetown/trou
 	shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
 	belt = /obj/item/storage/belt/rogue/leather/rope
-	beltl = /obj/item/rogueweapon/knife/villager
+	beltl = /obj/item/rogueweapon/knife/villager // won't be able to light a torch without this, bare minimum
 
 	if(H.mind)
 		H.mind?.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
-		H.mind?.adjust_skillrank(/datum/skill/combat/axesmaces, 3, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/axesmaces, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
@@ -33,10 +33,8 @@
 		H.mind?.adjust_skillrank(/datum/skill/craft/tanning, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/sewing, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
-		H.change_stat("strength", 1)
-		H.change_stat("constitution", 1)
-		H.change_stat("endurance", 1)
-		H.change_stat("speed", -1)
+		H.mind?.adjust_skillrank(/datum/skill/labor/fishing, 4, TRUE)
+		H.change_stat("speed", -2)
 	ADD_TRAIT(H, TRAIT_CRITICAL_RESISTANCE, TRAIT_GENERIC) // wouldn't include this normally, but due to heart-bleeding, it's required :/
 	H.cmode_music = 'sound/music/cmode/towner/CombatPrisoner.ogg'
 

--- a/stonekeep.dme
+++ b/stonekeep.dme
@@ -618,6 +618,7 @@
 #include "code\datums\migrants\migrant_wave.dm"
 #include "code\datums\migrants\waves\crusader_wave.dm"
 #include "code\datums\migrants\waves\dark_itinerant_knight_wave.dm"
+#include "code\datums\migrants\waves\deprived.dm"
 #include "code\datums\migrants\waves\dwarven_company.dm"
 #include "code\datums\migrants\waves\follower_of_the_tens.dm"
 #include "code\datums\migrants\waves\grenzelhoft_wave.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

Adds the 'Deprived', a migrant roll with average combat skills, skills for living in the wild, no armor, critical resistance, and terrible speed. Spawns with a sack hood, a knife, pants, a belt, and shoes. A challenge run, all things considered. Essentially a nerfed Barbarian with better utility stats.

## Why It's Good For The Game

New filler shit for the Migrant system is good, as it makes people spend more time rolling for the "good" stuff - seeing zybantine, rockhill, and heartfelt nobles all in the same round trying to talk to the king is a problem. One way to fix it is to nerf the occurrence, the other is to add more variation to the system - both is preferable, but I can't balance for shit.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
