### PR TITLE
Old blacksmiths now get some extra skills

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/blacksmith.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/blacksmith.dm
@@ -53,6 +53,11 @@
 		H.mind?.adjust_skillrank(/datum/skill/craft/smelting, 3, TRUE)
 		if(prob(50))
 			H.mind?.adjust_skillrank(/datum/skill/craft/carpentry, 1, TRUE)
+		if(H.age == AGE_OLD) //Oldness points are a bit different here, you get a pool of 1-3 points that are assigned randomly to the smithing stats since you're not a specialist
+			var/oldnesspoints = rand(1,3)
+			for(var/i=1, i<oldnesspoints, i++)
+				var/datum/skill/craft/skillpicked = pick(/datum/skill/craft/weaponsmithing, /datum/skill/craft/armorsmithing, /datum/skill/craft/blacksmithing)
+				H.mind?.adjust_skillrank(skillpicked, 1, TRUE)
 		H.change_stat("strength", 1)
 		H.change_stat("endurance", 1)
 		H.change_stat("constitution", 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

Blacksmiths who have the age category Old now get between 1-3 bonus skill points, divided randomly between Blacksmithing, Armorsmithing, and Weaponsmithing

## Why It's Good For The Game

Old characters generally get some bonus skills, including the Master Blacksmith and the two townie smithing classes, but the Blacksmith doesn't. This gives them a slightly smaller potential pool than townie smiths (they get 2-4 points extra) but still helps compensate for their stat penalties and lower XP rate.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
