### PR TITLE
Fixes the metalizer's interaction with lockable doors

### DIFF
--- a/code/modules/roguetown/roguejobs/artifcier/contraption.dm
+++ b/code/modules/roguetown/roguejobs/artifcier/contraption.dm
@@ -142,6 +142,8 @@
 		new_door.locked = I.locked
 		if(I.lockid)
 			new_door.lockid = I.lockid
+		if(I.lockhash)
+			new_door.lockhash = I.lockhash
 		qdel(I)
 	else
 		var/obj/I = O


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

Metalizer is supposed to allow the same key to work on a lockable door after it's been metalized, but it didn't because it only copied LockID, which did nothing. Lockhash is what's actually used after initializing

## Why It's Good For The Game

Bugs should be fixed 

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
