### PR TITLE
Orphans no longer have a 15% change to spawn with rings.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/youngfolk/orphan.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/orphan.dm
@@ -43,10 +43,6 @@
 	if(prob(30))
 		head = pick(/obj/item/clothing/head/roguetown/knitcap, /obj/item/clothing/head/roguetown/bardhat, /obj/item/clothing/head/roguetown/courtierhat, /obj/item/clothing/head/roguetown/fancyhat)
 	if(prob(15))
-		id = pick(typesof(/obj/item/clothing/ring/silver, /obj/item/clothing/ring/gold))
-		if(prob(50))
-			H.STASTR = H.STASTR + roll(1,4) // "He whom holds the ring has the power."
-	if(prob(15))
 		r_hand = pick(/obj/item/rogue/instrument/lute, /obj/item/rogue/instrument/accord, /obj/item/rogue/instrument/guitar, /obj/item/rogue/instrument/flute, /obj/item/rogue/instrument/hurdygurdy, /obj/item/rogue/instrument/viola)
 		if(H.mind)
 			H.mind.adjust_skillrank(/datum/skill/misc/music, pick(2,3,4), TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
Orphans can no longer spawn with a ring rarely,

## Why It's Good For The Game
I thought that the magic rings were thier own subtype of ring, they were not.

Ook requested it be so.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
