### PR TITLE
Invisibility is now a status effect, replacing MT_INVISIBILITY

### DIFF
--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,5 +1,3 @@
-#define LOWMEMORYMODE
-
 #ifndef LOWMEMORYMODE
 	#include "map_files\generic\CentCom.dmm"
 	#ifdef ALL_MAPS

--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,3 +1,5 @@
+#define LOWMEMORYMODE
+
 #ifndef LOWMEMORYMODE
 	#include "map_files\generic\CentCom.dmm"
 	#ifdef ALL_MAPS

--- a/code/__DEFINES/mob_timers.dm
+++ b/code/__DEFINES/mob_timers.dm
@@ -1,4 +1,3 @@
 #define MT_MADELOVE "1"
 #define MT_PSYPRAY "2"
 #define MT_FOUNDSNEAK "3"
-#define MT_INVISIBILITY "4"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -322,6 +322,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 ///trait determines if this mob can breed given by /datum/component/breeding
 #define TRAIT_MOB_BREEDER "mob_breeder"
 #define TRAIT_UNTARGETTABLE "untargettable" //can't be targetted by basic mobs
+#define TRAIT_IMPERCEPTIBLE "imperceptible" //! can't be percieved in any way
 
 //bodypart traits
 #define TRAIT_PARALYSIS	"paralysis" //Used for limb-based paralysis and full body paralysis

--- a/code/datums/ai/targetting_datum/simpe_targetting_datum.dm
+++ b/code/datums/ai/targetting_datum/simpe_targetting_datum.dm
@@ -22,12 +22,12 @@
 		var/mob/M = the_target
 		if(M.status_flags & GODMODE)
 			return FALSE
-		if(M.mob_timers[MT_INVISIBILITY] > world.time) // Check if the mob is affected by the invisibility spell
-			return FALSE
 
 	if(living_mob.see_invisible < the_target.invisibility)//Target's invisible to us, forget it
 		return FALSE
 
+	if(HAS_TRAIT(the_target, TRAIT_IMPERCEPTIBLE))
+		return FALSE
 	if(HAS_TRAIT(the_target, TRAIT_UNTARGETTABLE))
 		return FALSE
 

--- a/code/datums/status_effects/buffs/invisibility.dm
+++ b/code/datums/status_effects/buffs/invisibility.dm
@@ -1,3 +1,9 @@
+/*
+ * Handles traditional invisibility given from spells or potions.
+ * We don't use mob.invisibility here on purpose,
+ * because it risks being overridden by other systems.
+ */
+
 /datum/status_effect/invisibility
 	id = "invisibility"
 	status_type = STATUS_EFFECT_REFRESH
@@ -13,8 +19,11 @@
 /datum/status_effect/invisibility/on_apply()
 	. = ..()
 	ADD_TRAIT(owner, TRAIT_IMPERCEPTIBLE, id)
+
+	// don't show a message to other people if we're sneaking
+	var/viewing_message = owner.rogue_sneaking ? null : span_warning("[owner] fades into nothing!")
 	owner.visible_message( \
-		span_warning("[owner] fades into nothing!"), \
+		viewing_message, \
 		span_notice("My form fades away.") \
 	)
 	animate(owner, alpha = 0, time = 1 SECONDS, easing = EASE_IN)

--- a/code/datums/status_effects/buffs/invisibility.dm
+++ b/code/datums/status_effects/buffs/invisibility.dm
@@ -1,0 +1,44 @@
+/datum/status_effect/invisibility
+	id = "invisibility"
+	status_type = STATUS_EFFECT_REFRESH
+	duration = 30 SECONDS
+	on_remove_on_mob_delete = TRUE
+	alert_type = /atom/movable/screen/alert/status_effect/invisible
+
+/datum/status_effect/invisibility/on_creation(mob/living/new_owner, new_duration)
+	if(isnum(new_duration) && (new_duration != duration))
+		duration = new_duration
+	return ..()
+
+/datum/status_effect/invisibility/on_apply()
+	. = ..()
+	ADD_TRAIT(owner, TRAIT_IMPERCEPTIBLE, id)
+	owner.visible_message( \
+		span_warning("[owner] fades into nothing!"), \
+		span_notice("My form fades away.") \
+	)
+	animate(owner, alpha = 0, time = 1 SECONDS, easing = EASE_IN)
+
+/datum/status_effect/invisibility/on_remove()
+	if(QDELETED(owner))
+		return
+
+	. = ..()
+	REMOVE_TRAIT(owner, TRAIT_IMPERCEPTIBLE, id)
+
+	owner.update_sneak_invis()
+	if(owner.rogue_sneaking)
+		to_chat(owner, span_notice("I blend into the shadows as my form reveals itself. I remain hidden."))
+	else
+		owner.visible_message( \
+			span_warning("[owner] appears from nothing!"), \
+			span_warning("I become visible again.") \
+		)
+
+/* ------------------- */
+
+/atom/movable/screen/alert/status_effect/invisible
+	name = "Invisible"
+	desc = span_info("My form bends the light around me, \
+		making me imperceptible to all but the most astute observers.")
+	icon_state = "buff" //pick an empty one on purpose, cause we're invisible

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -402,7 +402,7 @@
 	probby += extra_prob
 	var/sneak_bonus = 0
 	if(target.mind)
-		if (world.time < target.mob_timers[MT_INVISIBILITY])
+		if(target.has_status_effect(/datum/status_effect/invisibility))
 			// we're invisible as per the spell effect, so use the highest of our arcane magic (or holy) skill instead of our sneaking
 			sneak_bonus = (max(target.mind?.get_skill_level(/datum/skill/magic/arcane), target.mind?.get_skill_level(/datum/skill/magic/holy)) * 10)
 			probby -= 20 // also just a fat lump of extra difficulty for the npc since spells are hard, you know?

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1695,7 +1695,7 @@
 				continue
 			if(see_invisible < M.invisibility)
 				continue
-			if(M.mob_timers[MT_INVISIBILITY] > world.time) // Check if the mob is affected by the invisibility spell
+			if(HAS_TRAIT(M, TRAIT_IMPERCEPTIBLE)) // Check if the mob is affected by the invisibility spell
 				continue
 			var/probby = 3 * STAPER
 			if(M.mind)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -586,7 +586,7 @@
 
 //* Updates a mob's sneaking status, rendering them invisible or visible in accordance to their status. TODO:Fix people bypassing the sneak fade by turning, and add a proc var to have a timer after resetting visibility.
 /mob/living/update_sneak_invis(reset = FALSE) //Why isn't this in mob/living/living_movements.dm? Why, I'm glad you asked!
-	if(!reset && world.time < mob_timers[MT_INVISIBILITY]) // Check if the mob is affected by the invisibility spell
+	if(!reset && HAS_TRAIT(src, TRAIT_IMPERCEPTIBLE)) // Check if the mob is affected by the invisibility spell
 		rogue_sneaking = TRUE
 		return
 	var/turf/T = get_turf(src)

--- a/code/modules/spells/roguetown/acolyte/noc.dm
+++ b/code/modules/spells/roguetown/acolyte/noc.dm
@@ -49,11 +49,7 @@
 		var/mob/living/target = targets[1]
 		if(target.anti_magic_check(TRUE, TRUE))
 			return FALSE
-		target.visible_message("<span class='warning'>[target] starts to fade into thin air!</span>", "<span class='notice'>You start to become invisible!</span>")
-		animate(target, alpha = 0, time = 1 SECONDS, easing = EASE_IN)
-		target.mob_timers[MT_INVISIBILITY] = world.time + 30 SECONDS
-		addtimer(CALLBACK(target, TYPE_PROC_REF(/mob/living, update_sneak_invis), TRUE), 30 SECONDS)
-		addtimer(CALLBACK(target, TYPE_PROC_REF(/atom/movable, visible_message), span_warning("[target] fades back into view."), span_warning("You become visible again!")), 15 SECONDS)
+		target.apply_status_effect(/datum/status_effect/invisibility, 30 SECONDS)
 		return ..()
 	return FALSE
 

--- a/stonekeep.dme
+++ b/stonekeep.dme
@@ -676,6 +676,7 @@
 #include "code\datums\status_effects\gas.dm"
 #include "code\datums\status_effects\neutral.dm"
 #include "code\datums\status_effects\status_effect.dm"
+#include "code\datums\status_effects\buffs\invisibility.dm"
 #include "code\datums\status_effects\debuffs\silenced.dm"
 #include "code\datums\status_effects\debuffs\traps.dm"
 #include "code\datums\status_effects\rogue\alerts.dm"


### PR DESCRIPTION
## About The Pull Request

Converts Noc's invisibility spell behaviour into an "invisibility" status effect which applies a trait, `TRAIT_IMPERCEPTIBLE`
All usages of MT_INVISIBILITY have been replaced by this trait

### Minor QOL
Fading out of invisibility while sneaking will let you know that you stayed hidden.
<details>

https://github.com/user-attachments/assets/bd47d15f-d799-4a7c-b0bd-f272efb2150f

</details>

## Why It's Good For The Game

Mob timers bad. We should stop using mob timers.
Mobs shouldn't handle absolutely everything.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.