### PR TITLE
Shillelagh craftable, and changes its intent!

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -321,7 +321,7 @@
 
 //................ Shillelagh ............... //
 /obj/item/rogueweapon/mace/goden/shillelagh		// The Briar signature weapon. Sturdy oak war club.
-	gripped_intents = list(/datum/intent/mace/smash/heavy)
+	gripped_intents = list(/datum/intent/mace/smash/wood)
 	name = "shillelagh"
 	desc = "Big old oak branch, carved to a deadly weapon."
 	icon_state = "shillelagh"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/briar.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/briar.dm
@@ -45,6 +45,7 @@
 		H.mind?.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)
+		H.mind.teach_crafting_recipe(/datum/crafting_recipe/dendor/shillelagh)
 
 		if(H.age == AGE_OLD)
 			H.mind?.adjust_skillrank(/datum/skill/magic/holy, 1, TRUE)
@@ -93,6 +94,14 @@
 	verbage = "consecrate"
 	verbage_tp = "consecrates"
 	craftsound = 'sound/foley/Building-01.ogg'
+
+/datum/crafting_recipe/dendor/shillelagh
+	name = "Shillelagh (unique)"
+	result = /obj/item/rogueweapon/mace/goden/shillelagh
+	reqs = list(/obj/item/grown/log/tree/small = 1,
+				/obj/item/ash = 1,
+				/obj/item/reagent_containers/food/snacks/fat =1 )
+	craftdiff = 2
 
 /datum/crafting_recipe/dendor/shrine/saiga
 	name = "stinging shrine to Dendor (unique)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
makes shillelaghs craft-able, but only by briars

now also has a change in the intent to make it a bit less punishing to use in combat. Now uses /smash/wood instead of smash/heavy
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
replace the weapon that you broke! and letting you craft it, i don't really see how this is bad?

for the balance side this is better to be less punishing if its the only weapon you use, from my experience if you miss a few times your sentenced to death
## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->