### PR TITLE
Speech Fomatting (PORT)

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -98,6 +98,9 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	if(!message || message == "")
 		return
 
+	//allow player to format their speech
+	message = replacetextEx(message, regex(@"^([/+]*)(.*?)([/+]*)$"), /proc/format_dialogue)
+
 	if(ic_blocked)
 		//The filter warning message shows the sanitized message though.
 		to_chat(src, "<span class='warning'>That message contained a word prohibited in IC chat! Consider reviewing the server rules.\n<span replaceRegex='show_filtered_ic_chat'>\"[message]\"</span></span>")
@@ -489,3 +492,45 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			return .
 
 	. = ..()
+
+
+/*
+	If a player types "//bold text//" into the chat then this proc recieves the following parameters due to regex:
+		group1 - "//"
+		group2 - "bold text"
+		group3 - "//"
+	The automatical capitalization and punctuation procs are then applied to group2, which then becomes:
+		"Bold text."
+	group2 is then recombined with group1 and group3 (if they exist) and stored in message:
+		"//Bold text.//"
+	Before being returned, this message is then passed through yet another regex replace proc and the slashes are converted to their correct tags:
+		return "<b>Bold text.</b>"
+	If the player only inputted slashes (e.g. "////////") the proc immediately returns null, and no chat message appears.
+*/
+/proc/format_dialogue(match, group1, group2, group3)
+	if (!group2)
+		return
+	var/message = capitalize(group2)
+	message = autopunct_bare(message)
+	if (group1)
+		message = group1 + message
+	if (group3)
+		message = message + group3
+	message = replacetextEx(message, regex(@"(///([^/]+?)///)|(//([^/]+?)//)|(/([^/]+?)/)", "g"), /proc/format_dialogue_html)
+	message = replacetextEx(message, regex(@"(\+([^+]+?)\+)", "g"), /proc/format_dialogue_html_2)
+	return message
+
+//replace designated player formatting characters with their corresponding html tags
+/proc/format_dialogue_html(match, group1, group2, group3, group4, group5, group6)
+	if (group5)
+		return "<i>" + group6 + "</i>"
+	else if (group3)
+		return "<b>" + group4 + "</b>"
+	else if (group1)
+		return "<i><b>" + group2 + "</b></i>"
+	return match
+/proc/format_dialogue_html_2(match, group1, group2)
+	if (group1)
+		return "<b>" + group2 + "</b>"
+	return match
+

--- a/modular/modular_azure/code/autopunctuation.dm
+++ b/modular/modular_azure/code/autopunctuation.dm
@@ -1,0 +1,15 @@
+//Does the line end in any EOL char that isn't appropriate punctuation OR does it end in a chat-formatted markdown sequence (+bold+, etc) without a period?
+GLOBAL_DATUM_INIT(needs_eol_autopunctuation, /regex, regex(@"([a-zA-Z\d\u0400-\u04FF]|[^.?!~-][+|_])$"))
+
+//All non-capitalized 'i' surrounded with whitespace (aka, 'hello >i< am a cat')
+GLOBAL_DATUM_INIT(noncapital_i, /regex, regex(@"\b[i]\b", "g"))
+
+/// Ensures sentences end in appropriate punctuation (a period if none exist) and that all whitespace-bounded 'i' characters are capitalized.
+/// If the sentence ends in chat-flavored markdown for bolds, italics or underscores and does not have a preceding period, exclamation mark or other flavored sentence terminator, add a period.
+/// (e.g: 'Borgs are rogue' becomes 'Borgs are rogue.', '+BORGS ARE ROGUE+ becomes '+BORGS ARE ROGUE+.', '+Borgs are rogue~+' is untouched.)
+/proc/autopunct_bare(input_text)
+	if (findtext(input_text, GLOB.needs_eol_autopunctuation))
+		input_text += "."
+
+	input_text = replacetext(input_text, GLOB.noncapital_i, "I")
+	return input_text

--- a/stonekeep.dme
+++ b/stonekeep.dme
@@ -1878,6 +1878,7 @@
 #include "modular\Barding\code\music_effect.dm"
 #include "modular\Mapping\Mapping_aides.dm"
 #include "modular\Mapping\hammer\hammer_mapping_helpers.dm"
+#include "modular\modular_azure\code\autopunctuation.dm"
 #include "modular\modular_azure\code\necra.dm"
 #include "modular\modular_azure\code\wizard.dm"
 #include "modular\modular_hearthstone\code\interface\LOOC.dm"


### PR DESCRIPTION
## About The Pull Request

Ports the Formatting from https://github.com/sylphynford/Penumbra/pull/110/files
Looks like this
![emphasis](https://github.com/user-attachments/assets/772a10a2-50cd-466a-a003-ce8416a9d48e)

So / word / for cursive, //other// for thick
Also reminder you can sing by putting % in front of words, for all the bards.

The Blackstone branch refactored their speech code somewhat at some point, possibly worth considering adopting the whole thing, then again maybe not. This works independently at least. Had to include the autopunctuation from Azure to keep it consistent, works too.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
