### PR TITLE
(BALANCE/FIX) Rakshari Cat Fall

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -211,7 +211,7 @@
 	if(isliving(A))
 		var/mob/living/O = A
 		var/dex_save = O.mind?.get_skill_level(/datum/skill/misc/climbing)
-		if(dex_save >= 5 || HAS_TRAIT(O, TRAIT_NOFALLDAMAGE1))
+		if(dex_save >= 5 || HAS_TRAIT(O, TRAIT_NOFALLDAMAGE1) || HAS_TRAIT(O, TRAIT_NOFALLDAMAGE2))
 			if(O.m_intent != MOVE_INTENT_SNEAK) // If we're sneaking, don't show a message to anybody, shhh!
 				O.visible_message("<span class='danger'>[A] gracefully lands on top of [src]!</span>")
 		else

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -211,7 +211,7 @@
 	if(isliving(A))
 		var/mob/living/O = A
 		var/dex_save = O.mind?.get_skill_level(/datum/skill/misc/climbing)
-		if(dex_save >= 5)
+		if(dex_save >= 5 || HAS_TRAIT(O, TRAIT_NOFALLDAMAGE1))
 			if(O.m_intent != MOVE_INTENT_SNEAK) // If we're sneaking, don't show a message to anybody, shhh!
 				O.visible_message("<span class='danger'>[A] gracefully lands on top of [src]!</span>")
 		else

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/rakshari/_rakshari.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/rakshari/_rakshari.dm
@@ -31,7 +31,7 @@
 	custom_clothes = FALSE
 	possible_ages = list(AGE_CHILD, AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
 	species_traits = list(EYECOLOR,OLDGREY)
-	inherent_traits = list(TRAIT_NOMOBSWAP)
+	inherent_traits = list(TRAIT_NOMOBSWAP, TRAIT_NOFALLDAMAGE1)
 
 	offset_features = list(OFFSET_ID = list(0,0), OFFSET_GLOVES = list(0,0), OFFSET_WRISTS = list(0,0),\
 	OFFSET_CLOAK = list(0,0), OFFSET_FACEMASK = list(0,0), OFFSET_HEAD = list(0,0), \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->
It adds the NOFALLDAMAGE1 trait to Rakshari, making them able to fall through one Zlevel and not be paincritted instantly.
It also fixes the falling logic to also check for traits like Nofalldamage1 or nofalldamage2 (currently unused), so it doesn't say "crashes into the floor" when falling down with a buff like featherfall.
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This change makes it so Rakshari have an unique advantage to other races, being able to run away via jumping off rooftops or onto sewers will make them harder to catch.
It will not affect classes that already start with Master Climbing, like Thieves, as those classes are already immune to falling down 1 zlevel.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
