### PR TITLE
Wrong sign buddy

### DIFF
--- a/_maps/map_files/roguetown/roguetown.dmm
+++ b/_maps/map_files/roguetown/roguetown.dmm
@@ -10390,7 +10390,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "lxr" = (
-/obj/structure/fluff/walldeco/sign/trophy{
+/obj/structure/fluff/walldeco/feldshersign{
 	desc = "A somewhat unfitting sign for a physician's office.";
 	name = "Medicae Office";
 	pixel_y = -32

--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -21190,7 +21190,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "psB" = (
-/obj/structure/fluff/walldeco/sign/trophy{
+/obj/structure/fluff/walldeco/feldshersign{
 	desc = "A somewhat unfitting sign for a physician's office.";
 	name = "Medicae Office"
 	},
@@ -28070,7 +28070,7 @@
 	},
 /area/rogue/outdoors/town/roofs)
 "unF" = (
-/obj/structure/fluff/walldeco/sign/trophy{
+/obj/structure/fluff/walldeco/feldshersign{
 	desc = "A somewhat unfitting sign for a physician's office.";
 	name = "Medicae Office"
 	},


### PR DESCRIPTION
## About The Pull Request

For some unexplicable reason the saiga trophy made for the drunken saiga inn decoration set is used as a medicus sign.
There exists a sign with medical theme with snake etc, replaced the stolen saiga sign with their own.

The Broken Skull inn signs used in the Drunken inn is also wrong technically but isn´t as annoying to me since I had nothing to do with that inn.


