### PR TITLE
Give z-jump to troupe jesters

### DIFF
--- a/code/datums/migrants/waves/jestertroupe.dm
+++ b/code/datums/migrants/waves/jestertroupe.dm
@@ -46,6 +46,7 @@
 		H.change_stat("speed", 1)
 	H.verbs |= /mob/living/carbon/human/proc/ventriloquate
 	ADD_TRAIT(H, TRAIT_EMPATH, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_ZJUMP, TRAIT_GENERIC)
 	H.cmode_music = 'sound/music/cmode/nobility/CombatJester2.ogg'
 
 /datum/migrant_wave/jestertroupe


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

This change gives migrant troupe jesters the ability to z-jump.

## Why It's Good For The Game

Z-jump is the best thing about jester! LET THEM HAVE FUN!!

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
