### PR TITLE
Re applies the updated omen flavor text

### DIFF
--- a/code/modules/events/rogue/_rogue.dm
+++ b/code/modules/events/rogue/_rogue.dm
@@ -33,17 +33,17 @@ GLOBAL_LIST_INIT(badomens, list())
 	var/used
 	switch(eventreason)
 		if(OMEN_ROUNDSTART)
-			used = "Zizo."
+			used = "Zizo's apocalypse brings death to the land once more."
 		if(OMEN_NOPRIEST)
 			used = "The Priest has perished! The Ten are weakened..."
 		if(OMEN_SKELETONSIEGE)
-			used = "Unwelcome visitors!"
+			used = "Unwelcome visitors invade our lands!"
 		if(OMEN_NOLORD)
-			used = "The Monarch is dead! We need a new ruler."
+			used = "The Monarch has been slain! Our town is at the mercy of invaders."
 		if(OMEN_SUNSTEAL)
-			used = "The Sun, she is wounded!"
+			used = "The Sun is wounded! Astrata falls silent across the land!"
 		if(OMEN_ASCEND)
-			used = "Zizo will rise once again!"
+			used = "Zizo has risen again! Make peace with your god for not even they can save you!"
 	if(eventreason && used)
 		priority_announce(used, "Bad Omen", 'sound/misc/evilevent.ogg')
 


### PR DESCRIPTION
## About The Pull Request

Previously the omen text was changed to be more thematic and flavorful for what was happening, and somehow it was reverted and went under the radar. This PR re-adds the flavortext we should have

![PR](https://github.com/user-attachments/assets/b1cff395-b3d3-472a-b77b-0bc6cb27f31d)


## Why It's Good For The Game

Flavor good!

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
