### PR TITLE
Fixing dice rigs, adding card interactions with Matthios Boon

### DIFF
--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -195,8 +195,11 @@
 /obj/item/dice/proc/diceroll(mob/user)
 	result = roll(sides)
 	if(rigged != DICE_NOT_RIGGED && result != rigged_value)
-		if(rigged == DICE_BASICALLY_RIGGED && prob(CLAMP(1/(sides - 1) * 100, 40, 80)))
-			result = rigged_value
+		if(rigged == DICE_BASICALLY_RIGGED)
+			if(prob(80))
+				result = rigged_value
+			else
+				to_chat(user,"<span class='big'>Xylix laughs at your pitiable attempt at sleight of hand.</span>")
 		else if(rigged == DICE_TOTALLY_RIGGED)
 			result = rigged_value
 	if(!permanently_rigged)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

- Bumped the successful dice rig chance from 40% to 80%.
- Made a visible message when a dice rig fails.
- Added the ability for Blackleg Trait (Matthios Boon) holders to false shuffle and to force a card when shuffling.
- Added the ability for Blackleg Trait holders to peek at the top card of a deck.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
Adding more interactions for the Matthios Boon makes for fun RP scenarios, and adds viability to a non-mechanical God Boon.



I like gambling, I like Vanderlin. I like gambling in Vanderlin.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
