### PR TITLE
Prisoner cell QOL Update

### DIFF
--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -1671,6 +1671,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"bfL" = (
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/cell)
 "bga" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/floor/rogue/tile{
@@ -1818,14 +1822,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/butchershop)
-"bla" = (
-/obj/structure/closet/crate/chest/wicker,
-/obj/item/neuFarm/seed/potato,
-/obj/item/neuFarm/seed/potato,
-/obj/item/neuFarm/seed/pear,
-/obj/item/neuFarm/seed/pear,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/cell)
 "ble" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -2741,6 +2737,10 @@
 /obj/structure/closet/crate/chest/neu,
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town)
+"bPY" = (
+/obj/structure/bars,
+/turf/open/water/cleanshallow,
+/area/rogue/indoors/town/cell)
 "bQk" = (
 /turf/closed/wall/mineral/rogue/wood/window,
 /area/rogue/indoors/town)
@@ -3291,10 +3291,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/water/swamp/deep,
 /area/rogue/under/town/sewer)
-"ckz" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/cell)
 "ckU" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner{
 	dir = 4
@@ -4674,6 +4670,9 @@
 	dir = 8
 	},
 /area/rogue/outdoors/rtfield/safe)
+"doz" = (
+/turf/open/water/cleanshallow,
+/area/rogue/indoors/town/cell)
 "doI" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	icon_state = "iron_end";
@@ -6460,6 +6459,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"exe" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/cell)
 "exf" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/woodturned/nosmooth,
@@ -6492,13 +6495,6 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/church)
-"eyt" = (
-/obj/structure/mineral_door/bars{
-	lockid = "dungeon";
-	name = "Cell Door"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/cell)
 "eyC" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass/red,
@@ -7421,6 +7417,15 @@
 "fgn" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/church/inquisition)
+"fgB" = (
+/obj/structure/closet/crate/chest/wicker,
+/obj/item/neuFarm/seed/oat,
+/obj/item/neuFarm/seed/oat,
+/obj/item/storage/roguebag,
+/obj/item/neuFarm/seed/wheat,
+/obj/item/neuFarm/seed/wheat,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/cell)
 "fgI" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_x = 32;
@@ -8233,6 +8238,12 @@
 /obj/item/reagent_containers/food/snacks/rogue/meat/poultry,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/garrison)
+"fMF" = (
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/cell)
 "fML" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/cobble/mossy,
@@ -10261,10 +10272,6 @@
 /obj/structure/closet/crate/chest/crafted,
 /turf/open/floor/rogue/ruinedwood/turned/darker,
 /area/rogue/indoors/town)
-"hnl" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/cell)
 "hnB" = (
 /obj/structure/table/wood/plain_alt,
 /obj/item/candle/skull/lit,
@@ -10274,6 +10281,10 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
+"hob" = (
+/obj/machinery/loom,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/cell)
 "hoc" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8;
@@ -10445,10 +10456,6 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
-"htL" = (
-/obj/machinery/loom,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/cell)
 "htM" = (
 /obj/structure/chair/stool/rogue{
 	pixel_y = 5
@@ -10689,6 +10696,10 @@
 /obj/item/ingot/copper,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/dwarfin)
+"hCR" = (
+/obj/item/rogueweapon/hoe/stone,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/cell)
 "hDd" = (
 /obj/structure/table/wood/reinf_long,
 /turf/open/floor/rogue/ruinedwood,
@@ -13178,6 +13189,14 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"jlg" = (
+/obj/structure/mineral_door/bars{
+	locked = 1;
+	lockid = "dungeon";
+	name = "Cell Door"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement)
 "jlM" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -14375,10 +14394,6 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
-"kcU" = (
-/obj/item/rogueweapon/thresher,
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/cell)
 "kdk" = (
 /obj/structure/rack/rogue/shelf/biggest{
 	pixel_x = 1;
@@ -14568,6 +14583,11 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"kiS" = (
+/obj/machinery/light/rogue/torchholder/l,
+/obj/structure/composter/halffull,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/cell)
 "kiV" = (
 /obj/effect/landmark/mapGenerator/rogue/cave,
 /turf/closed,
@@ -15651,6 +15671,14 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"kZN" = (
+/obj/structure/closet/crate/chest/wicker,
+/obj/item/neuFarm/seed/potato,
+/obj/item/neuFarm/seed/potato,
+/obj/item/neuFarm/seed/pear,
+/obj/item/neuFarm/seed/pear,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/cell)
 "laa" = (
 /obj/structure/table/wood{
 	dir = 2;
@@ -16088,12 +16116,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
-"lvP" = (
-/obj/machinery/light/rogue/torchholder/l{
-	dir = 8
-	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/cell)
 "lvV" = (
 /obj/machinery/light/rogue/smelter,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -17036,6 +17058,10 @@
 /obj/structure/table/wood/reinf_long,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/clinic_large)
+"mkm" = (
+/obj/structure/feedinghole,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/cell)
 "mku" = (
 /turf/closed/wall/mineral/rogue/decostone/center,
 /area/rogue/indoors/town/church)
@@ -17564,10 +17590,6 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
-"mFl" = (
-/obj/structure/bars,
-/turf/open/water/cleanshallow,
-/area/rogue/indoors/town/cell)
 "mFw" = (
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/woodturned,
@@ -18421,10 +18443,6 @@
 "nlp" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield/safe)
-"nlN" = (
-/obj/item/needle/thorn,
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/cell)
 "nlO" = (
 /obj/structure/table/wood/large/corner{
 	dir = 8
@@ -18528,6 +18546,10 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
+"nqJ" = (
+/obj/item/needle/thorn,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/cell)
 "nqN" = (
 /obj/item/roguemachine/drugtrade,
 /turf/open/floor/rogue/ruinedwood/chevron,
@@ -18843,9 +18865,6 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"nBk" = (
-/turf/open/water/cleanshallow,
-/area/rogue/indoors/town/cell)
 "nBK" = (
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/shop)
@@ -20278,10 +20297,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
-"oFw" = (
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/cell)
 "oFJ" = (
 /obj/structure/bed/rogue/bear,
 /obj/effect/landmark/start/villager,
@@ -20916,6 +20931,10 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/under/town/sewer)
+"pdO" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/cell)
 "pec" = (
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/blocks,
@@ -22661,6 +22680,10 @@
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
+"qvO" = (
+/obj/item/rogueweapon/thresher,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/cell)
 "qvV" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	lockid = "puritan";
@@ -23810,14 +23833,6 @@
 /obj/structure/gravemarker,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"rto" = (
-/obj/structure/mineral_door/bars{
-	locked = 1;
-	lockid = "dungeon";
-	name = "Cell Door"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement)
 "rtH" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
@@ -26136,13 +26151,6 @@
 "sWL" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"sXw" = (
-/obj/structure/closet/crate/chest/wicker,
-/obj/item/neuFarm/seed/oat,
-/obj/item/neuFarm/seed/oat,
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/cell)
 "sXF" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods_safe)
@@ -29854,10 +29862,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"vze" = (
-/obj/structure/feedinghole,
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/cell)
 "vzr" = (
 /obj/structure/mineral_door/wood/green{
 	locked = 1;
@@ -31020,6 +31024,13 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield/safe)
+"wtY" = (
+/obj/structure/mineral_door/bars{
+	lockid = "dungeon";
+	name = "Cell Door"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/cell)
 "wun" = (
 /obj/structure/fluff/railing/wood{
 	pixel_y = -4
@@ -31034,11 +31045,6 @@
 /obj/machinery/light/rogue/campfire/longlived,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield/safe)
-"wuH" = (
-/obj/machinery/light/rogue/torchholder/l,
-/obj/structure/composter/halffull,
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/cell)
 "wvf" = (
 /turf/closed/mineral/rogue,
 /area/rogue/outdoors/rtfield/safe)
@@ -32293,10 +32299,6 @@
 	dir = 1
 	},
 /area/rogue/indoors/town)
-"xop" = (
-/obj/item/rogueweapon/hoe/stone,
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/cell)
 "xoL" = (
 /obj/structure/table/wood/reinforced_alter,
 /obj/item/natural/feather,
@@ -50305,9 +50307,9 @@ vgJ
 huh
 huh
 iqd
-wuH
-sXw
-bla
+kiS
+fgB
+kZN
 huh
 huh
 huh
@@ -50505,7 +50507,7 @@ jUb
 fkZ
 vgJ
 huh
-xop
+hCR
 iqd
 iqd
 pXR
@@ -50712,7 +50714,7 @@ iqd
 iqd
 iqd
 pXR
-eyt
+wtY
 pXR
 oEw
 hpQ
@@ -51112,7 +51114,7 @@ fkZ
 vgJ
 lBA
 iqd
-nlN
+nqJ
 iqd
 iqd
 pXR
@@ -51318,7 +51320,7 @@ iqd
 iqd
 iqd
 pXR
-rto
+jlg
 qqq
 bET
 iRT
@@ -51515,10 +51517,10 @@ jUb
 fkZ
 vgJ
 huh
-vze
+mkm
 iqd
 iqd
-ckz
+exe
 pXR
 jZU
 cQG
@@ -51722,7 +51724,7 @@ iqd
 iqd
 pXR
 pXR
-rto
+jlg
 iRT
 iRT
 iRT
@@ -51918,12 +51920,12 @@ jZh
 jUb
 fkZ
 nmv
-mFl
+bPY
 iqd
-oFw
+bfL
 iqd
 pXR
-htL
+hob
 huh
 lBA
 nqS
@@ -52120,12 +52122,12 @@ jZh
 jUb
 fkZ
 nmv
-mFl
-nBk
+bPY
+doz
 iqd
 iqd
 pXR
-hnl
+pdO
 lBA
 kjO
 pXR
@@ -52322,13 +52324,13 @@ jZh
 jUb
 fkZ
 nmv
-mFl
-nBk
+bPY
+doz
 iqd
 iqd
 iqd
 pXR
-eyt
+wtY
 pXR
 oEw
 hpQ
@@ -52525,8 +52527,8 @@ jUb
 fkZ
 vgJ
 jEP
-nBk
-kcU
+doz
+qvO
 iqd
 iqd
 iqd
@@ -52729,7 +52731,7 @@ vgJ
 jEP
 jEP
 iqd
-lvP
+fMF
 iqd
 iqd
 jEP

--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -1818,6 +1818,14 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/butchershop)
+"bla" = (
+/obj/structure/closet/crate/chest/wicker,
+/obj/item/neuFarm/seed/potato,
+/obj/item/neuFarm/seed/potato,
+/obj/item/neuFarm/seed/pear,
+/obj/item/neuFarm/seed/pear,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/cell)
 "ble" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -3283,6 +3291,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/water/swamp/deep,
 /area/rogue/under/town/sewer)
+"ckz" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/cell)
 "ckU" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner{
 	dir = 4
@@ -4423,11 +4435,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"dcH" = (
-/obj/machinery/light/rogue/torchholder/l,
-/obj/structure/composter/halffull,
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/cell)
 "ddA" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/cloak/lordcloak,
@@ -4470,13 +4477,6 @@
 	},
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/indoors/town/dwarfin)
-"dfC" = (
-/obj/structure/mineral_door/bars{
-	lockid = "dungeon";
-	name = "Cell Door"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/cell)
 "dgc" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -6492,6 +6492,13 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/church)
+"eyt" = (
+/obj/structure/mineral_door/bars{
+	lockid = "dungeon";
+	name = "Cell Door"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/cell)
 "eyC" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass/red,
@@ -10254,6 +10261,10 @@
 /obj/structure/closet/crate/chest/crafted,
 /turf/open/floor/rogue/ruinedwood/turned/darker,
 /area/rogue/indoors/town)
+"hnl" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/cell)
 "hnB" = (
 /obj/structure/table/wood/plain_alt,
 /obj/item/candle/skull/lit,
@@ -10434,6 +10445,10 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
+"htL" = (
+/obj/machinery/loom,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/cell)
 "htM" = (
 /obj/structure/chair/stool/rogue{
 	pixel_y = 5
@@ -11056,10 +11071,6 @@
 /obj/machinery/light/rogue/torchholder,
 /turf/open/floor/rogue/ruinedwood/turned/darker,
 /area/rogue/indoors/town/garrison)
-"hQi" = (
-/obj/structure/feedinghole,
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/cell)
 "hQs" = (
 /obj/structure/fluff/walldeco/stone,
 /turf/closed/wall/mineral/rogue/stone,
@@ -14364,6 +14375,10 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
+"kcU" = (
+/obj/item/rogueweapon/thresher,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/cell)
 "kdk" = (
 /obj/structure/rack/rogue/shelf/biggest{
 	pixel_x = 1;
@@ -16073,6 +16088,12 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
+"lvP" = (
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/cell)
 "lvV" = (
 /obj/machinery/light/rogue/smelter,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -17543,6 +17564,10 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
+"mFl" = (
+/obj/structure/bars,
+/turf/open/water/cleanshallow,
+/area/rogue/indoors/town/cell)
 "mFw" = (
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/woodturned,
@@ -18396,6 +18421,10 @@
 "nlp" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield/safe)
+"nlN" = (
+/obj/item/needle/thorn,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/cell)
 "nlO" = (
 /obj/structure/table/wood/large/corner{
 	dir = 8
@@ -18814,6 +18843,9 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
+"nBk" = (
+/turf/open/water/cleanshallow,
+/area/rogue/indoors/town/cell)
 "nBK" = (
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/shop)
@@ -19943,14 +19975,6 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
-"ouh" = (
-/obj/structure/mineral_door/bars{
-	locked = 1;
-	lockid = "dungeon";
-	name = "Cell Door"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement)
 "ouO" = (
 /obj/structure/table/wood/plain_alt,
 /obj/machinery/light/rogue/wallfire/candle{
@@ -20012,10 +20036,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
-"owX" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/cell)
 "oxn" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /obj/structure/flora/roguegrass/water,
@@ -20258,6 +20278,10 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"oFw" = (
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/cell)
 "oFJ" = (
 /obj/structure/bed/rogue/bear,
 /obj/effect/landmark/start/villager,
@@ -21776,12 +21800,6 @@
 /obj/structure/closet/crate/chest/crafted,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
-"pPD" = (
-/obj/machinery/light/rogue/torchholder/l{
-	dir = 8
-	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/cell)
 "pPK" = (
 /obj/structure/noticeboard{
 	dir = 4;
@@ -23588,10 +23606,6 @@
 /obj/item/toy/cards/deck/syndicate,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
-"rjy" = (
-/obj/structure/bars,
-/turf/open/water/cleanshallow,
-/area/rogue/indoors/town/cell)
 "rjz" = (
 /obj/structure/roguewindow/solid,
 /turf/open/floor/rogue/metal/barograte,
@@ -23796,6 +23810,14 @@
 /obj/structure/gravemarker,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
+"rto" = (
+/obj/structure/mineral_door/bars{
+	locked = 1;
+	lockid = "dungeon";
+	name = "Cell Door"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement)
 "rtH" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
@@ -26114,6 +26136,13 @@
 "sWL" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"sXw" = (
+/obj/structure/closet/crate/chest/wicker,
+/obj/item/neuFarm/seed/oat,
+/obj/item/neuFarm/seed/oat,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/cell)
 "sXF" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods_safe)
@@ -26139,14 +26168,6 @@
 /obj/structure/chair/wood/rogue/chair_noble/red,
 /turf/open/floor/rogue/blocks/newstone,
 /area/rogue/indoors/town/manor)
-"sZc" = (
-/obj/structure/closet/crate/chest/wicker,
-/obj/item/neuFarm/seed/potato,
-/obj/item/neuFarm/seed/potato,
-/obj/item/neuFarm/seed/pear,
-/obj/item/neuFarm/seed/pear,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/cell)
 "sZz" = (
 /obj/structure/chair/bench/coucha,
 /turf/open/floor/rogue/woodturned,
@@ -29609,13 +29630,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/shop)
-"vqX" = (
-/obj/structure/closet/crate/chest/wicker,
-/obj/item/neuFarm/seed/oat,
-/obj/item/neuFarm/seed/oat,
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/cell)
 "vrJ" = (
 /turf/closed/wall/mineral/rogue/wooddark/slitted,
 /area/rogue/indoors/villagegarrison)
@@ -29840,6 +29854,10 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"vze" = (
+/obj/structure/feedinghole,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/cell)
 "vzr" = (
 /obj/structure/mineral_door/wood/green{
 	locked = 1;
@@ -30101,10 +30119,6 @@
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/clinic_large)
-"vIO" = (
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/cell)
 "vJq" = (
 /obj/structure/table/wood/plain_alt,
 /turf/open/floor/rogue/ruinedwood{
@@ -31020,6 +31034,11 @@
 /obj/machinery/light/rogue/campfire/longlived,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield/safe)
+"wuH" = (
+/obj/machinery/light/rogue/torchholder/l,
+/obj/structure/composter/halffull,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/cell)
 "wvf" = (
 /turf/closed/mineral/rogue,
 /area/rogue/outdoors/rtfield/safe)
@@ -31885,10 +31904,6 @@
 "wYj" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/manor)
-"wYP" = (
-/obj/item/rogueweapon/thresher,
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/cell)
 "wYV" = (
 /obj/structure/stairs{
 	dir = 8
@@ -32278,6 +32293,10 @@
 	dir = 1
 	},
 /area/rogue/indoors/town)
+"xop" = (
+/obj/item/rogueweapon/hoe/stone,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/cell)
 "xoL" = (
 /obj/structure/table/wood/reinforced_alter,
 /obj/item/natural/feather,
@@ -32497,9 +32516,6 @@
 /obj/item/clothing/cloak/raincloak/green,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
-"xyq" = (
-/turf/open/water/cleanshallow,
-/area/rogue/indoors/town/cell)
 "xyA" = (
 /obj/structure/mineral_door/swing_door,
 /turf/open/floor/rogue/dirt/road,
@@ -33366,10 +33382,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/church)
-"yeL" = (
-/obj/item/rogueweapon/hoe/stone,
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/cell)
 "yff" = (
 /obj/structure/fluff/nest,
 /turf/open/floor/rogue/dirt/road,
@@ -50293,9 +50305,9 @@ vgJ
 huh
 huh
 iqd
-dcH
-vqX
-sZc
+wuH
+sXw
+bla
 huh
 huh
 huh
@@ -50493,7 +50505,7 @@ jUb
 fkZ
 vgJ
 huh
-yeL
+xop
 iqd
 iqd
 pXR
@@ -50700,7 +50712,7 @@ iqd
 iqd
 iqd
 pXR
-dfC
+eyt
 pXR
 oEw
 hpQ
@@ -51100,7 +51112,7 @@ fkZ
 vgJ
 lBA
 iqd
-iqd
+nlN
 iqd
 iqd
 pXR
@@ -51306,7 +51318,7 @@ iqd
 iqd
 iqd
 pXR
-ouh
+rto
 qqq
 bET
 iRT
@@ -51503,10 +51515,10 @@ jUb
 fkZ
 vgJ
 huh
-hQi
+vze
 iqd
 iqd
-owX
+ckz
 pXR
 jZU
 cQG
@@ -51710,7 +51722,7 @@ iqd
 iqd
 pXR
 pXR
-ouh
+rto
 iRT
 iRT
 iRT
@@ -51906,12 +51918,12 @@ jZh
 jUb
 fkZ
 nmv
-rjy
+mFl
 iqd
-vIO
+oFw
 iqd
 pXR
-pXR
+htL
 huh
 lBA
 nqS
@@ -52108,12 +52120,12 @@ jZh
 jUb
 fkZ
 nmv
-rjy
-xyq
+mFl
+nBk
 iqd
 iqd
 pXR
-pXR
+hnl
 lBA
 kjO
 pXR
@@ -52310,13 +52322,13 @@ jZh
 jUb
 fkZ
 nmv
-rjy
-xyq
+mFl
+nBk
 iqd
 iqd
 iqd
 pXR
-dfC
+eyt
 pXR
 oEw
 hpQ
@@ -52513,8 +52525,8 @@ jUb
 fkZ
 vgJ
 jEP
-xyq
-wYP
+nBk
+kcU
 iqd
 iqd
 iqd
@@ -52717,7 +52729,7 @@ vgJ
 jEP
 jEP
 iqd
-pPD
+lvP
 iqd
 iqd
 jEP

--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -245,12 +245,6 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
-"aif" = (
-/obj/machinery/light/rogue/torchholder/l{
-	dir = 8
-	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/cell)
 "ail" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -1333,10 +1327,6 @@
 /obj/structure/table/wood/plain_alt,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
-"aQT" = (
-/obj/item/rogueweapon/thresher,
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/cell)
 "aRr" = (
 /obj/structure/fluff/statue/gargoyle{
 	pixel_x = 16;
@@ -3052,9 +3042,6 @@
 "cbf" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/town/caverogue)
-"cbi" = (
-/turf/open/water/cleanshallow,
-/area/rogue/indoors/town/cell)
 "cbI" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/cobble,
@@ -4436,6 +4423,11 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"dcH" = (
+/obj/machinery/light/rogue/torchholder/l,
+/obj/structure/composter/halffull,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/cell)
 "ddA" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/cloak/lordcloak,
@@ -4478,6 +4470,13 @@
 	},
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/indoors/town/dwarfin)
+"dfC" = (
+/obj/structure/mineral_door/bars{
+	lockid = "dungeon";
+	name = "Cell Door"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/cell)
 "dgc" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -4597,13 +4596,6 @@
 "dlq" = (
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/merc_guild)
-"dlv" = (
-/obj/structure/closet/crate/chest/wicker,
-/obj/item/neuFarm/seed/oat,
-/obj/item/neuFarm/seed/oat,
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/cell)
 "dlx" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/ruinedwood/turned/darker,
@@ -6645,10 +6637,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/clocktower)
-"eEO" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/cell)
 "eES" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned,
@@ -11068,6 +11056,10 @@
 /obj/machinery/light/rogue/torchholder,
 /turf/open/floor/rogue/ruinedwood/turned/darker,
 /area/rogue/indoors/town/garrison)
+"hQi" = (
+/obj/structure/feedinghole,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/cell)
 "hQs" = (
 /obj/structure/fluff/walldeco/stone,
 /turf/closed/wall/mineral/rogue/stone,
@@ -12314,13 +12306,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/theatre)
-"iJe" = (
-/obj/structure/mineral_door/bars{
-	lockid = "dungeon";
-	name = "Cell Door"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/cell)
 "iJg" = (
 /obj/item/reagent_containers/glass/bucket/pot,
 /obj/structure/table/wood/plain_alt,
@@ -12563,10 +12548,6 @@
 /obj/effect/spawner/roguemap/treeorstump,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"iRj" = (
-/obj/structure/bars,
-/turf/open/water/cleanshallow,
-/area/rogue/indoors/town/cell)
 "iRp" = (
 /obj/structure/mineral_door/wood/violet{
 	locked = 1;
@@ -14691,10 +14672,6 @@
 /obj/structure/flora/roguegrass/maneater/real,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"kmV" = (
-/obj/structure/feedinghole,
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/cell)
 "kmY" = (
 /obj/structure/bars,
 /obj/structure/bars/passage/shutter/open{
@@ -19966,6 +19943,14 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"ouh" = (
+/obj/structure/mineral_door/bars{
+	locked = 1;
+	lockid = "dungeon";
+	name = "Cell Door"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement)
 "ouO" = (
 /obj/structure/table/wood/plain_alt,
 /obj/machinery/light/rogue/wallfire/candle{
@@ -20027,6 +20012,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/shop)
+"owX" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/cell)
 "oxn" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /obj/structure/flora/roguegrass/water,
@@ -20907,14 +20896,6 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/church)
-"peA" = (
-/obj/structure/closet/crate/chest/wicker,
-/obj/item/neuFarm/seed/potato,
-/obj/item/neuFarm/seed/potato,
-/obj/item/neuFarm/seed/pear,
-/obj/item/neuFarm/seed/pear,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/cell)
 "peE" = (
 /obj/item/rogueweapon/knife/cleaver{
 	pixel_x = 0;
@@ -21795,6 +21776,12 @@
 /obj/structure/closet/crate/chest/crafted,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"pPD" = (
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/cell)
 "pPK" = (
 /obj/structure/noticeboard{
 	dir = 4;
@@ -23601,6 +23588,10 @@
 /obj/item/toy/cards/deck/syndicate,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
+"rjy" = (
+/obj/structure/bars,
+/turf/open/water/cleanshallow,
+/area/rogue/indoors/town/cell)
 "rjz" = (
 /obj/structure/roguewindow/solid,
 /turf/open/floor/rogue/metal/barograte,
@@ -24883,10 +24874,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/garrison)
-"sho" = (
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/cell)
 "shy" = (
 /obj/effect/landmark/tram/queued_path/cargo_exit{
 	next_path_id = "cargo_map_exit"
@@ -26152,6 +26139,14 @@
 /obj/structure/chair/wood/rogue/chair_noble/red,
 /turf/open/floor/rogue/blocks/newstone,
 /area/rogue/indoors/town/manor)
+"sZc" = (
+/obj/structure/closet/crate/chest/wicker,
+/obj/item/neuFarm/seed/potato,
+/obj/item/neuFarm/seed/potato,
+/obj/item/neuFarm/seed/pear,
+/obj/item/neuFarm/seed/pear,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/cell)
 "sZz" = (
 /obj/structure/chair/bench/coucha,
 /turf/open/floor/rogue/woodturned,
@@ -29614,6 +29609,13 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/shop)
+"vqX" = (
+/obj/structure/closet/crate/chest/wicker,
+/obj/item/neuFarm/seed/oat,
+/obj/item/neuFarm/seed/oat,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/cell)
 "vrJ" = (
 /turf/closed/wall/mineral/rogue/wooddark/slitted,
 /area/rogue/indoors/villagegarrison)
@@ -29986,14 +29988,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
-"vFr" = (
-/obj/structure/mineral_door/bars{
-	locked = 1;
-	lockid = "dungeon";
-	name = "Cell Door"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement)
 "vFI" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1
@@ -30107,6 +30101,10 @@
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/clinic_large)
+"vIO" = (
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/cell)
 "vJq" = (
 /obj/structure/table/wood/plain_alt,
 /turf/open/floor/rogue/ruinedwood{
@@ -30941,10 +30939,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"wrN" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/cell)
 "wrT" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -31712,10 +31706,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/tavern)
-"wQq" = (
-/obj/item/rogueweapon/hoe/stone,
-/turf/open/floor/rogue/dirt,
-/area/rogue/indoors/town/cell)
 "wQN" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	name = "Clinic";
@@ -31895,6 +31885,10 @@
 "wYj" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/manor)
+"wYP" = (
+/obj/item/rogueweapon/thresher,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/cell)
 "wYV" = (
 /obj/structure/stairs{
 	dir = 8
@@ -32503,6 +32497,9 @@
 /obj/item/clothing/cloak/raincloak/green,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
+"xyq" = (
+/turf/open/water/cleanshallow,
+/area/rogue/indoors/town/cell)
 "xyA" = (
 /obj/structure/mineral_door/swing_door,
 /turf/open/floor/rogue/dirt/road,
@@ -33369,6 +33366,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/church)
+"yeL" = (
+/obj/item/rogueweapon/hoe/stone,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/cell)
 "yff" = (
 /obj/structure/fluff/nest,
 /turf/open/floor/rogue/dirt/road,
@@ -50292,9 +50293,9 @@ vgJ
 huh
 huh
 iqd
-wrN
-dlv
-peA
+dcH
+vqX
+sZc
 huh
 huh
 huh
@@ -50492,7 +50493,7 @@ jUb
 fkZ
 vgJ
 huh
-wQq
+yeL
 iqd
 iqd
 pXR
@@ -50699,7 +50700,7 @@ iqd
 iqd
 iqd
 pXR
-iJe
+dfC
 pXR
 oEw
 hpQ
@@ -51305,7 +51306,7 @@ iqd
 iqd
 iqd
 pXR
-vFr
+ouh
 qqq
 bET
 iRT
@@ -51502,10 +51503,10 @@ jUb
 fkZ
 vgJ
 huh
-kmV
+hQi
 iqd
 iqd
-eEO
+owX
 pXR
 jZU
 cQG
@@ -51709,7 +51710,7 @@ iqd
 iqd
 pXR
 pXR
-vFr
+ouh
 iRT
 iRT
 iRT
@@ -51905,9 +51906,9 @@ jZh
 jUb
 fkZ
 nmv
-iRj
+rjy
 iqd
-sho
+vIO
 iqd
 pXR
 pXR
@@ -52107,8 +52108,8 @@ jZh
 jUb
 fkZ
 nmv
-iRj
-cbi
+rjy
+xyq
 iqd
 iqd
 pXR
@@ -52309,13 +52310,13 @@ jZh
 jUb
 fkZ
 nmv
-iRj
-cbi
+rjy
+xyq
 iqd
 iqd
 iqd
 pXR
-iJe
+dfC
 pXR
 oEw
 hpQ
@@ -52512,8 +52513,8 @@ jUb
 fkZ
 vgJ
 jEP
-cbi
-aQT
+xyq
+wYP
 iqd
 iqd
 iqd
@@ -52716,7 +52717,7 @@ vgJ
 jEP
 jEP
 iqd
-aif
+pPD
 iqd
 iqd
 jEP

--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -245,6 +245,12 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"aif" = (
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/cell)
 "ail" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -1327,6 +1333,10 @@
 /obj/structure/table/wood/plain_alt,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
+"aQT" = (
+/obj/item/rogueweapon/thresher,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/cell)
 "aRr" = (
 /obj/structure/fluff/statue/gargoyle{
 	pixel_x = 16;
@@ -3042,6 +3052,9 @@
 "cbf" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/town/caverogue)
+"cbi" = (
+/turf/open/water/cleanshallow,
+/area/rogue/indoors/town/cell)
 "cbI" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/cobble,
@@ -4165,7 +4178,6 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/orphanage)
 "cQG" = (
-/obj/machinery/light/rogue/torchholder/c,
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
@@ -4585,6 +4597,13 @@
 "dlq" = (
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/merc_guild)
+"dlv" = (
+/obj/structure/closet/crate/chest/wicker,
+/obj/item/neuFarm/seed/oat,
+/obj/item/neuFarm/seed/oat,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/cell)
 "dlx" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/ruinedwood/turned/darker,
@@ -6626,6 +6645,10 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/clocktower)
+"eEO" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/cell)
 "eES" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/woodturned,
@@ -10998,15 +11021,6 @@
 "hNY" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/magician)
-"hOf" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/obj/structure/bed/rogue/mediocre,
-/obj/item/bedsheet/rogue/cloth,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
 "hOg" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -12300,6 +12314,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/theatre)
+"iJe" = (
+/obj/structure/mineral_door/bars{
+	lockid = "dungeon";
+	name = "Cell Door"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/cell)
 "iJg" = (
 /obj/item/reagent_containers/glass/bucket/pot,
 /obj/structure/table/wood/plain_alt,
@@ -12542,6 +12563,10 @@
 /obj/effect/spawner/roguemap/treeorstump,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"iRj" = (
+/obj/structure/bars,
+/turf/open/water/cleanshallow,
+/area/rogue/indoors/town/cell)
 "iRp" = (
 /obj/structure/mineral_door/wood/violet{
 	locked = 1;
@@ -14666,6 +14691,10 @@
 /obj/structure/flora/roguegrass/maneater/real,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"kmV" = (
+/obj/structure/feedinghole,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/cell)
 "kmY" = (
 /obj/structure/bars,
 /obj/structure/bars/passage/shutter/open{
@@ -20878,6 +20907,14 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/church)
+"peA" = (
+/obj/structure/closet/crate/chest/wicker,
+/obj/item/neuFarm/seed/potato,
+/obj/item/neuFarm/seed/potato,
+/obj/item/neuFarm/seed/pear,
+/obj/item/neuFarm/seed/pear,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/cell)
 "peE" = (
 /obj/item/rogueweapon/knife/cleaver{
 	pixel_x = 0;
@@ -21391,11 +21428,12 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
 "pzP" = (
-/obj/structure/mineral_door/wood/window{
-	lockid = "shop1";
-	name = "Tailor Shop";
-	locked = 1
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_x = 32;
+	pixel_y = 0
 	},
+/obj/structure/bed/rogue/mediocre,
+/obj/item/bedsheet/rogue/cloth,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "pAp" = (
@@ -24845,6 +24883,10 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/garrison)
+"sho" = (
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/cell)
 "shy" = (
 /obj/effect/landmark/tram/queued_path/cargo_exit{
 	next_path_id = "cargo_map_exit"
@@ -29944,6 +29986,14 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"vFr" = (
+/obj/structure/mineral_door/bars{
+	locked = 1;
+	lockid = "dungeon";
+	name = "Cell Door"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement)
 "vFI" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1
@@ -30891,6 +30941,10 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"wrN" = (
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/cell)
 "wrT" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -31658,6 +31712,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/tavern)
+"wQq" = (
+/obj/item/rogueweapon/hoe/stone,
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/cell)
 "wQN" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	name = "Clinic";
@@ -50030,11 +50088,11 @@ jUb
 fkZ
 vgJ
 vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
+huh
+huh
+jEP
+jEP
+jEP
 tHe
 kbO
 iRT
@@ -50231,12 +50289,12 @@ jZh
 jUb
 fkZ
 vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
+huh
+huh
+iqd
+wrN
+dlv
+peA
 huh
 huh
 huh
@@ -50433,15 +50491,15 @@ jZh
 jUb
 fkZ
 vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
 huh
-wbl
+wQq
+iqd
+iqd
 pXR
+pXR
+lBA
+wbl
+jbT
 pXR
 awh
 lBA
@@ -50635,14 +50693,14 @@ jZh
 jUb
 fkZ
 vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-huh
-jbT
+lBA
+iqd
+iqd
+iqd
+iqd
+pXR
+iJe
+pXR
 oEw
 hpQ
 hhi
@@ -50837,13 +50895,13 @@ jZh
 jUb
 fkZ
 vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-huh
+lBA
+iqd
+iqd
+iqd
+iqd
+pXR
+lBA
 kjO
 pXR
 hpQ
@@ -51039,12 +51097,12 @@ jZh
 jUb
 fkZ
 vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
+lBA
+iqd
+iqd
+iqd
+iqd
+pXR
 huh
 lBA
 nqS
@@ -51241,13 +51299,13 @@ jZh
 jUb
 fkZ
 vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-tHe
+huh
+iqd
+iqd
+iqd
+iqd
+pXR
+vFr
 qqq
 bET
 iRT
@@ -51443,13 +51501,13 @@ jZh
 jUb
 fkZ
 vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-tHe
+huh
+kmV
+iqd
+iqd
+eEO
+pXR
+jZU
 cQG
 iRT
 iRT
@@ -51645,13 +51703,13 @@ jZh
 jUb
 fkZ
 vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-tHe
+jEP
+iqd
+iqd
+iqd
+pXR
+pXR
+vFr
 iRT
 iRT
 iRT
@@ -51846,13 +51904,13 @@ jZh
 (92,1,1) = {"
 jUb
 fkZ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
+nmv
+iRj
+iqd
+sho
+iqd
+pXR
+pXR
 huh
 lBA
 nqS
@@ -52048,14 +52106,14 @@ jZh
 (93,1,1) = {"
 jUb
 fkZ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-huh
+nmv
+iRj
+cbi
+iqd
+iqd
+pXR
+pXR
+lBA
 kjO
 pXR
 hpQ
@@ -52250,15 +52308,15 @@ jZh
 (94,1,1) = {"
 jUb
 fkZ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-huh
-jbT
+nmv
+iRj
+cbi
+iqd
+iqd
+iqd
+pXR
+iJe
+pXR
 oEw
 hpQ
 hhi
@@ -52453,15 +52511,15 @@ jZh
 jUb
 fkZ
 vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
 jEP
+cbi
+aQT
+iqd
+iqd
+iqd
+lBA
 gOJ
-pXR
+jbT
 pXR
 awh
 lBA
@@ -52655,12 +52713,12 @@ jZh
 jUb
 fkZ
 vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
+jEP
+jEP
+iqd
+aif
+iqd
+iqd
 jEP
 jEP
 bkg
@@ -52858,12 +52916,12 @@ jUb
 fkZ
 vgJ
 vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
-vgJ
+huh
+huh
+huh
+huh
+huh
+huh
 vgJ
 vgJ
 vgJ
@@ -96207,7 +96265,7 @@ svU
 svU
 nlk
 lKm
-pzP
+aPs
 nlk
 svU
 rnJ
@@ -137214,7 +137272,7 @@ tnN
 fpE
 erd
 wXO
-hOf
+pzP
 erd
 iBK
 hQZ


### PR DESCRIPTION
## About The Pull Request

This PR slightly touches up the prisoner area of the keep, giving them a joint yard for them to congregate in with just enough to grow oat, wheat, potatoes, and pears(Which don't do anything, other than being a very basic food) with a thorn needle and a loom. 

## Why It's Good For The Game

Right now, Prisoners are completely dependent on the dungeoneer for gameplay. If there is none or they are ignored they are essentially trapped in a 3x4 room with only one piece of food, an instrument, no water, and only the ability to stare at each other.

This PR allows prisoners some very basic tasks and needs (assuming effort for growing pears is put in) that could easily be rescinded to make the job a LITTLE bit more fun and gives them an opportunity to earn their freedom by allowing them access to the feeding hole to input their crops fiber and cloth.

![PR](https://github.com/user-attachments/assets/7c02b7b1-3743-4265-af2c-2ccd0e43c5d0)

The doors circled in blue are LOCKED roundstart, the doors circled in purple are unlocked roundstart.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

