### PR TITLE
Alchemy buff

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy/potionbuffs.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/potionbuffs.dm
@@ -5,7 +5,7 @@
 /datum/status_effect/buff/alch/strengthpot
 	id = "strpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/strengthpot
-	effectedstats = list("strength" = 3)
+	effectedstats = list("strength" = 4)
 	duration = 930
 
 /atom/movable/screen/alert/status_effect/buff/alch/strengthpot
@@ -15,7 +15,7 @@
 /datum/status_effect/buff/alch/perceptionpot
 	id = "perpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/perceptionpot
-	effectedstats = list("perception" = 3)
+	effectedstats = list("perception" = 4)
 	duration = 3000
 
 /atom/movable/screen/alert/status_effect/buff/alch/perceptionpot
@@ -25,7 +25,7 @@
 /datum/status_effect/buff/alch/intelligencepot
 	id = "intpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/intelligencepot
-	effectedstats = list("intelligence" = 3)
+	effectedstats = list("intelligence" = 4)
 	duration = 3000
 
 /atom/movable/screen/alert/status_effect/buff/alch/intelligencepot
@@ -35,7 +35,7 @@
 /datum/status_effect/buff/alch/constitutionpot
 	id = "conpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/constitutionpot
-	effectedstats = list("constitution" = 3)
+	effectedstats = list("constitution" = 4)
 	duration = 930
 
 /atom/movable/screen/alert/status_effect/buff/alch/constitutionpot
@@ -45,7 +45,7 @@
 /datum/status_effect/buff/alch/endurancepot
 	id = "endpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/endurancepot
-	effectedstats = list("endurance" = 3)
+	effectedstats = list("endurance" = 4)
 	duration = 930
 
 /atom/movable/screen/alert/status_effect/buff/alch/endurancepot
@@ -55,7 +55,7 @@
 /datum/status_effect/buff/alch/speedpot
 	id = "spdpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/speedpot
-	effectedstats = list("speed" = 3)
+	effectedstats = list("speed" = 4)
 	duration = 930
 
 /atom/movable/screen/alert/status_effect/buff/alch/speedpot
@@ -65,7 +65,7 @@
 /datum/status_effect/buff/alch/fortunepot
 	id = "forpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/fortunepot
-	effectedstats = list("fortune" = 3)
+	effectedstats = list("fortune" = 4)
 	duration = 3000
 
 /atom/movable/screen/alert/status_effect/buff/alch/fortunepot

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -170,7 +170,7 @@
 /datum/reagent/buff
 	description = ""
 	reagent_state = LIQUID
-	metabolization_rate = REAGENTS_METABOLISM * 0.5 // buff potions last 2 times longer
+	metabolization_rate = REAGENTS_METABOLISM
 
 /datum/reagent/buff/strength
 	name = "Strength"
@@ -181,7 +181,7 @@
 	testing("str pot in system")
 	if(M.has_status_effect(/datum/status_effect/buff/alch/strengthpot))
 		return ..()
-	if(M.reagents.has_reagent(/datum/reagent/buff/strength,5))
+	if(M.reagents.has_reagent(/datum/reagent/buff/strength,4))
 		M.apply_status_effect(/datum/status_effect/buff/alch/strengthpot)
 		M.reagents.remove_reagent(/datum/reagent/buff/strength, M.reagents.get_reagent_amount(/datum/reagent/buff/strength))
 	return ..()
@@ -195,7 +195,7 @@
 	testing("per pot in system")
 	if(M.has_status_effect(/datum/status_effect/buff/alch/perceptionpot))
 		return ..()
-	if(M.reagents.has_reagent((/datum/reagent/buff/perception),5))
+	if(M.reagents.has_reagent((/datum/reagent/buff/perception),4))
 		M.apply_status_effect(/datum/status_effect/buff/alch/perceptionpot)
 		M.reagents.remove_reagent(/datum/reagent/buff/perception, M.reagents.get_reagent_amount(/datum/reagent/buff/perception))
 	return ..()
@@ -209,7 +209,7 @@
 	testing("int pot in system")
 	if(M.has_status_effect(/datum/status_effect/buff/alch/intelligencepot))
 		return ..()
-	if(M.reagents.has_reagent((/datum/reagent/buff/intelligence),5))
+	if(M.reagents.has_reagent((/datum/reagent/buff/intelligence),4))
 		M.apply_status_effect(/datum/status_effect/buff/alch/intelligencepot)
 		M.reagents.remove_reagent(/datum/reagent/buff/intelligence, M.reagents.get_reagent_amount(/datum/reagent/buff/intelligence))
 	return ..()
@@ -223,7 +223,7 @@
 	testing("con pot in system")
 	if(M.has_status_effect(/datum/status_effect/buff/alch/constitutionpot))
 		return ..()
-	if(M.reagents.has_reagent((/datum/reagent/buff/constitution),5))
+	if(M.reagents.has_reagent((/datum/reagent/buff/constitution),4))
 		M.apply_status_effect(/datum/status_effect/buff/alch/constitutionpot)
 		M.reagents.remove_reagent(/datum/reagent/buff/constitution, M.reagents.get_reagent_amount(/datum/reagent/buff/constitution))
 	return ..()
@@ -237,7 +237,7 @@
 	testing("end pot in system")
 	if(M.has_status_effect(/datum/status_effect/buff/alch/endurancepot))
 		return ..()
-	if(M.reagents.has_reagent((/datum/reagent/buff/endurance),5))
+	if(M.reagents.has_reagent((/datum/reagent/buff/endurance),4))
 		M.apply_status_effect(/datum/status_effect/buff/alch/endurancepot)
 		M.reagents.remove_reagent(/datum/reagent/buff/endurance, M.reagents.get_reagent_amount(/datum/reagent/buff/endurance))
 	return ..()
@@ -251,7 +251,7 @@
 	testing("spd pot in system")
 	if(M.has_status_effect(/datum/status_effect/buff/alch/speedpot))
 		return ..()
-	if(M.reagents.has_reagent((/datum/reagent/buff/speed),5))
+	if(M.reagents.has_reagent((/datum/reagent/buff/speed),4))
 		M.apply_status_effect(/datum/status_effect/buff/alch/speedpot)
 		M.reagents.remove_reagent(/datum/reagent/buff/speed, M.reagents.get_reagent_amount(/datum/reagent/buff/speed))
 	return ..()
@@ -265,7 +265,7 @@
 	testing("luck pot in system")
 	if(M.has_status_effect(/datum/status_effect/buff/alch/fortunepot))
 		return ..()
-	if(M.reagents.has_reagent((/datum/reagent/buff/fortune),5))
+	if(M.reagents.has_reagent((/datum/reagent/buff/fortune),4))
 		M.apply_status_effect(/datum/status_effect/buff/alch/fortunepot)
 		M.reagents.remove_reagent(/datum/reagent/buff/fortune, M.reagents.get_reagent_amount(/datum/reagent/buff/fortune))
 	return ..()

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -123,7 +123,7 @@
 
 /datum/reagent/medicine/stampot/on_mob_life(mob/living/carbon/M)
 	if(!HAS_TRAIT(M,TRAIT_NOSTAMINA))
-		M.adjust_stamina(-1.5)
+		M.adjust_stamina(-6)
 	..()
 
 /datum/reagent/medicine/strongstam
@@ -131,11 +131,11 @@
 	description = "Rapidly regenerates stamina."
 	color = "#13df00"
 	taste_description = "sparkly static"
-	metabolization_rate = REAGENTS_METABOLISM * 3
+	metabolization_rate = REAGENTS_METABOLISM
 
 /datum/reagent/medicine/strongstam/on_mob_life(mob/living/carbon/M)
 	if(!HAS_TRAIT(M,TRAIT_NOSTAMINA))
-		M.adjust_stamina(-6)
+		M.adjust_stamina(-32) // pretty much infinite stamina during the duration
 	..()
 
 /datum/reagent/medicine/antidote
@@ -170,7 +170,7 @@
 /datum/reagent/buff
 	description = ""
 	reagent_state = LIQUID
-	metabolization_rate = REAGENTS_METABOLISM
+	metabolization_rate = REAGENTS_METABOLISM * 0.5 // buff potions last 2 times longer
 
 /datum/reagent/buff/strength
 	name = "Strength"
@@ -181,7 +181,7 @@
 	testing("str pot in system")
 	if(M.has_status_effect(/datum/status_effect/buff/alch/strengthpot))
 		return ..()
-	if(M.reagents.has_reagent(/datum/reagent/buff/strength,4))
+	if(M.reagents.has_reagent(/datum/reagent/buff/strength,5))
 		M.apply_status_effect(/datum/status_effect/buff/alch/strengthpot)
 		M.reagents.remove_reagent(/datum/reagent/buff/strength, M.reagents.get_reagent_amount(/datum/reagent/buff/strength))
 	return ..()
@@ -195,7 +195,7 @@
 	testing("per pot in system")
 	if(M.has_status_effect(/datum/status_effect/buff/alch/perceptionpot))
 		return ..()
-	if(M.reagents.has_reagent((/datum/reagent/buff/perception),4))
+	if(M.reagents.has_reagent((/datum/reagent/buff/perception),5))
 		M.apply_status_effect(/datum/status_effect/buff/alch/perceptionpot)
 		M.reagents.remove_reagent(/datum/reagent/buff/perception, M.reagents.get_reagent_amount(/datum/reagent/buff/perception))
 	return ..()
@@ -209,7 +209,7 @@
 	testing("int pot in system")
 	if(M.has_status_effect(/datum/status_effect/buff/alch/intelligencepot))
 		return ..()
-	if(M.reagents.has_reagent((/datum/reagent/buff/intelligence),4))
+	if(M.reagents.has_reagent((/datum/reagent/buff/intelligence),5))
 		M.apply_status_effect(/datum/status_effect/buff/alch/intelligencepot)
 		M.reagents.remove_reagent(/datum/reagent/buff/intelligence, M.reagents.get_reagent_amount(/datum/reagent/buff/intelligence))
 	return ..()
@@ -223,7 +223,7 @@
 	testing("con pot in system")
 	if(M.has_status_effect(/datum/status_effect/buff/alch/constitutionpot))
 		return ..()
-	if(M.reagents.has_reagent((/datum/reagent/buff/constitution),4))
+	if(M.reagents.has_reagent((/datum/reagent/buff/constitution),5))
 		M.apply_status_effect(/datum/status_effect/buff/alch/constitutionpot)
 		M.reagents.remove_reagent(/datum/reagent/buff/constitution, M.reagents.get_reagent_amount(/datum/reagent/buff/constitution))
 	return ..()
@@ -237,7 +237,7 @@
 	testing("end pot in system")
 	if(M.has_status_effect(/datum/status_effect/buff/alch/endurancepot))
 		return ..()
-	if(M.reagents.has_reagent((/datum/reagent/buff/endurance),4))
+	if(M.reagents.has_reagent((/datum/reagent/buff/endurance),5))
 		M.apply_status_effect(/datum/status_effect/buff/alch/endurancepot)
 		M.reagents.remove_reagent(/datum/reagent/buff/endurance, M.reagents.get_reagent_amount(/datum/reagent/buff/endurance))
 	return ..()
@@ -251,7 +251,7 @@
 	testing("spd pot in system")
 	if(M.has_status_effect(/datum/status_effect/buff/alch/speedpot))
 		return ..()
-	if(M.reagents.has_reagent((/datum/reagent/buff/speed),4))
+	if(M.reagents.has_reagent((/datum/reagent/buff/speed),5))
 		M.apply_status_effect(/datum/status_effect/buff/alch/speedpot)
 		M.reagents.remove_reagent(/datum/reagent/buff/speed, M.reagents.get_reagent_amount(/datum/reagent/buff/speed))
 	return ..()
@@ -265,7 +265,7 @@
 	testing("luck pot in system")
 	if(M.has_status_effect(/datum/status_effect/buff/alch/fortunepot))
 		return ..()
-	if(M.reagents.has_reagent((/datum/reagent/buff/fortune),4))
+	if(M.reagents.has_reagent((/datum/reagent/buff/fortune),5))
 		M.apply_status_effect(/datum/status_effect/buff/alch/fortunepot)
 		M.reagents.remove_reagent(/datum/reagent/buff/fortune, M.reagents.get_reagent_amount(/datum/reagent/buff/fortune))
 	return ..()

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -118,7 +118,7 @@
 	color = "#129c00"
 	taste_description = "sweet tea"
 	overdose_threshold = 0
-	metabolization_rate = REAGENTS_METABOLISM
+	metabolization_rate = REAGENTS_METABOLISM * 0.25
 	alpha = 173
 
 /datum/reagent/medicine/stampot/on_mob_life(mob/living/carbon/M)
@@ -131,7 +131,7 @@
 	description = "Rapidly regenerates stamina."
 	color = "#13df00"
 	taste_description = "sparkly static"
-	metabolization_rate = REAGENTS_METABOLISM
+	metabolization_rate = REAGENTS_METABOLISM * 0.5
 
 /datum/reagent/medicine/strongstam/on_mob_life(mob/living/carbon/M)
 	if(!HAS_TRAIT(M,TRAIT_NOSTAMINA))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
- all stat buff potions have their stat increase *increased* by one more, so a strength potion will now give 4+ strength when the previous iteration gave +3
- Normal stamina potion will now last 4 times longer (around 2 minutes with 9 oz) and is the same strength as the old strong stamina potion.
- Strong stamina potion will now last 6 times longer (around a minute per 9 oz which is an alchemimcal vial) and gives you pretty much infinite stamina during the duration.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
- since it takes a lot of effort and preparation to use these potions, they should give you a good advantage in a fight, especially since it's a consumable.
- Stamina potions, as it turns out, are completely useless! They heal 1.5 stamina per tick (maximum is 100) and run out in 3 seconds per each oz! This change will make them useful in combat.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
