### PR TITLE
MEATPIE

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -79,6 +79,7 @@
 #define ADMIN_PUNISHMENT_CBT "CBT"
 #define ADMIN_PUNISHMENT_NECKSNAP "Snap Neck"
 #define ADMIN_PUNISHMENT_HUNTED "Mark for Assassins"
+#define ADMIN_PUNISHMENT_MEATPIE "Pie-ify"
 
 #define AHELP_ACTIVE 1
 #define AHELP_CLOSED 2

--- a/code/modules/admin/drags_special_requests/itembound.dm
+++ b/code/modules/admin/drags_special_requests/itembound.dm
@@ -1,0 +1,30 @@
+/// When a movable has this component AND they are in the contents of a container, they will no longer be able to use their hands and be immobilized until they are removed from the container. So far, this is only useful for smites.
+/datum/component/itembound
+	/// Weak reference to the container that the movable is inside of.
+	var/datum/weakref/containerref
+	/// Detect any movement of the container
+	var/datum/movement_detector/move_tracker
+
+/datum/component/itembound/Initialize(atom/movable/passed_container)
+	if(!ismovable(parent))
+		return COMPONENT_INCOMPATIBLE
+	if(QDELETED(passed_container))
+		return
+	containerref = WEAKREF(passed_container)
+	move_tracker = new(parent, CALLBACK(src, PROC_REF(verify_containment)))
+
+	ADD_TRAIT(parent, TRAIT_INCAPACITATED, TRAIT_GENERIC)
+
+/// Ensure that when we move, we still are in the container. If not in the container, remove all the traits.
+/datum/component/itembound/proc/verify_containment()
+	var/atom/movable/container = containerref.resolve()
+	if(!QDELETED(container) && container.contains(parent))
+		return
+	qdel(src)
+
+/datum/component/itembound/Destroy(force)
+	containerref = null
+	QDEL_NULL(move_tracker)
+	return ..()
+
+//ported from Monke

--- a/code/modules/admin/drags_special_requests/smitepie.dm
+++ b/code/modules/admin/drags_special_requests/smitepie.dm
@@ -1,0 +1,51 @@
+/obj/item/reagent_containers/food/snacks/rogue/pie/cooked/meat/smite
+    desc = "If you put this close to your ear, you can hear the screams of the damned"
+
+
+GLOBAL_LIST_EMPTY(transformation_animation_objects)
+
+/proc/pieify(atom/movable/target)
+	var/obj/item/reagent_containers/food/snacks/rogue/pie/cooked/meat/meat/tomb = new(get_turf(target))
+	target.forceMove(tomb)
+	target.AddComponent(/datum/component/itembound, tomb)
+
+/atom/movable/proc/transformation_animation(result_appearance, time = 3 SECONDS, transform_appearance)
+	var/list/transformation_objects = GLOB.transformation_animation_objects[src] || list()
+	//Disappearing part
+	var/top_part_filter = filter(type="alpha",icon=icon('icons/effects/alphacolors.dmi',"white"),y=0)
+	filters += top_part_filter
+	var/filter_index = length(filters)
+	animate(filters[filter_index],y=-32,time=time)
+	//Appearing part
+	var/obj/effect/overlay/appearing_part = new
+	appearing_part.appearance = result_appearance
+	appearing_part.appearance_flags |= KEEP_TOGETHER | KEEP_APART
+	appearing_part.vis_flags = VIS_INHERIT_ID
+	appearing_part.filters = filter(type="alpha",icon=icon('icons/effects/alphacolors.dmi',"white"),y=0,flags=MASK_INVERSE)
+	animate(appearing_part.filters[1],y=-32,time=time)
+	transformation_objects += appearing_part
+	//Transform effect thing
+	if(transform_appearance)
+		var/obj/transform_effect = new
+		transform_effect.appearance = transform_appearance
+		transform_effect.vis_flags = VIS_INHERIT_ID
+		transform_effect.pixel_y = 16
+		transform_effect.alpha = 255
+		transformation_objects += transform_effect
+		animate(transform_effect,pixel_y=-16,time=time)
+		animate(alpha=0)
+
+	GLOB.transformation_animation_objects[src] = transformation_objects
+	for(var/A in transformation_objects)
+		vis_contents += A
+	addtimer(CALLBACK(src, PROC_REF(_reset_transformation_animation),filter_index),time)
+
+/atom/movable/proc/_reset_transformation_animation(filter_index)
+	var/list/transformation_objects = GLOB.transformation_animation_objects[src]
+	for(var/A in transformation_objects)
+		vis_contents -= A
+		qdel(A)
+	transformation_objects.Cut()
+	GLOB.transformation_animation_objects -= src
+	if(filters && length(filters) >= filter_index)
+		filters -= filters[filter_index]

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -749,6 +749,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		ADMIN_PUNISHMENT_CBT,
 		ADMIN_PUNISHMENT_NECKSNAP,
 		ADMIN_PUNISHMENT_HUNTED,
+		ADMIN_PUNISHMENT_MEATPIE,
 	)
 
 	var/punishment = input("Choose a punishment", "DIVINE SMITING") as null|anything in sortList(punishment_list)
@@ -834,6 +835,14 @@ Traitors and the like can also be revived with the previous role mostly intact.
 					// 	if(istype(I, /obj/item/rogueweapon/knife/dagger/steel/profane)) // Checks to see if the assassin has their dagger on them.
 					to_chat(carbon, "<span class='danger'>\"The Dark Sun Graggar himself has ordered us to punish [target.real_name] for their transgressions!\"</span>")
 			to_chat(target.mind, "<span class='danger'>My hair stands on end. Has someone just said my name? I should watch my back.</span>")
+		if(ADMIN_PUNISHMENT_MEATPIE)
+			if(!ishuman(target))
+				to_chat(usr, "<space class='warning'>Target must be human!</span>")
+				return
+			var/mutable_appearance/meatpie_appearance = mutable_appearance('modular/Neu_Food/icons/food.dmi', "meatpie")
+			var/mutable_appearance/transform_scanline = mutable_appearance('icons/effects/effects.dmi', "smoke")
+			target.transformation_animation(meatpie_appearance, 5 SECONDS, transform_scanline.appearance)
+			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(pieify), target), 5 SECONDS)
 	punish_log(target, punishment)
 
 /client/proc/punish_log(whom, punishment)

--- a/stonekeep.dme
+++ b/stonekeep.dme
@@ -1010,6 +1010,8 @@
 #include "code\modules\admin\topic.dm"
 #include "code\modules\admin\whitelist.dm"
 #include "code\modules\admin\callproc\callproc.dm"
+#include "code\modules\admin\drags_special_requests\itembound.dm"
+#include "code\modules\admin\drags_special_requests\smitepie.dm"
 #include "code\modules\admin\role_ban\role_ban.dm"
 #include "code\modules\admin\role_ban\role_ban_panel.dm"
 #include "code\modules\admin\verbs\adminhelp.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

Adds itembound to component, allowing players to be trapped inside items (used for the smite, ported from monkestation).
Adds transformation_animation, allowing for animations to be played while people are transformed(used for the smite, ported from monkestation)
Adds an adminsmite to turn sinners into a meat pie.


## Why It's Good For The Game


Adds an admin smite to turn someone into a meatpie. Drag asked for this, don't ask me.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
