### PR TITLE
Jumping nerf

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -349,12 +349,12 @@
 				var/jextra = FALSE
 				if(m_intent == MOVE_INTENT_RUN)
 					OffBalance(30)
-					jadded = 15
+					jadded = 60
 					jrange = 3
 					jextra = TRUE
 				else
 					OffBalance(20)
-					jadded = 10
+					jadded = 30
 					jrange = 2
 				if(ishuman(src))
 					var/mob/living/carbon/human/H = src


### PR DESCRIPTION
Makes the base cost for a jump 30 and 60 if running. If you jump around like a maniac all the time you're gonna get tired quick.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
This makes jumping cost more stamina.
- normal jumps have 'jadded' set to 30
- running jumps set it to 60.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->
People are starting to frolic joyfully, leaping around all over the place. We must put a stop to this. Also it was better than running with no consequences!!

## Why It's Good For The Game
It'll stop the people leaping about all the time. They can still do it but they'll soon learn...
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
