### PR TITLE
Flailing around

### DIFF
--- a/code/game/objects/effects/spawners/roguemapgen.dm
+++ b/code/game/objects/effects/spawners/roguemapgen.dm
@@ -246,7 +246,7 @@
 		/obj/item/rogueweapon/polearm/eaglebeak/lucerne = 10,
 		/obj/item/rogueweapon/mace = 10,
 		/obj/item/rogueweapon/sword/scimitar/messer = 10,
-		/obj/item/rogueweapon/flail/militia = 10,
+		/obj/item/rogueweapon/flail = 10,
 		/obj/item/rogueweapon/sword/short = 10,
 		/obj/item/rogueweapon/sword/long/greatsword/zwei = 10,
 		/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve = 10,

--- a/code/game/objects/items/rogueweapons/melee/flail.dm
+++ b/code/game/objects/items/rogueweapons/melee/flail.dm
@@ -78,26 +78,6 @@
 	misscost = 12
 
 
-//................ Militia Flail ............... //
-/obj/item/rogueweapon/flail/militia
-	name = "militia flail"
-	desc = "A lucky hit from such a flail can squash a cheap helmet along with the wearer's skull."
-	icon_state = "militiaflail"
-
-//................ Wooden Flail ............... // Obsolete by the thresher? No smash so its bad
-/obj/item/rogueweapon/flail/towner
-	force = DAMAGE_WEAK_FLAIL
-	possible_item_intents = list(/datum/intent/mace/strike/wood)
-	gripped_intents = list(/datum/intent/flailthresh, /datum/intent/mace/strike/wood)
-	name = "wooden flail"
-	desc = "During peacetime these flails are used to thresh wheat. During wartime - to chase off marauders."
-	icon_state = "peasantflail"
-	smeltresult = /obj/item/rogueore/coal //is mostly wood
-	max_integrity = 200
-	minstr = 5
-	sellprice = 10
-
-
 //................ Steel Flail ............... //
 /obj/item/rogueweapon/flail/sflail
 	force = DAMAGE_GOOD_FLAIL
@@ -109,12 +89,12 @@
 	max_integrity = 500
 	sellprice = 35
 
-//................ Peasant Flail ............... // A little confusing still
+//................ Great Flail ............... //
 /obj/item/rogueweapon/flail/peasant
 	force = DAMAGE_NORMAL_FLAIL
 	force_wielded = DAMAGE_GOOD_FLAIL
-	name = "peasant flail"
-	desc = "What used to be a humble thresher by design, has become a deadly flail with extended range and punch. Favored by the peasantry militia or knight errants."
+	name = "great flail"
+	desc = "Inspired by the humble thresher, this is a deadly flail with great range and punch. Favored by the peasantry militia or knight errants."
 	icon = 'icons/roguetown/weapons/64.dmi'
 	icon_state = "bigflail"
 	possible_item_intents = list(/datum/intent/flail/strike/long)

--- a/code/modules/farming/tools.dm
+++ b/code/modules/farming/tools.dm
@@ -36,7 +36,7 @@
 	force = 12
 	force_wielded = 25
 	possible_item_intents = list(MACE_STRIKE)
-	gripped_intents = list(/datum/intent/flail/strike/long, /datum/intent/flail/strike/smash/long, /datum/intent/flailthresh,)
+	gripped_intents = list(/datum/intent/flail/strike, /datum/intent/flail/strike/smash, /datum/intent/flailthresh,)
 	name = "military flail"
 	desc = "Crushes skulls, or grain."
 	icon_state = "military"

--- a/code/modules/jobs/job_types/roguetown/other/skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/skeleton.dm
@@ -141,7 +141,7 @@
 			var/obj/item/rogueweapon/sword/long/rider/copper/P = new()
 			H.put_in_hands(P, forced = TRUE)
 		if (6)
-			var/obj/item/rogueweapon/flail/militia/P = new()
+			var/obj/item/rogueweapon/flail/P = new()
 			H.put_in_hands(P, forced = TRUE)
 
 	H.TOTALSTR = rand(8,10)

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -370,26 +370,7 @@
 	result = list(/obj/item/rogueweapon/polearm/woodstaff/quarterstaff/iron)
 	craftdiff = 2
 
-/datum/crafting_recipe/roguetown/woodflail
-	name = "wooden flail x2"
-	skillcraft = /datum/skill/craft/carpentry
-	reqs = list(/obj/item/rope/chain = 1,
-			/obj/item/grown/log/tree/stick = 1, /obj/item/grown/log/tree/small = 1)
-	tools = list(/obj/item/rogueweapon/hammer)
-	req_table = TRUE
-	result = list(/obj/item/rogueweapon/flail/towner, /obj/item/rogueweapon/flail/towner)
-	craftdiff = 2
-
-/datum/crafting_recipe/roguetown/militia_flail
-	name = "militia flail"
-	skillcraft = /datum/skill/craft/carpentry
-	reqs = list(/obj/item/rogueweapon/flail/towner = 1, /obj/item/ingot/iron = 1)
-	tools = list(/obj/item/rogueweapon/hammer)
-	req_table = TRUE
-	result = list(/obj/item/rogueweapon/flail/militia)
-	craftdiff = 3
-
-/datum/crafting_recipe/roguetown/woodengreatflail
+/datum/crafting_recipe/roguetown/thresher
 	name = "thresher"
 	skillcraft = /datum/skill/craft/carpentry
 	reqs = list(/obj/item/rope = 1,
@@ -399,11 +380,11 @@
 	result = list(/obj/item/rogueweapon/thresher)
 	craftdiff = 1
 
-/datum/crafting_recipe/roguetown/bigflail
-	name = "great militia flail"
+/datum/crafting_recipe/roguetown/militiaflail
+	name = "militia flail"
 	skillcraft = /datum/skill/craft/carpentry
 	reqs = list(/obj/item/rope/chain = 1,
-			/obj/item/rogueweapon/thresher = 1, /obj/item/ingot/iron = 1)
+			/obj/item/rogueweapon/thresher = 1)
 	tools = list(/obj/item/rogueweapon/hammer)
 	req_table = TRUE
 	result = list(/obj/item/rogueweapon/thresher/military)

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
@@ -187,14 +187,6 @@
 	createditem_num = 2
 	craftdiff = 0
 
-/datum/anvil_recipe/weapons/iron/flail_iron
-	name = "Militia flail (+Chain, +Stick)"
-	recipe_name = "a militia flail"
-	req_bar = /obj/item/ingot/iron
-	additional_items = list(/obj/item/rope/chain, /obj/item/grown/log/tree/stick)
-	created_item = /obj/item/rogueweapon/flail/militia
-
-
 /datum/anvil_recipe/weapons/iron/lucerne
 	name = "Lucerne (+Bar, +Small Log)"
 	recipe_name = "a Lucerne"
@@ -489,8 +481,8 @@
 	created_item = /obj/item/rogueweapon/mace/warhammer/steel
 	craftdiff = 2
 
-/datum/anvil_recipe/weapons/steel/peasant_flail
-	name = "Peasant Flail (+Chain, +Small Log)"
+/datum/anvil_recipe/weapons/steel/great_flail
+	name = "Great Flail (+Chain, +Small Log)"
 	recipe_name = "a two-handed flail"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/iron


### PR DESCRIPTION
# About The Pull Request

Flails are a unholy mess. This PR cleans it up a little.

What flails exist?
- iron flail
- steel flail
- peasant flail (2h, 2 tile range, requires anvil)
- militia flail (reskinned iron flail)
- wooden flail (also called towner flail) Called thresher in desc.
- thresher (1h, upgrades to below)
- military flail (1h, got 2 tile range)

Its a hodgepodge, obviously thresher existed in two different versions of the game, and the upgrade from thresher to military flail makes little sense (the +1 range part, also due to inheritance). 
Filenames dont match item names (fine I guess), but its just kinda slop and no one planned that out.

## What the PR does
### Iron & Steel flail untouched

### Towner and Wooden flails have been removed.  
Not even used in any mapping or job kits, few players ever seen either probably. The single person who religiously plays a beggar making a stick flail in the bog every round might have his life ruined. Or he can make a thresher thats basically the same thing.

### Military flail has been made cheaper to craft.
(no iron bar needed, just chain, but dropped the 2 tile range)

### The peasant flail renamed great flail
because thats what it is, 2 tile range. unchanged recipe so still need to anvil it.

Is it important? Not really, just think this makes it less dumb.

New list
iron flail
steel flail
thresher (1h, upgrades to below)
military flail (1h)
great flail (2h, 2 tile range, requires anvil)