### PR TITLE
Reverts cackleberry name change

### DIFF
--- a/code/modules/farming/eggs.dm
+++ b/code/modules/farming/eggs.dm
@@ -1,7 +1,7 @@
 
 /obj/item/reagent_containers/food/snacks/egg
-	name = "egg"
-	desc = "Also known as cackleberries amongst the peasants."
+	name = "cackleberry"
+	desc = "Also known as eggs in some far away corners of the world."
 	icon_state = "egg"
 	list_reagents = list(/datum/reagent/consumable/eggyolk = 5)
 	cooked_type = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

As the title says, changes the name of the cackleberries from egg back to cackleberry. Do comment if you think the description should be something else.
## Why It's Good For The Game

I think it's very "soulful" that eggs are called cackleberries in the world of Vanderlin. Also consistency with the ingame universal accent, if you try to say "egg" ingame it will convert to "cackleberry"

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
