### PR TITLE
Meathook butchering reward refactor

### DIFF
--- a/code/game/objects/structures/meathook.dm
+++ b/code/game/objects/structures/meathook.dm
@@ -158,26 +158,13 @@
 /obj/structure/meathook/proc/butchery(mob/living/user, mob/living/simple_animal/butchery_target)
 	var/list/butcher = list()
 	if(butchery_target.butcher_results)
-		if(user.mind.get_skill_level(/datum/skill/labor/butchering) <= 1)
-			if(prob(50))
-				butcher = butchery_target.botched_butcher_results // chance to get shit result
-			else
-				butcher =butchery_target.butcher_results
-		if(user.mind.get_skill_level(/datum/skill/labor/butchering) == 3)
-			if(prob(10))
-				butcher = butchery_target.perfect_butcher_results // small chance to get great result
-			else
-				butcher = butchery_target.butcher_results
-		if(user.mind.get_skill_level(/datum/skill/labor/butchering) == 4)
-			if(prob(50))
-				butcher = butchery_target.perfect_butcher_results // decent chance to get great result
-			else
-				butcher = butchery_target.butcher_results
-		else
-			if(user.mind.get_skill_level(/datum/skill/labor/butchering) == 5)
+		if(prob(50 + (user.mind.get_skill_level(/datum/skill/labor/butchering) * 25))) // need level 2 to get consistent result
+			if(prob((user.mind.get_skill_level(/datum/skill/labor/butchering) * 25) - 50)) // level 3 to 6 get better result
 				butcher = butchery_target.perfect_butcher_results
 			else
 				butcher = butchery_target.butcher_results
+		else
+			butcher = butchery_target.botched_butcher_results
 
 	if(!draining_blood && butchery_target.blood_drained < 60)
 		if(!(user.used_intent.type == /datum/intent/dagger/cut || user.used_intent.type == /datum/intent/sword/cut || user.used_intent.type == /datum/intent/axe/cut))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
Includes legendary skill level in butchering reward calculation, cleans up the code.
Changes the chance to get botched result from 50% at levels 0 and 1 to 50% at level 0, 25% at level 1
Changes the chance to get perfect result from 10% at level 3, 50% at level 4, 100% at level 5, 0% at level 6 to 25% at level 3, 50% at level 4, 75% at level 5, 100% at level 6.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
Now legendary butcher gets the same result as an average. This PR fixes it and makes the code three times smaller
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
