### PR TITLE
Reworks the Steward's Office and Gatekeepers office.

### DIFF
--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -26,12 +26,14 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "abb" = (
-/obj/structure/chair/wood/rogue/chair_noble{
-	dir = 8
+/obj/structure/roguemachine/mail/r,
+/obj/structure/rack/rogue/shelf/biggest{
+	pixel_x = -1;
+	pixel_y = 0
 	},
-/obj/item/roguemachine/mastermail,
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/steward)
+/obj/effect/spawner/roguemap/loot/armor,
+/turf/open/floor/rogue/ruinedwood/spiralfade,
+/area/rogue/indoors/town/manorgate)
 "abk" = (
 /obj/structure/fluff/railing/border{
 	dir = 4;
@@ -66,21 +68,9 @@
 /turf/open/floor/rogue/ruinedwood/darker,
 /area/rogue/outdoors/mountains)
 "aci" = (
-/obj/structure/closet/crate/drawer/random,
-/obj/item/clothing/suit/roguetown/shirt/tunic/random,
-/obj/item/clothing/suit/roguetown/shirt/tunic/random,
-/obj/item/clothing/under/roguetown/tights,
-/obj/item/clothing/under/roguetown/tights/black,
-/obj/structure/fluff/railing/border{
-	dir = 4;
-	icon_state = "border"
-	},
-/obj/machinery/light/rogue/wallfire/candle/l{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/steward)
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "acs" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
@@ -488,11 +478,13 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement)
 "arI" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 1
+/obj/structure/winch{
+	gid = "keepgatenorth";
+	redstone_id = "keepgatenorth";
+	name = "winch (north)"
 	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manorgate)
 "arX" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/dirt/road,
@@ -627,13 +619,33 @@
 /turf/open/water/sewer,
 /area/rogue/under/town/sewer)
 "awF" = (
-/obj/structure/winch{
-	gid = "keepgatenorth";
-	redstone_id = "keepgatenorth";
-	name = "winch (north)"
+/obj/item/key/manor{
+	pixel_x = -8;
+	pixel_y = 10
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manorgate)
+/obj/item/key/doctor{
+	pixel_x = 1;
+	pixel_y = 11
+	},
+/obj/item/key/tailor{
+	pixel_x = 11;
+	pixel_y = 10
+	},
+/obj/item/key/artificer{
+	pixel_y = -2;
+	pixel_x = -8
+	},
+/obj/item/key/church{
+	pixel_y = -3;
+	pixel_x = 1
+	},
+/obj/item/key/mercenary{
+	pixel_x = 11;
+	pixel_y = -2
+	},
+/obj/structure/table/wood/large_new,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "awR" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/inquisition)
@@ -658,6 +670,13 @@
 "ayy" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/church)
+"azo" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	icon_state = "woodrailing"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "azy" = (
 /obj/structure/table/vtable/v2,
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak{
@@ -922,16 +941,10 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/steward)
 "aFs" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	icon_state = "woodrailing";
-	pixel_y = -1
-	},
-/obj/structure/fluff/railing/wood,
 /obj/structure/fluff/signage{
 	name = "Church of the Ten - East"
 	},
-/turf/open/floor/rogue/dirt,
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "aFt" = (
 /obj/structure/flora/roguegrass,
@@ -970,10 +983,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "aFX" = (
-/obj/structure/roguemachine/mail,
-/obj/structure/roguewindow/stained,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/clinic_large)
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "aGa" = (
 /obj/structure/closet/crate/roguecloset/dark,
 /turf/open/floor/rogue/churchrough,
@@ -1426,7 +1440,6 @@
 /area/rogue/indoors/town/orphanage)
 "aTN" = (
 /obj/structure/roguemachine/camera,
-/obj/structure/roguemachine/mail,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/orphanage)
 "aTT" = (
@@ -1642,23 +1655,14 @@
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/under/town/basement)
 "bdl" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
+/obj/structure/bars/pipe{
+	dir = 6;
+	icon_state = "pipe";
+	pixel_x = 0;
+	pixel_y = 9
 	},
-/obj/item/reagent_containers/glass/cup/golden{
-	pixel_x = 7;
-	pixel_y = 15
-	},
-/obj/item/reagent_containers/glass/carafe/gold/redwine{
-	pixel_x = -5;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/glass/cup/steel{
-	pixel_x = 7;
-	pixel_y = 4
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/steward)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "bdv" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -2111,12 +2115,8 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/clinic_large)
 "bvm" = (
-/obj/machinery/light/rogue/wallfire/candle/l{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/closed/wall/mineral/rogue/stone,
-/area/rogue/indoors/town/steward)
+/turf/closed/wall/mineral/rogue/stonebrick,
+/area/rogue/outdoors/town/roofs)
 "bvE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2484,8 +2484,11 @@
 	pixel_x = 0;
 	pixel_y = -32
 	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/steward)
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/manorgate)
 "bET" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
@@ -2698,9 +2701,9 @@
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/indoors/town/church)
 "bMv" = (
-/obj/structure/roguemachine/mail/r,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors/town/manorgate)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/steward)
 "bMS" = (
 /obj/structure/stairs{
 	dir = 4
@@ -2773,6 +2776,12 @@
 /obj/structure/bars,
 /turf/open/water/cleanshallow,
 /area/rogue/indoors/town/cell)
+"bQj" = (
+/obj/structure/chair/wood/rogue/chair_noble{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "bQk" = (
 /turf/closed/wall/mineral/rogue/wood/window,
 /area/rogue/indoors/town)
@@ -3054,6 +3063,10 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"bZw" = (
+/obj/structure/fluff/wallclock,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "bZO" = (
 /obj/structure/flora/roguegrass/herb/hypericum,
 /turf/open/floor/rogue/grass,
@@ -3222,7 +3235,6 @@
 	icon_state = "tablewood1"
 	},
 /obj/item/clothing/mask/rogue/spectacles/golden,
-/obj/structure/roguemachine/mail,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -3576,11 +3588,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
 "cuB" = (
-/obj/structure/fluff/wallclock,
-/turf/open/floor/rogue/metal{
-	icon_state = "plating2"
-	},
-/area/rogue/indoors/town/manorgate)
+/obj/machinery/light/rogue/torchholder,
+/turf/closed/wall/mineral/rogue/stonebrick,
+/area/rogue/outdoors/town)
 "cuC" = (
 /obj/structure/chair/stool/rogue,
 /obj/machinery/light/rogue/wallfire/candle{
@@ -3737,6 +3747,24 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"cAm" = (
+/obj/structure/table/wood{
+	icon_state = "map4"
+	},
+/obj/item/paper{
+	pixel_x = 10;
+	pixel_y = -3
+	},
+/obj/item/natural/feather{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/carafe/silver/redwine{
+	pixel_x = 10;
+	pixel_y = -3
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "cBh" = (
 /obj/structure/floordoor/gatehatch/inner{
 	redstone_id = "gatelava"
@@ -3954,11 +3982,12 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/vault)
 "cGr" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	icon_state = "border"
 	},
-/turf/open/floor/rogue/ruinedwood/spiralfade,
-/area/rogue/indoors/town/manorgate)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "cGz" = (
 /turf/open/floor/rogue/blocks{
 	icon_state = "newstone2"
@@ -4113,13 +4142,10 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/town)
 "cNH" = (
-/obj/structure/table/wood,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/manorgate)
+/obj/structure/bars,
+/obj/structure/roguewindow/stained,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/steward)
 "cNM" = (
 /obj/structure/fluff/railing/border{
 	dir = 4;
@@ -4154,8 +4180,30 @@
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/outdoors/mountains)
 "cOl" = (
-/obj/structure/stairs,
-/turf/open/floor/rogue/carpet,
+/obj/structure/table/wood{
+	icon_state = "longtable"
+	},
+/obj/item/key/warehouse{
+	pixel_x = -12;
+	pixel_y = 16
+	},
+/obj/item/key/shops/shop1{
+	pixel_x = -1;
+	pixel_y = 16
+	},
+/obj/item/key/shops/shop2{
+	pixel_y = 16;
+	pixel_x = 9
+	},
+/obj/item/key/shops/shop3{
+	pixel_y = 4;
+	pixel_x = -13
+	},
+/obj/item/key/shops/shop4{
+	pixel_x = -1;
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "cOM" = (
 /obj/structure/flora/roguegrass/bush_meagre,
@@ -4468,11 +4516,9 @@
 /turf/open/floor/rogue/tile/masonic/spiral,
 /area/rogue/under/town/basement)
 "ddL" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/fluff/wallclock/r,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "deB" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/item/key/apartments/apartment15,
@@ -4528,6 +4574,20 @@
 "dgW" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/bath)
+"dhn" = (
+/obj/structure/table/wood{
+	icon_state = "map6"
+	},
+/obj/item/paper{
+	pixel_x = -8;
+	pixel_y = -3
+	},
+/obj/item/natural/feather{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "dhF" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/church/inquisition)
@@ -4755,11 +4815,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/smithy)
 "dpY" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
+/obj/machinery/light/rogue/wallfire/big_fireplace,
+/turf/closed/wall/mineral/rogue/stonebrick,
+/area/rogue/indoors/town/steward)
 "dqq" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/blocks/newstone/alt,
@@ -4824,9 +4882,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/magician)
 "dsu" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "dsx" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "vanderlin-bog_town-bog";
@@ -5047,10 +5105,53 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/church)
 "dCv" = (
-/obj/item/bedsheet/rogue/cloth,
-/obj/structure/bed/rogue/wool,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors/town/manorgate)
+/obj/structure/closet/crate/chest,
+/obj/item/paper{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/paper{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/item/paper{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/paper{
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/obj/item/paper{
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/obj/item/paper{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/item/paper{
+	pixel_x = 3;
+	pixel_y = -4
+	},
+/obj/item/paper{
+	pixel_x = 4;
+	pixel_y = -5
+	},
+/obj/item/paper{
+	pixel_x = 3;
+	pixel_y = -4
+	},
+/obj/item/paper{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/structure/fluff/railing/border{
+	dir = 9;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/steward)
 "dCB" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
@@ -5093,10 +5194,14 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "dEk" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
+/obj/structure/table/wood{
+	icon_state = "map5"
 	},
-/turf/open/floor/rogue/carpet,
+/obj/item/paper{
+	pixel_x = -1;
+	pixel_y = 4
+	},
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "dEl" = (
 /obj/structure/closet/crate/chest/wicker,
@@ -5338,12 +5443,15 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
 "dMz" = (
-/obj/structure/roguewindow/openclose{
-	dir = 4;
-	icon_state = "woodwindowdir"
+/obj/structure/roguemachine/scomm{
+	pixel_y = -32
+	},
+/obj/structure/mineral_door/wood/window{
+	lockid = "steward";
+	name = "Steward's Balcony"
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors/town/manorgate)
+/area/rogue/indoors/town/steward)
 "dMG" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -5483,14 +5591,8 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/clinic_large)
 "dQt" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/flora/roguegrass/bush_meagre,
-/turf/open/floor/rogue/dirt,
+/obj/structure/flora/roguegrass,
+/turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "dQx" = (
 /obj/structure/table/wood/plain_alt,
@@ -5644,6 +5746,12 @@
 	},
 /turf/open/floor/rogue/tile/masonic/spiral,
 /area/rogue/under/town/basement)
+"dVA" = (
+/obj/structure/fluff/walldeco/customflag{
+	name = "vanderlin flag"
+	},
+/turf/closed/wall/mineral/rogue/stonebrick,
+/area/rogue/indoors/town/manorgate)
 "dWi" = (
 /turf/closed/mineral/random/rogue/low_nonval,
 /area/rogue/under/town/sewer)
@@ -5747,13 +5855,12 @@
 	},
 /area/rogue/outdoors/town)
 "dZv" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "walls";
-	name = "gatekeeper's bedroom door"
+/obj/structure/giantfur/small{
+	pixel_x = -14;
+	pixel_y = -26
 	},
-/turf/open/floor/rogue/ruinedwood/spiralfade,
-/area/rogue/indoors/town/manorgate)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/steward)
 "dZB" = (
 /obj/structure/closet/crate/roguecloset{
 	lockid = "butler"
@@ -5888,9 +5995,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/soilsons)
 "edD" = (
-/obj/structure/roguemachine/mail,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/smithy)
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manorgate)
 "edW" = (
 /obj/structure/fluff/railing/border{
 	dir = 8;
@@ -5916,9 +6023,16 @@
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/town/sewer)
 "efh" = (
-/obj/structure/roguemachine/mail,
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/shop)
+/obj/structure/bars/passage/shutter{
+	redstone_id = "stewardshutter"
+	},
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/obj/structure/table/wood/reinforced_alt,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/steward)
 "efk" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/carpet/purple,
@@ -6072,12 +6186,9 @@
 	},
 /area/rogue/under/town/sewer)
 "ekU" = (
-/obj/machinery/light/rogue/wallfire/candle/l{
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/steward)
+/obj/effect/landmark/start/vagrant,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "ekX" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/closet/crate/chest/neu,
@@ -6531,6 +6642,10 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/church)
+"eys" = (
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "eyC" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass/red,
@@ -6600,9 +6715,11 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "eBt" = (
-/obj/effect/landmark/start/vagrant,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/structure/fluff/walldeco/customflag{
+	name = "vanderlin flag"
+	},
+/turf/closed/wall/mineral/rogue/stone,
+/area/rogue/indoors/town/manorgate)
 "eBI" = (
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/carpet/inn,
@@ -6928,10 +7045,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
-"eNR" = (
-/obj/structure/roguemachine/mail,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/dwarfin)
 "eNT" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/fluff/railing/wood,
@@ -7400,11 +7513,12 @@
 	},
 /area/rogue/indoors/town/dwarfin)
 "fdZ" = (
-/obj/structure/roguemachine/mail,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
+/obj/structure/fluff/wallclock,
+/obj/structure/mineral_door/wood/window,
+/turf/open/floor/rogue/metal{
+	icon_state = "plating2"
 	},
-/area/rogue/indoors/town/church/chapel)
+/area/rogue/indoors/town/manorgate)
 "feb" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 4
@@ -7433,16 +7547,11 @@
 /turf/open/floor/rogue/ruinedwood/turned/darker,
 /area/rogue/indoors/town)
 "fga" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	icon_state = "woodrailing";
-	pixel_y = -1
-	},
-/obj/structure/fluff/railing/wood{
+/obj/structure/roguewindow/openclose{
 	dir = 1
 	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/steward)
 "fgi" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/fluff/railing/wood,
@@ -7515,11 +7624,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/river)
 "fiE" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/steward)
+/obj/effect/landmark/start/vagrant,
+/turf/open/floor/rogue/metal/barograte,
+/area/rogue/outdoors/town)
 "fiF" = (
 /obj/structure/table/wood/large/corner_new{
 	dir = 10
@@ -7899,9 +8006,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/smithy)
 "fwn" = (
-/obj/structure/roguemachine/mail,
-/turf/closed/wall/mineral/rogue/stone,
-/area/rogue/indoors/town/church/inquisition)
+/obj/structure/mineral_door/wood/fancywood,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "fww" = (
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
@@ -8250,27 +8357,14 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "fLn" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/structure/fluff/railing/border{
+/obj/structure/flora/newtree,
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
 	dir = 4;
-	icon_state = "border"
+	icon_state = "woodrailing"
 	},
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/steward)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "fME" = (
 /obj/structure/closet/crate/chest/neu_iron,
 /obj/item/reagent_containers/food/snacks/egg,
@@ -8366,17 +8460,10 @@
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/indoors/town/dwarfin)
 "fPI" = (
-/obj/structure/table/vtable/v2,
-/obj/effect/spawner/roguemap/loot/food{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/effect/spawner/roguemap/loot/food{
-	pixel_x = 5;
-	pixel_y = 11
-	},
-/turf/open/floor/rogue/ruinedwood/spiralfade,
-/area/rogue/indoors/town/manorgate)
+/obj/structure/roguewindow/stained,
+/obj/structure/bars,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/steward)
 "fPM" = (
 /obj/item/reagent_containers/glass/bottle/rogue,
 /obj/machinery/light/rogue/wallfire/candle/blue{
@@ -8473,8 +8560,37 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/villagegarrison)
 "fSW" = (
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manorgate)
+/obj/item/key/tavern{
+	pixel_x = -8;
+	pixel_y = 22
+	},
+/obj/item/key/forrestgarrison{
+	pixel_x = 0;
+	pixel_y = 23
+	},
+/obj/item/key/clinic{
+	pixel_x = 11;
+	pixel_y = 22
+	},
+/obj/item/key/apothecary{
+	pixel_x = -8;
+	pixel_y = 11
+	},
+/obj/item/key/tailor{
+	pixel_x = 2;
+	pixel_y = 11
+	},
+/obj/item/key/soilson{
+	pixel_x = 11;
+	pixel_y = 11
+	},
+/obj/item/key/walls{
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/obj/structure/table/wood/large_new,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "fSY" = (
 /turf/open/water,
 /area/rogue/under/town/sewer)
@@ -9682,12 +9798,6 @@
 /obj/structure/fluff/telescope,
 /turf/open/floor/rogue/ruinedwood/darker,
 /area/rogue/outdoors/town/roofs)
-"gNi" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/flora/roguegrass,
-/obj/effect/landmark/start/vagrant,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "gNP" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/item/natural/feather{
@@ -9704,14 +9814,9 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town)
 "gOb" = (
-/obj/structure/chair/wood/rogue/chair_noble/red{
-	dir = 1
-	},
-/obj/effect/landmark/start/watchman{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood/spiralfade,
-/area/rogue/indoors/town/manorgate)
+/obj/structure/kneestingers,
+/turf/open/water/river,
+/area/rogue/outdoors/river)
 "gOe" = (
 /obj/structure/fluff/walldeco/sign/merchantsign/left,
 /turf/open/transparent/openspace,
@@ -9844,6 +9949,10 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
+"gTi" = (
+/obj/structure/mineral_door/wood/window,
+/turf/open/floor/rogue/ruinedwood/spiralfade,
+/area/rogue/indoors/town/manorgate)
 "gTw" = (
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/wood,
@@ -9882,14 +9991,27 @@
 	},
 /area/rogue/indoors/town/theatre)
 "gUL" = (
-/turf/open/floor/rogue/wood,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood/spiralfade,
+/area/rogue/indoors/town/manorgate)
 "gVa" = (
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/tile{
 	icon_state = "greenstone"
 	},
 /area/rogue/under/town/sewer)
+"gVe" = (
+/obj/item/natural/feather,
+/obj/item/natural/feather,
+/obj/item/natural/feather,
+/obj/item/natural/feather,
+/obj/item/natural/feather,
+/obj/structure/closet/crate/chest,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/steward)
 "gVm" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/stairs{
@@ -10655,14 +10777,10 @@
 /turf/open/floor/rogue/cobble/alt,
 /area/rogue/under/town/sewer)
 "hzl" = (
-/obj/structure/stairs{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/ruinedwood/spiralfade,
-/area/rogue/indoors/town/manorgate)
+/obj/structure/table/wood/nice/decorated,
+/obj/item/book/rogue/bookofpriests,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/steward)
 "hzs" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -10994,10 +11112,17 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/church)
 "hMz" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/newtree,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/bars/passage/shutter{
+	redstone_id = "stewardshutter"
+	},
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81;
+	dir = 1
+	},
+/obj/structure/table/wood/reinforced_alt,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/steward)
 "hMA" = (
 /obj/item/soap{
 	pixel_x = -6;
@@ -11035,12 +11160,13 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/outdoors/town)
 "hNm" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
+/obj/structure/bars/pipe{
+	dir = 4;
+	pixel_x = 0;
+	pixel_y = 8
 	},
-/obj/item/paper,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors/town/manorgate)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "hNp" = (
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/twig,
@@ -11522,10 +11648,8 @@
 /turf/open/floor/rogue/ruinedwood/turned/darker,
 /area/rogue/indoors/town)
 "ieD" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/carpet,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "ieY" = (
 /obj/item/natural/rock/iron,
@@ -11639,14 +11763,11 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "ijE" = (
-/obj/effect/landmark/start/steward{
-	dir = 4
-	},
-/obj/structure/chair/wood/rogue/chair_noble/purple{
+/obj/structure/chair/wood/rogue/chair_noble/red{
 	dir = 4
 	},
 /turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/steward)
+/area/rogue/indoors/town/manorgate)
 "ijP" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/wood,
@@ -11662,6 +11783,10 @@
 /obj/structure/rack/rogue/shelf/biggest,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/manor)
+"ilQ" = (
+/obj/structure/flora/roguegrass/water,
+/turf/closed/wall/mineral/rogue/stone,
+/area/rogue/outdoors/river)
 "ima" = (
 /obj/machinery/light/rogue/campfire,
 /turf/open/floor/rogue/tile{
@@ -11854,12 +11979,12 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "itF" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4
+/obj/structure/fluff/railing/border{
+	dir = 10
 	},
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/steward)
 "itR" = (
 /obj/structure/bars/pipe{
 	icon_state = "pipe";
@@ -11988,28 +12113,14 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "iwO" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable"
+/obj/structure/fluff/railing/wood,
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	icon_state = "woodrailing";
+	pixel_y = -1
 	},
-/obj/item/key/shops/shop1{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/item/key/shops/shop2{
-	pixel_y = -3;
-	pixel_x = -3
-	},
-/obj/item/key/shops/shop3{
-	pixel_y = 7;
-	pixel_x = 4
-	},
-/obj/item/key/shops/shop4{
-	pixel_x = 10;
-	pixel_y = -4
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/steward)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "iwX" = (
 /obj/structure/stairs{
 	dir = 1
@@ -12079,28 +12190,18 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "iAj" = (
-/obj/structure/mineral_door/wood/window{
-	locked = 1;
-	lockid = "walls";
-	name = "keep gate door"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/manorgate)
+/turf/closed,
+/area/rogue/outdoors/town)
 "iAr" = (
 /obj/structure/table/wood/plain_alt,
 /obj/item/rogueweapon/tongs,
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/indoors/town/smithy)
 "iAw" = (
-/obj/structure/chair/wood/rogue/chair_noble/red{
-	dir = 1
-	},
 /obj/machinery/light/rogue/wallfire/candle/l,
-/obj/effect/landmark/start/watchman{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood/spiralfade,
-/area/rogue/indoors/town/manorgate)
+/obj/structure/bookcase/random/myths,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/steward)
 "iAB" = (
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/rooftop{
@@ -12373,6 +12474,11 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"iJr" = (
+/obj/structure/bed/rogue/wool,
+/obj/item/bedsheet/rogue/pelt,
+/turf/open/floor/rogue/ruinedwood/spiralfade,
+/area/rogue/indoors/town/manorgate)
 "iJz" = (
 /obj/structure/closet/crate/chest/neu_fancy,
 /obj/item/reagent_containers/powder/spice,
@@ -12384,9 +12490,20 @@
 	},
 /area/rogue/indoors/town/magician)
 "iJI" = (
-/obj/structure/stairs,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/steward)
+/obj/structure/rack/rogue/shelf/biggest{
+	pixel_x = 1;
+	pixel_y = 0
+	},
+/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow{
+	pixel_x = 1;
+	pixel_y = 12
+	},
+/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow{
+	pixel_x = -1;
+	pixel_y = -2
+	},
+/turf/open/floor/rogue/ruinedwood/spiralfade,
+/area/rogue/indoors/town/manorgate)
 "iJQ" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobblerock,
@@ -12590,12 +12707,15 @@
 	},
 /area/rogue/under/town/basement)
 "iQo" = (
-/obj/structure/mineral_door/wood/donjon{
-	locked = 1;
-	lockid = "steward";
-	name = "Steward"
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
 	},
-/turf/open/floor/rogue/wood,
+/obj/structure/table/wood/reinforced_alt,
+/obj/structure/bars/passage/shutter{
+	redstone_id = "stewardshutter"
+	},
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/steward)
 "iQH" = (
 /obj/structure/rack/rogue/shelf/biggest,
@@ -12613,6 +12733,18 @@
 /obj/effect/spawner/roguemap/treeorstump,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"iRm" = (
+/obj/structure/table/vtable,
+/obj/item/paper{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/natural/feather{
+	pixel_x = 6;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/ruinedwood/spiralfade,
+/area/rogue/indoors/town/manorgate)
 "iRp" = (
 /obj/structure/mineral_door/wood/violet{
 	locked = 1;
@@ -13232,16 +13364,17 @@
 	},
 /area/rogue/under/town/basement)
 "jnz" = (
-/obj/structure/table/wood/reinforced_alt,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
+/obj/structure/flora/newtree,
+/obj/structure/fluff/railing/wood{
+	dir = 1
 	},
-/obj/structure/bars/passage/shutter{
-	redstone_id = "stewardshutter"
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	icon_state = "woodrailing";
+	pixel_y = -1
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/steward)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "jnP" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle,
 /area/rogue/indoors/town/manor)
@@ -13355,8 +13488,8 @@
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/indoors/town/dwarfin)
 "jry" = (
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/wood,
+/obj/structure/roguewindow/stained,
+/turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town/steward)
 "jrL" = (
 /obj/machinery/light/rogue/wallfire/candle{
@@ -13391,8 +13524,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town)
 "jtP" = (
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors/town/manorgate)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/steward)
 "juf" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/item/reagent_containers/glass/bottle/rogue/wine/sourwine,
@@ -13438,6 +13574,16 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield)
+"jyo" = (
+/obj/structure/table/wood{
+	icon_state = "map1"
+	},
+/obj/item/paper{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "jyv" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1
@@ -13823,6 +13969,10 @@
 /obj/structure/fluff/railing/border,
 /turf/open/transparent/openspace,
 /area/rogue/indoors/soilsons)
+"jLV" = (
+/obj/machinery/light/rogue/firebowl/standing,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "jMs" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/neck/roguetown/psycross/silver{
@@ -14041,13 +14191,14 @@
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/manor)
 "jQY" = (
-/obj/structure/table/wood/reinf_long{
-	dir = 1
+/obj/structure/rack/rogue/shelf/biggest{
+	pixel_x = -1;
+	pixel_y = 0
 	},
-/obj/item/paper/scroll,
-/obj/structure/feedinghole,
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/steward)
+/obj/effect/spawner/roguemap/loot/armor,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood/spiralfade,
+/area/rogue/indoors/town/manorgate)
 "jRn" = (
 /obj/structure/bookcase/random/legends,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -14084,17 +14235,6 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church)
-"jSl" = (
-/obj/structure/bars/pipe{
-	dir = 10;
-	icon_state = "pipe"
-	},
-/obj/structure/bookcase,
-/obj/item/book/rogue/abyssor,
-/obj/item/book/rogue/bookofpriests,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/steward)
 "jSz" = (
 /obj/structure/bed/rogue/mediocre,
 /obj/item/bedsheet/rogue/wool,
@@ -14383,20 +14523,21 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
 "kdk" = (
-/obj/structure/rack/rogue/shelf/biggest{
-	pixel_x = 1;
-	pixel_y = 0
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/item/clothing/cloak/half{
+	pixel_x = -9;
+	pixel_y = 14
 	},
-/obj/effect/spawner/roguemap/loot/weapon{
-	pixel_x = -11;
-	pixel_y = 5
+/obj/item/clothing/cloak/raincloak/blue{
+	pixel_x = 6;
+	pixel_y = 13
 	},
-/obj/effect/spawner/roguemap/loot/armor{
-	pixel_x = 4;
-	pixel_y = -4
+/obj/item/storage/belt/rogue/pouch{
+	pixel_x = -1;
+	pixel_y = -5
 	},
-/turf/open/floor/rogue/ruinedwood/spiralfade,
-/area/rogue/indoors/town/manorgate)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "kdw" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/item/reagent_containers/food/snacks/produce/dry_westleach,
@@ -14491,10 +14632,9 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/orphanage)
 "kgk" = (
-/obj/structure/roguemachine/mail,
-/obj/structure/chair/bench/couchablack/r,
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/steward)
+/obj/structure/fluff/wallclock,
+/turf/open/floor/rogue/ruinedwood/spiralfade,
+/area/rogue/indoors/town/manorgate)
 "kgt" = (
 /obj/structure/closet/crate/chest/crafted,
 /obj/item/reagent_containers/food/snacks/produce/poppy,
@@ -14630,9 +14770,13 @@
 /turf/closed/wall/mineral/rogue/wood/window,
 /area/rogue/indoors/town)
 "kkY" = (
-/obj/structure/roguemachine/mail,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/butchershop)
+/obj/structure/mineral_door/wood/donjon{
+	locked = 1;
+	lockid = "steward";
+	name = "Steward"
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/steward)
 "klp" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/toilet,
@@ -14682,10 +14826,10 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "kmz" = (
-/obj/structure/chair/bench/couchablack,
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/steward)
+/obj/structure/fluff/railing/border,
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood/spiralfade,
+/area/rogue/indoors/town/manorgate)
 "kmM" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -14794,17 +14938,39 @@
 "kpk" = (
 /obj/structure/closet/crate/chest/old_crate,
 /obj/item/bath/soap,
-/obj/structure/roguemachine/mail,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
 "kpz" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/chair/bench/church/smallbench{
-	pixel_x = 0;
-	pixel_y = 17
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable"
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/item/key/apartments/apartment1{
+	pixel_x = -10;
+	pixel_y = 16
+	},
+/obj/item/key/apartments/apartment2{
+	pixel_x = -2;
+	pixel_y = 16
+	},
+/obj/item/key/apartments/apartment3{
+	pixel_x = 5;
+	pixel_y = 16
+	},
+/obj/item/key/apartments/apartment4{
+	pixel_x = -11;
+	pixel_y = -2
+	},
+/obj/item/key/apartments/apartment5{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/key/apartments/apartment6{
+	pixel_x = 8;
+	pixel_y = -1
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "kqi" = (
 /turf/open/floor/rogue/blocks/paving,
 /area/rogue/under/town/sewer)
@@ -15942,11 +16108,10 @@
 /turf/open/water/bath,
 /area/rogue/under/town/basement)
 "lnk" = (
-/obj/structure/chair/wood/rogue/chair_noble/red,
 /obj/machinery/light/rogue/wallfire/candle/l,
-/obj/effect/landmark/start/watchman,
-/turf/open/floor/rogue/ruinedwood/spiralfade,
-/area/rogue/indoors/town/manorgate)
+/obj/structure/bookcase/random/archive,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/steward)
 "lnm" = (
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/mountains)
@@ -16244,13 +16409,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/villagegarrison)
 "lzD" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	icon_state = "churchslate"
-	},
-/obj/structure/roguemachine/mail,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/church/chapel)
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "lAc" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -16300,11 +16461,33 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "lCI" = (
-/obj/structure/chair/wood/rogue/chair_noble/red{
-	dir = 8
+/obj/item/key/garrison{
+	pixel_y = 17;
+	pixel_x = -8
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manorgate)
+/obj/item/key/steward{
+	pixel_x = 0;
+	pixel_y = 17
+	},
+/obj/item/key/blacksmith{
+	pixel_x = 11;
+	pixel_y = 15
+	},
+/obj/item/key/walls{
+	pixel_x = -9;
+	pixel_y = 2
+	},
+/obj/item/key/dungeon{
+	pixel_x = 1;
+	pixel_y = 2
+	},
+/obj/item/key/graveyard{
+	pixel_x = 11;
+	pixel_y = 1
+	},
+/obj/structure/table/wood/large_new,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "lCO" = (
 /obj/machinery/light/rogue/lanternpost{
 	dir = 1
@@ -16594,7 +16777,6 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/obj/structure/fluff/walldeco/steward,
 /turf/open/floor/rogue/metal{
 	icon_state = "plating2"
 	},
@@ -16782,10 +16964,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/clocktower)
-"lXX" = (
-/obj/structure/giantfur/small,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/steward)
 "lYt" = (
 /obj/machinery/light/rogue/firebowl/church,
 /obj/structure/fluff/walldeco/church/line,
@@ -16922,11 +17100,16 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "mev" = (
-/obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir"
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	icon_state = "woodrailing"
 	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/steward)
+/obj/structure/fluff/railing/wood{
+	dir = 1
+	},
+/obj/structure/flora/roguegrass/bush_meagre,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "mex" = (
 /obj/structure/mineral_door/wood/donjon{
 	locked = 1;
@@ -17095,11 +17278,8 @@
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/indoors/town/clocktower)
 "mls" = (
-/obj/structure/stairs{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood/spiralfade,
-/area/rogue/indoors/town/manorgate)
+/turf/closed/wall/mineral/rogue/wooddark,
+/area/rogue/indoors/town/steward)
 "mlJ" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/dirt/road,
@@ -17425,13 +17605,40 @@
 /turf/open/floor/rogue/carpet/green,
 /area/rogue/indoors/town/merc_guild)
 "mAr" = (
-/obj/structure/winch{
-	gid = "keepgatesouth";
-	redstone_id = "keepgatesouth";
-	name = "winch (south)"
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	icon_state = "border"
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manorgate)
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/steward)
+"mAS" = (
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/item/reagent_containers/glass/cup/silver{
+	pixel_x = -7;
+	pixel_y = 16
+	},
+/obj/item/reagent_containers/glass/cup/silver{
+	pixel_x = 6;
+	pixel_y = 16
+	},
+/obj/item/reagent_containers/glass/cup/silver{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/cup/silver{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/cup/silver{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/glass/cup/silver{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "mAU" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt,
@@ -17508,13 +17715,9 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/magician)
 "mBK" = (
-/obj/structure/table/wood/reinf_long,
-/obj/item/natural/feather,
-/obj/item/candle/yellow,
-/obj/item/candle/yellow,
-/obj/item/book/rogue/secret/ledger,
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/steward)
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/ruinedwood/spiralfade,
+/area/rogue/indoors/town/manorgate)
 "mCo" = (
 /obj/machinery/light/rogue/wallfire/candle/blue{
 	pixel_y = -32
@@ -17698,16 +17901,12 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/inquisition)
 "mIt" = (
-/obj/structure/rack/rogue/shelf/biggest{
-	pixel_x = 7;
-	pixel_y = 0
-	},
 /obj/structure/fluff/railing/border{
 	dir = 8;
 	icon_state = "border"
 	},
-/turf/open/floor/rogue/ruinedwood/spiralfade,
-/area/rogue/indoors/town/manorgate)
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/steward)
 "mIG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -17739,6 +17938,12 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/under/town/basement)
+"mJo" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/turf/closed,
+/area/rogue/indoors/town/manorgate)
 "mJp" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
@@ -17844,12 +18049,12 @@
 /turf/closed/mineral/rogue,
 /area/rogue/outdoors/mountains)
 "mOm" = (
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	icon_state = "border"
+/obj/effect/landmark/start/steward,
+/obj/structure/chair/wood/rogue/chair_noble/purple{
+	dir = 1
 	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/manorgate)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/steward)
 "mOo" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/dirt,
@@ -17890,11 +18095,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/woods_safe)
 "mPD" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/manorgate)
+/turf/closed/wall/mineral/rogue/stone/moss,
+/area/rogue/outdoors/river)
 "mPN" = (
 /obj/structure/fluff/walldeco/church/line,
 /obj/structure/fluff/walldeco/church/line{
@@ -18335,6 +18537,10 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
+"ndY" = (
+/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/steward)
 "nec" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/water,
@@ -18520,11 +18726,12 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/shop)
 "nob" = (
-/obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+/obj/structure/rack/rogue/shelf/biggest{
+	pixel_x = -1;
+	pixel_y = 0
 	},
-/turf/open/floor/rogue/ruinedwood/turned,
+/obj/effect/spawner/roguemap/loot/weapon,
+/turf/open/floor/rogue/ruinedwood/spiralfade,
 /area/rogue/indoors/town/manorgate)
 "noj" = (
 /obj/effect/landmark/start/vagrant,
@@ -18538,6 +18745,10 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/orphanage)
+"noF" = (
+/obj/effect/landmark/start/vagrant,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "npt" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -18613,6 +18824,20 @@
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
+"nrT" = (
+/obj/structure/closet/crate/chest,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/steward)
 "nrZ" = (
 /obj/structure/roguewindow/openclose{
 	dir = 4;
@@ -19328,7 +19553,12 @@
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/indoors/soilsons)
 "nNL" = (
-/obj/structure/roguemachine/scomm/r,
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
 /turf/open/floor/rogue/ruinedwood/spiralfade,
 /area/rogue/indoors/town/manorgate)
 "nOr" = (
@@ -20126,9 +20356,10 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/manor)
 "oyq" = (
-/obj/structure/roguemachine/mail,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/light/rogue/torchholder,
+/turf/closed/wall/mineral/rogue/stonebrick,
+/area/rogue/indoors/town/steward)
 "oyv" = (
 /obj/structure/bars/bent,
 /obj/structure/table/wood/reinf_long,
@@ -20311,12 +20542,12 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/clinic_large)
 "oEJ" = (
-/obj/structure/lever/wall{
-	dir = 4;
-	redstone_id = "stewardshutter"
+/obj/structure/mineral_door/wood/window{
+	lockid = "walls";
+	name = "keep gate door"
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/steward)
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/manorgate)
 "oEK" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/item/key/apartments/penthouse1,
@@ -20437,8 +20668,14 @@
 /turf/open/water/cleanshallow,
 /area/rogue/under/cave)
 "oJQ" = (
-/turf/open/floor/rogue/ruinedwood/spiralfade,
-/area/rogue/indoors/town/manorgate)
+/obj/structure/closet/crate/chest/neu_fancy,
+/obj/item/key_custom_blank,
+/obj/item/key_custom_blank,
+/obj/item/key_custom_blank,
+/obj/item/key_custom_blank,
+/obj/item/key_custom_blank,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "oJW" = (
 /obj/structure/table/wood{
 	icon_state = "longtable_mid";
@@ -20652,16 +20889,15 @@
 	},
 /area/rogue/indoors/town/dwarfin)
 "oQP" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	icon_state = "woodrailing";
-	pixel_y = -1
+/obj/structure/lever/wall{
+	dir = 4;
+	redstone_id = "stewardshutter"
 	},
-/obj/machinery/light/rogue/lanternpost/fixed{
-	dir = 1
+/obj/structure/fluff/railing/border{
+	dir = 5
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "oQW" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -21099,9 +21335,8 @@
 /turf/open/floor/rogue/cobble/alt,
 /area/rogue/under/town/sewer)
 "pke" = (
-/obj/structure/well/fountain,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manorgate)
 "pkl" = (
 /obj/structure/mineral_door/swing_door,
 /turf/open/floor/carpet/inn,
@@ -21332,6 +21567,15 @@
 	},
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
+"ptm" = (
+/obj/structure/rack/rogue/shelf/biggest{
+	pixel_x = -1;
+	pixel_y = 0
+	},
+/obj/effect/spawner/roguemap/loot/weapon,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood/spiralfade,
+/area/rogue/indoors/town/manorgate)
 "ptp" = (
 /obj/machinery/light/rogue/campfire,
 /turf/open/floor/rogue/blocks/paving,
@@ -21369,8 +21613,10 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/river)
 "ptT" = (
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/rogue/blocks,
+/obj/structure/fluff/walldeco/steward,
+/turf/open/floor/rogue/metal{
+	icon_state = "plating2"
+	},
 /area/rogue/outdoors/town)
 "ptV" = (
 /obj/machinery/light/rogue/torchholder{
@@ -21446,9 +21692,11 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/sewer)
 "pwF" = (
-/obj/structure/roguemachine/mail,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/orphanage)
+/obj/structure/closet/crate/drawer,
+/obj/item/storage/keyring,
+/obj/item/key/steward,
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/steward)
 "pxg" = (
 /obj/structure/underworld/barrier,
 /turf/open/floor/rogue/naturalstone,
@@ -21468,10 +21716,19 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/clinic_large)
 "pzf" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
+/obj/structure/rack/rogue/shelf/biggest{
+	pixel_x = -1;
+	pixel_y = 0
 	},
-/turf/open/floor/rogue/ruinedwood/turned,
+/obj/item/ammo_holder/quiver/bolts{
+	pixel_x = 9;
+	pixel_y = 0
+	},
+/obj/item/ammo_holder/quiver/bolts{
+	pixel_x = 0;
+	pixel_y = 9
+	},
+/turf/open/floor/rogue/ruinedwood/spiralfade,
 /area/rogue/indoors/town/manorgate)
 "pzq" = (
 /obj/structure/rack/rogue/shelf/biggest,
@@ -22127,6 +22384,12 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/shop)
+"qbG" = (
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/ruinedwood/spiralfade,
+/area/rogue/indoors/town/manorgate)
 "qbH" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	dir = 4;
@@ -22607,14 +22870,9 @@
 /turf/open/floor/rogue/blocks/paving,
 /area/rogue/indoors/town)
 "qtB" = (
-/obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
-	},
-/obj/item/paper,
-/obj/item/natural/feather,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors/town/manorgate)
+/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/steward)
 "qtI" = (
 /obj/structure/table/wood/plain_alt,
 /obj/item/rogue/instrument/harp,
@@ -22648,6 +22906,16 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church)
+"qur" = (
+/obj/structure/table/wood{
+	icon_state = "map3"
+	},
+/obj/item/paper{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "quu" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/tile/bfloorz,
@@ -23112,16 +23380,17 @@
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town/manor)
 "qPi" = (
-/obj/structure/roguemachine/mail,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/soilsons)
+/obj/structure/roguewindow/stained,
+/obj/structure/bars,
+/obj/structure/feedinghole,
+/turf/closed/wall/mineral/rogue/stonebrick,
+/area/rogue/indoors/town/steward)
 "qPl" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1
+/obj/structure/roguewindow/openclose{
+	icon_state = "woodwindowdir"
 	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/steward)
 "qPm" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -23216,15 +23485,9 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
 "qRf" = (
-/obj/structure/lever/wall{
-	dir = 4;
-	redstone_id = "keepgatekybraxor";
-	name = "Kybraxor's mouth lever"
-	},
-/turf/open/floor/rogue/metal{
-	icon_state = "plating2"
-	},
-/area/rogue/indoors/town/manorgate)
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "qRj" = (
 /obj/structure/fluff/walldeco/church/line,
 /obj/structure/fluff/walldeco/church/line{
@@ -24048,10 +24311,8 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "rya" = (
-/obj/structure/fluff/walldeco/customflag{
-	name = "vanderlin flag"
-	},
-/turf/closed/wall/mineral/rogue/stone,
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood/spiralfade,
 /area/rogue/indoors/town/manorgate)
 "ryr" = (
 /obj/structure/fluff/railing/wood{
@@ -24184,10 +24445,10 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
 "rEq" = (
-/obj/structure/bed/rogue/wooldouble,
-/obj/item/bedsheet/rogue/double_pelt,
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/steward)
+/obj/structure/table/wood/reinforced,
+/obj/item/flint,
+/turf/open/floor/rogue/ruinedwood/spiralfade,
+/area/rogue/indoors/town/manorgate)
 "rEw" = (
 /turf/open/floor/rogue/ruinedwood/darker,
 /area/rogue/outdoors/river)
@@ -24604,6 +24865,16 @@
 /obj/structure/table/wood/plain_alt,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"rRW" = (
+/obj/structure/bars/pipe{
+	dir = 4;
+	layer = 2.81;
+	pixel_x = -9
+	},
+/turf/open/floor/rogue/rooftop{
+	dir = 1
+	},
+/area/rogue/outdoors/town/roofs)
 "rSt" = (
 /obj/item/natural/cloth{
 	pixel_x = 6;
@@ -24664,7 +24935,6 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/inquisition)
 "rUa" = (
-/obj/structure/roguemachine/mail,
 /obj/structure/table/wood{
 	dir = 10;
 	icon_state = "largetable"
@@ -24746,6 +25016,17 @@
 "rWb" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner,
 /area/rogue/indoors/town/manor)
+"rWl" = (
+/obj/structure/table/wood{
+	icon_state = "map2"
+	},
+/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	pixel_x = 0;
+	pixel_y = 11
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "rWm" = (
 /obj/structure/stairs{
 	dir = 8;
@@ -24946,10 +25227,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "sfm" = (
-/obj/structure/flora/roguegrass/bush_meagre,
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/steward)
 "sgi" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/ruinedwood,
@@ -25162,6 +25441,12 @@
 	icon_state = "plating2"
 	},
 /area/rogue/outdoors/town)
+"spo" = (
+/obj/structure/roguewindow/stained,
+/obj/structure/bars,
+/obj/item/roguemachine/mastermail,
+/turf/closed/wall/mineral/rogue/stonebrick,
+/area/rogue/indoors/town/steward)
 "spw" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -25338,25 +25623,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
-"svn" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/structure/fluff/railing/border{
-	dir = 4;
-	icon_state = "border"
-	},
-/obj/item/key_custom_blank,
-/obj/item/key_custom_blank{
-	pixel_y = 6;
-	pixel_z = null;
-	pixel_x = -6
-	},
-/obj/item/key_custom_blank{
-	pixel_y = 4;
-	pixel_z = null;
-	pixel_x = 4
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/steward)
 "svp" = (
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/indoors/town/smithy)
@@ -25418,21 +25684,13 @@
 /turf/open/floor/rogue/ruinedwood/turned/darker,
 /area/rogue/outdoors/town)
 "swT" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
+/obj/structure/lever/wall{
+	dir = 4;
+	redstone_id = "keepgatekybraxor";
+	name = "Kybraxor's mouth lever"
 	},
-/obj/item/key/warehouse{
-	pixel_x = 10;
-	pixel_y = 6
-	},
-/obj/item/key/apartments/apartment5,
-/obj/item/key/apartments/apartment4,
-/obj/item/key/apartments/apartment3,
-/obj/item/key/apartments/apartment2,
-/obj/item/key/apartments/apartment1,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/steward)
+/turf/open/floor/rogue/ruinedwood/spiralfade,
+/area/rogue/indoors/town/manorgate)
 "swU" = (
 /obj/structure/flora/roguegrass/herb/paris,
 /turf/open/floor/rogue/grass,
@@ -25496,9 +25754,13 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/river)
 "syB" = (
-/obj/structure/roguemachine/mail,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/merc_guild)
+/obj/structure/bars/pipe{
+	dir = 9;
+	pixel_x = 10;
+	pixel_y = -9
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "syM" = (
 /obj/structure/chair/bench/church/mid{
 	dir = 1;
@@ -25563,10 +25825,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
 "sCl" = (
-/obj/item/bedsheet/rogue/wool,
-/obj/structure/bed/rogue/wool,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors/town/manorgate)
+/obj/structure/roguemachine/steward,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/steward)
 "sCx" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -25793,10 +26054,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "sIp" = (
-/obj/structure/chair/wood/rogue/chair_noble/red,
-/obj/effect/landmark/start/watchman,
-/turf/open/floor/rogue/ruinedwood/spiralfade,
-/area/rogue/indoors/town/manorgate)
+/obj/structure/chair/bench/couchablack,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/steward)
 "sIq" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/rogue/craftstone,
@@ -26245,11 +26505,8 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods_safe)
 "sYB" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/steward)
+/turf/open/floor/rogue/ruinedwood/spiralfade,
+/area/rogue/indoors/town/manorgate)
 "sYL" = (
 /obj/structure/chair/wood/rogue/chair_noble/red,
 /turf/open/floor/rogue/blocks/newstone,
@@ -26419,12 +26676,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"teR" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
-/obj/item/ammo_holder/quiver/bolts,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors/town/manorgate)
 "tfl" = (
 /obj/item/natural/poo,
 /turf/open/floor/rogue/tile/masonic/spiral,
@@ -27394,16 +27645,6 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
-"tLm" = (
-/obj/structure/fluff/railing/border{
-	dir = 8;
-	icon_state = "border"
-	},
-/obj/machinery/light/rogue/torchholder{
-	dir = 1
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/manorgate)
 "tLC" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -27411,11 +27652,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "tLG" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood/spiralfade,
-/area/rogue/indoors/town/manorgate)
+/obj/structure/chair/bench/couchablack/r,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/steward)
 "tLL" = (
 /obj/structure/table/wood/large/corner_new{
 	dir = 6
@@ -27492,12 +27731,6 @@
 /obj/structure/fluff/wallclock,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor)
-"tNw" = (
-/obj/structure/fluff/walldeco/customflag{
-	name = "vanderlin flag"
-	},
-/turf/closed/wall/mineral/rogue/stonebrick,
-/area/rogue/indoors/town/manorgate)
 "tNP" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/roguegrass,
@@ -27647,17 +27880,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"tSk" = (
-/obj/structure/closet/crate/drawer,
-/obj/item/storage/keyring,
-/obj/item/key/steward,
-/obj/machinery/light/rogue/wallfire/candle/l{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/steward)
 "tSK" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/metal/barograte,
@@ -27704,6 +27926,12 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield/safe)
+"tWh" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/turf/closed/wall/mineral/rogue/stone/window/moss,
+/area/rogue/indoors/town/manorgate)
 "tWt" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/gibs/old,
@@ -27828,47 +28056,16 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
 "uaz" = (
-/obj/structure/closet/crate/chest/neu_iron,
-/obj/item/key/manor,
-/obj/item/key/walls,
-/obj/item/key/blacksmith,
-/obj/item/key/steward{
-	pixel_x = 5;
-	pixel_y = 15
+/obj/machinery/light/rogue/wallfire/candle/l{
+	pixel_x = 0;
+	pixel_y = 32
 	},
-/obj/item/key/church{
-	pixel_y = 7;
-	pixel_x = -4
-	},
-/obj/item/key/dungeon{
-	pixel_x = -6;
-	pixel_y = -3
-	},
-/obj/item/key/graveyard{
-	pixel_x = -9;
-	pixel_y = -6
-	},
-/obj/item/key/garrison{
-	pixel_y = -4
-	},
-/obj/item/key/artificer{
-	pixel_y = -12;
-	pixel_x = -4
-	},
-/obj/item/key/mercenary{
-	pixel_x = -12;
-	pixel_y = -4
-	},
-/obj/item/key/tavern{
-	pixel_x = -12;
-	pixel_y = 12
-	},
-/obj/item/key/doctor{
-	pixel_x = 9;
-	pixel_y = 3
-	},
-/obj/item/key/tailor,
-/turf/open/floor/rogue/carpet,
+/obj/structure/closet/crate/drawer/random,
+/obj/item/clothing/under/roguetown/tights/black,
+/obj/item/clothing/under/roguetown/tights,
+/obj/item/clothing/suit/roguetown/shirt/tunic/random,
+/obj/item/clothing/suit/roguetown/shirt/tunic/random,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
 "uaD" = (
 /obj/structure/lever/hidden{
@@ -27889,6 +28086,26 @@
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/butchershop)
+"ubi" = (
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/item/reagent_containers/glass/bottle/rogue/redwine{
+	pixel_x = 5;
+	pixel_y = 18
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/redwine{
+	pixel_x = -6;
+	pixel_y = 18
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/redwine{
+	pixel_x = 5;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/redwine{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "ubG" = (
 /obj/structure/kneestingers,
 /turf/open/water/swamp/deep,
@@ -28010,6 +28227,14 @@
 /obj/structure/dock_bell,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/river)
+"ufU" = (
+/obj/structure/bed/rogue/wool,
+/obj/item/bedsheet/rogue/pelt,
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/turf/open/floor/rogue/ruinedwood/spiralfade,
+/area/rogue/indoors/town/manorgate)
 "ugP" = (
 /obj/structure/table/wood/crafted,
 /obj/item/reagent_containers/glass/bowl,
@@ -28099,34 +28324,12 @@
 /turf/open/floor/rogue/grass/red,
 /area/rogue/outdoors/woods_safe)
 "ujE" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
 	},
-/obj/machinery/light/rogue/wallfire/candle/l{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/steward)
-"ukg" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
-/obj/structure/closet/crate/drawer{
-	pixel_x = 0;
-	pixel_y = 8
-	},
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/natural/feather,
-/obj/item/natural/feather,
-/turf/open/floor/rogue/ruinedwood/turned,
+/obj/structure/table/wood,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manorgate)
 "ukp" = (
 /obj/structure/kneestingers,
@@ -28155,11 +28358,12 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church)
 "ulo" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 1
+/obj/structure/fluff/railing/border{
+	dir = 6;
+	icon_state = "border"
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/manorgate)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "ulp" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town/roofs)
@@ -28378,6 +28582,12 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
+"usb" = (
+/obj/structure/roguewindow/openclose{
+	icon_state = "woodwindowdir"
+	},
+/turf/closed,
+/area/rogue/indoors/town/manorgate)
 "usl" = (
 /obj/structure/table/wood{
 	icon_state = "largetable";
@@ -29083,7 +29293,6 @@
 	pixel_x = 0;
 	pixel_y = 10
 	},
-/obj/structure/roguemachine/mail,
 /obj/item/recipe_book/survival{
 	pixel_x = 0;
 	pixel_y = 7
@@ -29299,8 +29508,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement)
 "uYD" = (
-/obj/machinery/light/rogue/torchholder/c,
-/turf/closed/wall/mineral/rogue/stonebrick,
+/obj/structure/bed/rogue/wooldouble,
+/obj/item/bedsheet/rogue/double_pelt,
+/turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/steward)
 "uZi" = (
 /obj/structure/table/wood/plain_alt,
@@ -29361,28 +29571,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/merc_guild)
 "vcP" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -32
-	},
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/item/reagent_containers/glass/bottle/rogue/beer/fireleaf{
-	pixel_x = 5;
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/beer/hagwoodbitter{
-	pixel_x = -5;
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/beer/ratkept{
-	pixel_x = -5;
-	pixel_y = 0
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/beer/stonebeardreserve{
-	pixel_x = 5;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/ruinedwood/spiralfade,
-/area/rogue/indoors/town/manorgate)
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/steward)
 "vdd" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/natural/cloth,
@@ -29394,17 +29585,9 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
 "vdh" = (
-/obj/structure/table/vtable,
-/obj/item/toy/cards/deck/syndicate{
-	pixel_x = -7;
-	pixel_y = 6
-	},
-/obj/effect/spawner/roguemap/loot/coin/low{
-	pixel_x = 8;
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/ruinedwood/spiralfade,
-/area/rogue/indoors/town/manorgate)
+/obj/structure/bookcase/random/legends,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town/steward)
 "vdC" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/structure/fluff/nest,
@@ -29938,11 +30121,8 @@
 /turf/open/floor/rogue/ruinedwood/turned/darker,
 /area/rogue/indoors/town)
 "vwW" = (
-/obj/structure/mineral_door/wood/donjon{
-	locked = 1;
-	lockid = "steward";
-	name = "Steward";
-	dir = 1
+/obj/structure/chair/wood/rogue/chair_noble{
+	dir = 4
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
@@ -30119,12 +30299,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "vFI" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/obj/structure/bars,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manorgate)
 "vFV" = (
 /obj/structure/bars/pipe{
 	icon_state = "pipe";
@@ -30409,12 +30586,6 @@
 	icon_state = "linoleum"
 	},
 /area/rogue/indoors/town/vault)
-"vQY" = (
-/obj/structure/well/fountain{
-	pixel_x = -32
-	},
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town)
 "vRg" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -30552,8 +30723,8 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/river)
 "vWW" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/closed/wall/mineral/rogue/stone,
+/obj/machinery/light/rogue/torchholder,
+/turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town/steward)
 "vWZ" = (
 /obj/structure/stairs,
@@ -30955,7 +31126,6 @@
 /area/rogue/indoors/town/church)
 "wok" = (
 /obj/structure/closet/crate/chest/crate,
-/obj/structure/roguemachine/mail,
 /obj/item/rogueore/copper,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/smithy)
@@ -31339,6 +31509,10 @@
 "wBa" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/caverogue)
+"wBq" = (
+/obj/structure/chair/wood/rogue/chair_noble,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "wBr" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	name = "bath"
@@ -31604,9 +31778,13 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
 "wIi" = (
-/obj/structure/roguemachine/mail,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
+	},
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/steward)
 "wIn" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -31853,15 +32031,6 @@
 /obj/structure/fluff/walldeco/church/line,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/clinic_large)
-"wRB" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1
-	},
-/obj/structure/flora/roguegrass,
-/obj/effect/landmark/start/vagrant,
-/obj/structure/flora/roguegrass/bush,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "wRQ" = (
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/dirt/road,
@@ -32129,11 +32298,11 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "xcZ" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
+/obj/structure/fluff/railing/wood{
+	dir = 1
 	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "xdk" = (
 /obj/structure/closet/crate/roguecloset/dark,
 /turf/open/floor/carpet/royalblack,
@@ -32213,9 +32382,12 @@
 	},
 /area/rogue/outdoors/river)
 "xfG" = (
-/obj/machinery/light/rogue/firebowl/standing,
-/turf/open/floor/rogue/wood,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/ruinedwood/spiralfade,
+/area/rogue/indoors/town/manorgate)
 "xfL" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/metal{
@@ -32474,11 +32646,21 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "xsq" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/machinery/light/rogue/wallfire/candle/l{
+	pixel_x = 0;
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/steward)
+/obj/structure/table/vtable/v2,
+/obj/item/dice{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/obj/item/toy/cards/deck{
+	pixel_x = -4;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/ruinedwood/spiralfade,
+/area/rogue/indoors/town/manorgate)
 "xsL" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/cobble,
@@ -33345,9 +33527,14 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "xYu" = (
-/obj/structure/roguemachine/mail,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/garrison)
+/obj/structure/bars/pipe{
+	dir = 10;
+	icon_state = "pipe"
+	},
+/obj/structure/bookcase,
+/obj/item/book/rogue/abyssor,
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/steward)
 "xYL" = (
 /obj/structure/roguewindow/solid,
 /turf/open/floor/rogue/wood,
@@ -33545,9 +33732,16 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/clinic_large)
 "yhJ" = (
-/obj/structure/roguemachine/steward,
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/steward)
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
+/obj/structure/winch{
+	gid = "keepgatesouth";
+	redstone_id = "keepgatesouth";
+	name = "winch (south)"
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manorgate)
 "yii" = (
 /obj/structure/closet/crate/drawer,
 /obj/item/toy/cards/deck/syndicate,
@@ -56119,7 +56313,7 @@ lml
 lml
 vdE
 ogO
-bET
+ogO
 ogO
 jZU
 nYn
@@ -56533,8 +56727,8 @@ lwU
 nYn
 nYn
 lwU
-nYn
-nYn
+oZQ
+oZQ
 vgJ
 vgJ
 vgJ
@@ -56727,16 +56921,16 @@ jnw
 bUM
 bUM
 rsP
-gFA
-nYn
+mPD
+mgj
 nYn
 mgj
 nYn
+mgj
 nYn
-nYn
-nYn
-nYn
-nYn
+oZQ
+oZQ
+oZQ
 vgJ
 vgJ
 vgJ
@@ -56929,16 +57123,16 @@ qjc
 bUM
 bUM
 rsP
-xfD
+mPD
+wqL
+vMb
+oZQ
 nYn
-nYn
-nYn
-nYn
-nYn
-xfD
-nYn
-bxg
-nYn
+oZQ
+dSR
+oZQ
+oZQ
+mLm
 vgJ
 vgJ
 vgJ
@@ -57131,16 +57325,16 @@ qjc
 bUM
 bUM
 rsP
-nYn
-lwU
-nYn
-nYn
+mPD
+gOb
 nYn
 nYn
 vMb
 nYn
-nYn
-nYn
+mLm
+mLm
+vMb
+oZQ
 vgJ
 vgJ
 vgJ
@@ -57333,16 +57527,16 @@ qjc
 bUM
 bUM
 rsP
-nYn
-nYn
+mPD
+wqL
 nYn
 nYn
 nYn
 lwU
+mLm
+mLm
 vMb
-nYn
-nYn
-xfD
+vMb
 vgJ
 vgJ
 vgJ
@@ -57535,16 +57729,16 @@ qjc
 bUM
 bUM
 rsP
-nYn
-nYn
+mPD
+wqL
 nYn
 nYn
 nYn
 vMb
+mLm
+mLm
+nYn
 vMb
-nYn
-lwU
-nYn
 vgJ
 vgJ
 vgJ
@@ -57737,16 +57931,16 @@ qjc
 bUM
 bUM
 bUM
-nYn
-xfD
+mPD
+gFA
 lwU
 xfD
 nYn
 xfD
-xfD
-nYn
-nYn
-xfD
+dSR
+oZQ
+oZQ
+oZQ
 vgJ
 vgJ
 vgJ
@@ -57939,16 +58133,16 @@ hCF
 bUM
 bUM
 bUM
-nYn
-vMb
+mPD
+mgj
 xfD
 mgj
 xfD
-xfD
-nYn
-nYn
-nYn
-nYn
+ilQ
+oZQ
+oZQ
+oZQ
+oZQ
 vgJ
 vgJ
 vgJ
@@ -58141,16 +58335,16 @@ rDr
 bUM
 bUM
 bUM
-nYn
-nYn
+mPD
+wqL
 vMb
+dSR
+nYn
+oZQ
 xfD
-nYn
-nYn
-xfD
-nYn
-nYn
-vgJ
+oZQ
+oZQ
+oZQ
 vgJ
 vgJ
 vgJ
@@ -58343,16 +58537,16 @@ rDr
 bUM
 bUM
 bUM
-xfD
-nYn
+gFA
+wqL
 vMb
 bxg
 nYn
 nYn
 vMb
 nYn
-nYn
-vgJ
+oZQ
+oZQ
 vgJ
 vgJ
 vgJ
@@ -58554,7 +58748,7 @@ xfD
 hLN
 nYn
 nYn
-vgJ
+oZQ
 vgJ
 vgJ
 vgJ
@@ -89863,7 +90057,7 @@ xYa
 xYa
 xYa
 xYa
-iDg
+xYa
 xYa
 xYa
 xYa
@@ -90065,7 +90259,7 @@ xYa
 xYa
 xYa
 xYa
-iDg
+xYa
 xYa
 xYa
 xYa
@@ -90139,7 +90333,7 @@ jMD
 jMD
 jMD
 jMD
-syB
+pGO
 pGO
 pGO
 pGO
@@ -90244,7 +90438,7 @@ vnF
 vnF
 vnF
 vnF
-jdk
+vnF
 sWL
 vgJ
 vgJ
@@ -90267,7 +90461,7 @@ xYa
 xYa
 xYa
 xYa
-iDg
+xYa
 xYa
 xYa
 xYa
@@ -94699,11 +94893,11 @@ vnF
 vnF
 sWL
 sWL
-cHi
-uYD
-cHi
-cHi
-cHi
+rDr
+eBt
+cYY
+cYY
+cYY
 cYh
 cYh
 jki
@@ -94900,13 +95094,13 @@ vnF
 vnF
 vnF
 sWL
-jdk
-cHi
-jry
+vnF
+vnF
+cYY
 iJI
-xaa
-cHi
-cHi
+nNL
+cYY
+dVA
 cYh
 uGn
 tnD
@@ -95102,13 +95296,13 @@ vnF
 vnF
 vnF
 vnF
-qhM
-iQo
-vKO
-vKO
-lXX
-bdl
-cHi
+mUs
+vnF
+cYY
+pzf
+rya
+gUL
+cYY
 neL
 uxJ
 uxJ
@@ -95304,13 +95498,13 @@ vnF
 vnF
 vnF
 vnF
-mog
-cHi
+mUs
+vnF
 oEJ
-vKO
-vKO
+sYB
+sYB
 swT
-xaa
+cYY
 wzs
 wzs
 wzs
@@ -95471,7 +95665,7 @@ xFR
 cSA
 vwo
 bJN
-oyq
+faL
 evD
 cLm
 oXa
@@ -95506,13 +95700,13 @@ jdk
 vnF
 vnF
 vnF
-sWL
-cHi
-xaa
-vKO
-vKO
-iwO
-vWW
+vnF
+vnF
+cYY
+cYY
+fdZ
+cYY
+cYY
 xYa
 xYa
 xYa
@@ -95710,11 +95904,11 @@ vnF
 vnF
 sWL
 ntp
-xaa
-pYz
-pYz
-pYz
-xaa
+cYY
+arI
+pke
+edD
+sIO
 xYa
 xYa
 xYa
@@ -95753,7 +95947,7 @@ mgv
 pAp
 rkS
 tTU
-edD
+pnI
 sSS
 sSS
 sSS
@@ -95912,11 +96106,11 @@ vnF
 vnF
 jdk
 jdk
-xaa
-pYz
+cYY
+yhJ
 ijE
-pYz
-bvm
+pke
+sIO
 xYa
 xYa
 xYa
@@ -96114,20 +96308,20 @@ vnF
 vnF
 jdk
 hMQ
-eZF
-jnz
-jnz
-jnz
-xaa
+cYY
+vFI
+ujE
+vFI
+cYY
 iSk
 iSk
 iSk
 iSk
-arI
-eCc
-dsu
-dsu
-dsu
+iSk
+lKX
+lsl
+lsl
+lsl
 lfC
 bAV
 vqK
@@ -96534,7 +96728,7 @@ lsl
 lsl
 elp
 ohB
-uSV
+fiE
 elp
 elp
 elp
@@ -96722,7 +96916,7 @@ elp
 jvH
 jvH
 dkS
-aOr
+iAj
 dkS
 tDS
 tDS
@@ -96922,26 +97116,26 @@ vnF
 vnF
 sWL
 xWS
-rya
-sIO
+cHi
 cNH
-sIO
-tNw
+cNH
+cNH
+cHi
 iSk
 iSk
 iSk
 iSk
-arI
-eCc
-dsu
-dsu
-dsu
-xHY
+iSk
+lKX
+lsl
+lsl
+lsl
+lsl
 lsl
 elp
 ehF
-ehF
-ehF
+ekU
+elp
 ehF
 ehF
 ehF
@@ -97124,27 +97318,27 @@ vnF
 vnF
 sWL
 ntp
-sIO
+cHi
 awF
 lCI
 fSW
-sIO
+cHi
+cHi
+jry
+jry
+cHi
+oyq
 iSk
 iSk
-eCc
 iSk
 iSk
-iSk
-ptT
 lsl
-lKX
-dsu
-eBt
 lsl
-fga
-oQP
-cKJ
-iNK
+lsl
+lsl
+elp
+lsl
+lsl
 aFs
 lsl
 eLP
@@ -97326,28 +97520,28 @@ vnF
 vnF
 sWL
 jdk
-sIO
-mAr
-fSW
-fSW
-sIO
+cHi
+lzD
+vKO
+vKO
+ieD
+eys
+vKO
+vKO
+vKO
+cHi
 iSk
 iSk
 iSk
-iSk
-iSk
-iSk
-iSk
-iSk
+cuB
 lsl
-dsu
+elp
 lsl
+jnz
+mBz
+iwO
+elp
 lsl
-hsv
-oXQ
-cKJ
-hMz
-hwZ
 ehF
 fOL
 iSk
@@ -97528,28 +97722,28 @@ vnF
 vnF
 jdk
 jdk
-iAj
-fSW
-fSW
+cHi
+oJQ
+vKO
 ulo
-cYY
-iSk
-iSk
-iSk
-iSk
-iSk
-iSk
-iSk
-iSk
+cGr
+oQP
+vKO
+vKO
+pYz
+efh
+tPF
+tPF
+tPF
 ptT
-dsu
+elp
 lsl
 lsl
-vFI
-pke
-cKJ
-jim
-sfm
+xcZ
+oXQ
+aci
+elp
+elp
 elp
 fOL
 iSk
@@ -97728,30 +97922,30 @@ mpR
 jdk
 vnF
 vnF
+vnF
 jdk
-jdk
-cYY
-cYY
-cuB
+cHi
+vKO
+vKO
 qRf
-cYY
-iSk
-iSk
-iSk
-iSk
-iSk
-iSk
-iSk
-iSk
+mls
+cHi
+cOl
+vKO
+mOm
+iQo
+fBj
+fBj
+fBj
+fBj
 lsl
-dsu
+ehF
 lsl
+xcZ
+sWL
+aci
+ehF
 lsl
-qPl
-vQY
-cKJ
-kpz
-cHs
 elp
 fOL
 iSk
@@ -97931,29 +98125,29 @@ vnF
 vnF
 vnF
 vnF
-ntp
-cYY
-mls
-oJQ
-mIt
-cYY
-iSk
-iSk
-iSk
-iSk
-iSk
-iSk
-iSk
-iSk
-lKX
-dsu
+vnF
+kkY
+vKO
+vKO
+qRf
+aFX
+cHi
+wIi
+vKO
+pYz
+hMz
+tDS
+tDS
+tDS
+tDS
 lsl
+ehF
+ehF
+mev
+azo
+fLn
 lsl
-wRB
-bDv
-cKJ
-oXQ
-gNi
+ehF
 elp
 fOL
 iSk
@@ -98132,30 +98326,30 @@ cKJ
 vnF
 vnF
 vnF
-jdk
-sWL
-cYY
-cGr
-nNL
+vnF
+vnF
+cHi
 kdk
-cYY
+vKO
+vKO
+vKO
+cHi
+kpz
+vKO
+ddL
+cHi
 iSk
 iSk
 iSk
 iSk
-iSk
-iSk
-iSk
-iSk
-ptT
-dsu
-eBt
 lsl
-dQt
-bDH
-cKJ
-itF
-ylf
+lsl
+elp
+ehF
+lsl
+lsl
+lsl
+lsl
 ehF
 eLP
 iSk
@@ -98335,26 +98529,26 @@ jdk
 vnF
 vnF
 xWS
-sWL
-cYY
-cYY
-cYY
-cYY
-cYY
+xHY
+cHi
+cHi
+fwn
+cHi
+cHi
+cHi
+cHi
+cHi
+cHi
+vWW
 iSk
 iSk
-eCc
 iSk
 iSk
-iSk
-iSk
-iSk
-eCc
-eCc
+lsl
 lsl
 lsl
 elp
-elp
+noF
 lsl
 elp
 elp
@@ -98536,13 +98730,13 @@ mpR
 jdk
 vnF
 jdk
-jdk
-sWL
-rDr
-bUM
-bUM
-bUM
-rDr
+cHi
+ubi
+ieD
+vKO
+vKO
+ieD
+cHi
 iSk
 iSk
 iSk
@@ -98551,7 +98745,7 @@ iSk
 iSk
 iSk
 iSk
-mUs
+dQt
 lsl
 lsl
 elp
@@ -98738,13 +98932,13 @@ mpR
 jdk
 vnF
 vnF
-jdk
-sWL
-rDr
-bUM
-bUM
-bUM
-rDr
+cHi
+lzD
+vKO
+vwW
+vwW
+vKO
+cHi
 iSk
 iSk
 iSk
@@ -98752,10 +98946,10 @@ iSk
 iSk
 iSk
 iSk
-mUs
-ehF
+dQt
+iSk
 lsl
-elp
+noF
 elp
 elp
 elp
@@ -98940,22 +99134,22 @@ kTV
 jdk
 vnF
 vnF
-sWL
-jdk
-rDr
-bUM
-bUM
-bUM
-rDr
+cHi
+vKO
+wBq
+cAm
+jyo
+vKO
+cHi
 iSk
 iSk
 iSk
 iSk
 iSk
 iSk
-vnF
-xyY
-xyY
+iSk
+iSk
+iSk
 xyY
 elp
 lsl
@@ -99142,13 +99336,13 @@ jdk
 vnF
 vnF
 vnF
-ntp
-jdk
-rDr
-bUM
-bUM
-bUM
-rDr
+cHi
+bZw
+vKO
+dEk
+rWl
+vKO
+cHi
 iSk
 iSk
 iSk
@@ -99344,13 +99538,13 @@ vnF
 vnF
 vnF
 jdk
-sWL
-vgJ
-rDr
-bUM
-bUM
-bUM
-rDr
+cHi
+lzD
+wBq
+dhn
+qur
+vKO
+cHi
 xYa
 xYa
 xYa
@@ -99546,13 +99740,13 @@ vnF
 vnF
 jdk
 jim
-jdk
-vgJ
-rDr
-bUM
-bUM
-bUM
-rDr
+cHi
+mAS
+vKO
+bQj
+bQj
+vKO
+cHi
 xYa
 xYa
 xYa
@@ -99748,13 +99942,13 @@ vnF
 jdk
 qhM
 sWL
-vgJ
-vgJ
-rDr
-bUM
-bUM
-bUM
-rDr
+cHi
+cHi
+dsu
+vKO
+vKO
+dsu
+cHi
 xYa
 xYa
 xYa
@@ -99764,7 +99958,7 @@ foL
 oBm
 foL
 foL
-aFX
+xVZ
 foL
 vuu
 aPS
@@ -99951,12 +100145,12 @@ jdk
 sWL
 vgJ
 vgJ
-vgJ
-rDr
-bUM
-bUM
-bUM
-rDr
+cHi
+cHi
+cHi
+cHi
+cHi
+cHi
 xYa
 xYa
 xYa
@@ -107494,7 +107688,7 @@ jdk
 bbk
 dhF
 fgn
-fwn
+fgn
 mPN
 wZp
 nLM
@@ -108890,7 +109084,7 @@ oXy
 oXy
 ylc
 ayy
-wIi
+elp
 jdk
 vnF
 jdk
@@ -128471,7 +128665,7 @@ acx
 fKD
 fKD
 mJB
-pwF
+bec
 uDB
 bec
 fKD
@@ -134494,12 +134688,12 @@ acx
 acx
 acx
 vgJ
-cHi
-cHi
-cHi
-cHi
-cHi
-cHi
+cYY
+cYY
+cYY
+cYY
+cYY
+cYY
 acx
 acx
 acx
@@ -134696,12 +134890,12 @@ acx
 acx
 acx
 vgJ
-cHi
+cYY
 jQY
 mBK
-yhJ
-uaz
-cHi
+nob
+ptm
+cYY
 acx
 acx
 acx
@@ -134898,12 +135092,12 @@ acx
 acx
 acx
 vgJ
-cHi
+cYY
 abb
-woR
-woR
-ieD
-cHi
+sYB
+sYB
+sYB
+mJo
 acx
 acx
 acx
@@ -135100,12 +135294,12 @@ acx
 acx
 acx
 vgJ
-cHi
-aci
-svn
-fLn
+cYY
+cYY
 sYB
-fiE
+sYB
+sYB
+cYY
 acx
 acx
 acx
@@ -135179,7 +135373,7 @@ xMB
 xMB
 bbw
 wbN
-xYu
+maf
 bAz
 iyN
 iyN
@@ -135302,15 +135496,15 @@ acx
 acx
 acx
 acx
-cHi
-baY
-baY
-cOl
+fdp
+cYY
+iRm
+kmz
 bEH
-cHi
-bbZ
-bbZ
-qnL
+cYY
+acx
+acx
+acx
 acx
 acx
 acx
@@ -135504,15 +135698,15 @@ acx
 acx
 acx
 acx
-cHi
-ujE
+fdp
+cYY
 xsq
-xsq
-dEk
-cHi
-gUL
-xfG
-gQs
+rya
+uwj
+cYY
+acx
+acx
+acx
 acx
 acx
 acx
@@ -135706,15 +135900,15 @@ hUg
 hUg
 hUg
 hUg
-mev
-cfD
-cfD
-cfD
-cfD
-vwW
-gUL
-gUL
-gQs
+fdp
+usb
+sYB
+qbG
+xfG
+cYY
+acx
+acx
+acx
 acx
 acx
 acx
@@ -135908,15 +136102,15 @@ acx
 acx
 acx
 acx
-cHi
-cHi
-kmz
-woR
-woR
-cHi
-gUL
-xfG
-gQs
+fdp
+cYY
+cYY
+gTi
+cYY
+cYY
+acx
+acx
+acx
 acx
 acx
 acx
@@ -136111,14 +136305,14 @@ acx
 acx
 acx
 acx
-cHi
+cYY
 kgk
-woR
-ekU
-cHi
-dpY
-dpY
-ddL
+sYB
+sYB
+tWh
+acx
+acx
+acx
 acx
 acx
 acx
@@ -136313,11 +136507,11 @@ acx
 acx
 acx
 acx
-cHi
-tSk
+cYY
+ufU
 rEq
-jSl
-cHi
+iJr
+cYY
 acx
 acx
 acx
@@ -136515,12 +136709,12 @@ acx
 acx
 acx
 acx
-cHi
-cHi
-mfF
-cHi
-cHi
-xcZ
+cYY
+cYY
+sIO
+cYY
+cYY
+acx
 acx
 acx
 acx
@@ -136923,11 +137117,11 @@ jZU
 rzJ
 rzJ
 rzJ
-jZU
-acx
-acx
-acx
-acx
+rDr
+bbZ
+bbZ
+bbZ
+qnL
 acx
 acx
 acx
@@ -137126,10 +137320,10 @@ rzJ
 rzJ
 rzJ
 rDr
-acx
-acx
-acx
-acx
+vKO
+vKO
+jLV
+gQs
 acx
 acx
 acx
@@ -137323,15 +137517,15 @@ acx
 acx
 acx
 acx
-cYY
-cYY
-sIO
-cYY
-cYY
-xcZ
-acx
-acx
-acx
+cHi
+cHi
+mfF
+cHi
+cHi
+vKO
+vKO
+vKO
+gQs
 acx
 acx
 acx
@@ -137525,16 +137719,16 @@ acx
 acx
 acx
 acx
-cYY
+cHi
 lnk
 vdh
 iAw
-cYY
-cYY
+cHi
+cHi
 dMz
-cYY
-cYY
-acx
+cHi
+cHi
+baY
 acx
 acx
 acx
@@ -137727,18 +137921,18 @@ acx
 acx
 acx
 acx
-cYY
+cHi
 sIp
-fPI
-gOb
-cYY
-teR
-jtP
-hNm
-cYY
-acx
-acx
-acx
+cfD
+cfD
+cfD
+cfD
+cfD
+sfm
+cHi
+cHi
+qPi
+cHi
 acx
 acx
 acx
@@ -137929,18 +138123,18 @@ acx
 acx
 acx
 acx
-cYY
+cHi
 tLG
-oJQ
-oJQ
-dZv
-jtP
-jtP
+cfD
+cfD
+cfD
+cfD
+sfm
+sfm
 qtB
-pzf
-acx
-acx
-acx
+sfm
+sfm
+fPI
 acx
 acx
 acx
@@ -138131,18 +138325,18 @@ acx
 acx
 acx
 acx
-cYY
+cHi
 hzl
-oJQ
+dZv
 vcP
-cYY
+aFX
 jtP
-jtP
-nob
-cYY
-acx
-acx
-acx
+sfm
+sfm
+sfm
+sfm
+sCl
+fPI
 acx
 acx
 acx
@@ -138333,18 +138527,18 @@ acx
 acx
 acx
 acx
-cYY
-mPD
-mOm
-tLm
-cYY
-ukg
+dpY
+cfD
+cfD
+vcP
+baY
 jtP
-jtP
-cYY
-acx
-acx
-acx
+sfm
+sfm
+ndY
+sfm
+mAr
+fPI
 acx
 acx
 acx
@@ -138534,19 +138728,19 @@ acx
 acx
 acx
 acx
-acx
-cYY
-uwj
-uwj
-uwj
-cYY
-dCv
+fdp
+cHi
 bMv
-sCl
-cYY
-acx
-acx
-acx
+cfD
+itF
+mIt
+dCv
+gVe
+nrT
+cHi
+cHi
+spo
+cHi
 acx
 acx
 acx
@@ -138735,18 +138929,18 @@ acx
 acx
 acx
 acx
-acx
-acx
-cYY
-cYY
-cYY
-cYY
-cYY
-cYY
-cYY
-cYY
-cYY
-acx
+fdp
+fdp
+cHi
+cHi
+fwn
+cHi
+cHi
+cHi
+cHi
+cHi
+cHi
+baY
 acx
 acx
 acx
@@ -138936,15 +139130,15 @@ acx
 acx
 acx
 acx
-acx
-acx
-acx
-rDr
-bUM
-bUM
-bUM
-rDr
-acx
+fdp
+fdp
+fdp
+cHi
+vKO
+vKO
+vKO
+cHi
+bvm
 acx
 acx
 acx
@@ -139138,14 +139332,14 @@ acx
 acx
 acx
 acx
-acx
-acx
-acx
-rDr
-bUM
-bUM
-bUM
-rDr
+fdp
+fdp
+fdp
+cHi
+uaz
+woR
+vKO
+cHi
 acx
 acx
 acx
@@ -139328,26 +139522,26 @@ xGB
 pGD
 xGB
 xGB
-acx
-acx
-acx
-acx
-acx
-acx
-acx
-acx
-acx
-acx
-acx
-acx
-acx
-acx
-acx
-rDr
-bUM
-bUM
-bUM
-rDr
+syB
+hUg
+hUg
+hUg
+hUg
+hUg
+hUg
+hUg
+hUg
+hUg
+hUg
+hUg
+rRW
+rRW
+rRW
+qPl
+woR
+woR
+woR
+fga
 acx
 acx
 acx
@@ -139526,6 +139720,11 @@ phh
 phh
 vwo
 xGB
+wzm
+hNm
+hNm
+hNm
+bdl
 acx
 acx
 acx
@@ -139537,19 +139736,14 @@ acx
 acx
 acx
 acx
-acx
-acx
-acx
-acx
-acx
-acx
-acx
-acx
-rDr
-bUM
-bUM
-bUM
-rDr
+fdp
+fdp
+fdp
+cHi
+pwF
+uYD
+xYu
+cHi
 acx
 acx
 acx
@@ -139744,13 +139938,13 @@ acx
 acx
 acx
 acx
-acx
-acx
+fdp
+fdp
 vgJ
 rDr
-bUM
-bUM
-bUM
+rDr
+rDr
+rDr
 rDr
 acx
 acx
@@ -139946,8 +140140,8 @@ acx
 acx
 acx
 acx
-acx
-acx
+fdp
+fdp
 vgJ
 rDr
 bUM
@@ -140203,7 +140397,7 @@ fdp
 ago
 oZg
 kfl
-efh
+cMN
 cMN
 cKz
 cKz
@@ -145852,7 +146046,7 @@ nlp
 aJF
 dUI
 dUI
-qPi
+gap
 gap
 eES
 hgf
@@ -146826,7 +147020,7 @@ acx
 acx
 acx
 azE
-eNR
+leC
 leC
 leC
 vMQ
@@ -147884,7 +148078,7 @@ wMs
 wMs
 wMs
 nDz
-kkY
+hPu
 wdv
 rqQ
 rqQ
@@ -148445,12 +148639,12 @@ vgJ
 vgJ
 vgJ
 hBm
-fdZ
+omB
 omB
 omB
 hBm
 dHg
-lzD
+aTT
 faF
 qxX
 gOC
@@ -178137,9 +178331,9 @@ iBK
 iBK
 iBK
 iBK
-acx
-acx
-acx
+iBK
+iBK
+iBK
 acx
 acx
 acx
@@ -178339,10 +178533,10 @@ iBK
 iBK
 iBK
 iBK
-acx
-acx
-acx
-acx
+iBK
+iBK
+iBK
+iBK
 acx
 acx
 acx
@@ -178541,10 +178735,10 @@ iBK
 iBK
 iBK
 iBK
-acx
-acx
-acx
-acx
+iBK
+iBK
+iBK
+iBK
 acx
 acx
 acx
@@ -178743,10 +178937,10 @@ iBK
 iBK
 iBK
 iBK
-acx
-acx
-acx
-acx
+iBK
+iBK
+iBK
+iBK
 acx
 acx
 acx
@@ -178945,9 +179139,9 @@ iBK
 iBK
 iBK
 iBK
-acx
-acx
-acx
+iBK
+iBK
+iBK
 acx
 acx
 acx

--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -1623,12 +1623,24 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "bbZ" = (
-/obj/structure/fluff/railing/border{
-	dir = 4;
-	icon_state = "border"
+/obj/structure/table/wood{
+	icon_state = "longtable_mid";
+	dir = 4
 	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
+/obj/item/key/warehouse{
+	pixel_x = 13;
+	pixel_y = 0
+	},
+/obj/item/key/warehouse{
+	pixel_x = -6;
+	pixel_y = 0
+	},
+/obj/item/key/warehouse{
+	pixel_x = 4;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/steward)
 "bcI" = (
 /obj/structure/table/church{
 	dir = 1;
@@ -2115,8 +2127,13 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/clinic_large)
 "bvm" = (
-/turf/closed/wall/mineral/rogue/stonebrick,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/metal{
+	icon_state = "plating2"
+	},
+/area/rogue/outdoors/town)
 "bvE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3588,9 +3605,14 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
 "cuB" = (
-/obj/machinery/light/rogue/torchholder,
-/turf/closed/wall/mineral/rogue/stonebrick,
-/area/rogue/outdoors/town)
+/obj/effect/landmark/start/steward{
+	dir = 8
+	},
+/obj/structure/chair/wood/rogue/chair_noble/purple{
+	dir = 8
+	},
+/turf/open/floor/rogue/metal/barograte,
+/area/rogue/indoors/town/steward)
 "cuC" = (
 /obj/structure/chair/stool/rogue,
 /obj/machinery/light/rogue/wallfire/candle{
@@ -4180,30 +4202,8 @@
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/outdoors/mountains)
 "cOl" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
-	},
-/obj/item/key/warehouse{
-	pixel_x = -12;
-	pixel_y = 16
-	},
-/obj/item/key/shops/shop1{
-	pixel_x = -1;
-	pixel_y = 16
-	},
-/obj/item/key/shops/shop2{
-	pixel_y = 16;
-	pixel_x = 9
-	},
-/obj/item/key/shops/shop3{
-	pixel_y = 4;
-	pixel_x = -13
-	},
-/obj/item/key/shops/shop4{
-	pixel_x = -1;
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/wood,
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/metal/barograte,
 /area/rogue/indoors/town/steward)
 "cOM" = (
 /obj/structure/flora/roguegrass/bush_meagre,
@@ -4516,8 +4516,27 @@
 /turf/open/floor/rogue/tile/masonic/spiral,
 /area/rogue/under/town/basement)
 "ddL" = (
-/obj/structure/fluff/wallclock/r,
-/turf/open/floor/rogue/wood,
+/obj/structure/table/wood{
+	icon_state = "longtable_mid";
+	dir = 4
+	},
+/obj/item/key/shops/shop4{
+	pixel_x = 13;
+	pixel_y = -10
+	},
+/obj/item/key/shops/shop3{
+	pixel_y = -10;
+	pixel_x = 3
+	},
+/obj/item/key/shops/shop2{
+	pixel_y = -10;
+	pixel_x = -7
+	},
+/obj/item/key/shops/shop1{
+	pixel_x = 14;
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/metal/barograte,
 /area/rogue/indoors/town/steward)
 "deB" = (
 /obj/structure/closet/crate/roguecloset/inn,
@@ -5446,10 +5465,8 @@
 /obj/structure/roguemachine/scomm{
 	pixel_y = -32
 	},
-/obj/structure/mineral_door/wood/window{
-	lockid = "steward";
-	name = "Steward's Balcony"
-	},
+/obj/structure/roguewindow/stained,
+/obj/structure/bars,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/steward)
 "dMG" = (
@@ -6643,9 +6660,14 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/church)
 "eys" = (
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/steward)
+/obj/structure/fluff/railing/border{
+	dir = 6;
+	icon_state = "border"
+	},
+/turf/open/floor/rogue/metal{
+	icon_state = "plating2"
+	},
+/area/rogue/outdoors/town)
 "eyC" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass/red,
@@ -9867,11 +9889,10 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/smithy)
 "gQs" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/bars,
+/obj/structure/roguewindow/stained,
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/steward)
 "gQM" = (
 /turf/closed/mineral/random/rogue/low_nonval,
 /area/rogue/under/town/caverogue)
@@ -10009,7 +10030,6 @@
 /obj/item/natural/feather,
 /obj/item/natural/feather,
 /obj/structure/closet/crate/chest,
-/obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/steward)
 "gVm" = (
@@ -10779,6 +10799,7 @@
 "hzl" = (
 /obj/structure/table/wood/nice/decorated,
 /obj/item/book/rogue/bookofpriests,
+/obj/item/roguemachine/mastermail,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/steward)
 "hzs" = (
@@ -13488,9 +13509,11 @@
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/indoors/town/dwarfin)
 "jry" = (
-/obj/structure/roguewindow/stained,
-/turf/closed/wall/mineral/rogue/stonebrick,
-/area/rogue/indoors/town/steward)
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/metal{
+	icon_state = "plating2"
+	},
+/area/rogue/outdoors/town)
 "jrL" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_x = 32;
@@ -13970,9 +13993,9 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/soilsons)
 "jLV" = (
-/obj/machinery/light/rogue/firebowl/standing,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/steward)
+/obj/structure/bars,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "jMs" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/neck/roguetown/psycross/silver{
@@ -14941,21 +14964,17 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
 "kpz" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable"
-	},
 /obj/item/key/apartments/apartment1{
-	pixel_x = -10;
-	pixel_y = 16
+	pixel_x = -9;
+	pixel_y = 14
 	},
 /obj/item/key/apartments/apartment2{
-	pixel_x = -2;
-	pixel_y = 16
+	pixel_x = 1;
+	pixel_y = 14
 	},
 /obj/item/key/apartments/apartment3{
-	pixel_x = 5;
-	pixel_y = 16
+	pixel_x = 10;
+	pixel_y = 14
 	},
 /obj/item/key/apartments/apartment4{
 	pixel_x = -11;
@@ -14969,7 +14988,11 @@
 	pixel_x = 8;
 	pixel_y = -1
 	},
-/turf/open/floor/rogue/wood,
+/obj/structure/table/wood{
+	icon_state = "longtable_mid";
+	dir = 4
+	},
+/turf/open/floor/rogue/metal/barograte,
 /area/rogue/indoors/town/steward)
 "kqi" = (
 /turf/open/floor/rogue/blocks/paving,
@@ -17349,6 +17372,15 @@
 "mor" = (
 /turf/open/floor/carpet/inn,
 /area/rogue/under/town/basement)
+"mov" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/metal{
+	icon_state = "plating2"
+	},
+/area/rogue/outdoors/town)
 "moV" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1;
@@ -17605,11 +17637,8 @@
 /turf/open/floor/rogue/carpet/green,
 /area/rogue/indoors/town/merc_guild)
 "mAr" = (
-/obj/structure/fluff/railing/border{
-	dir = 4;
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/church,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/metal/barograte,
 /area/rogue/indoors/town/steward)
 "mAS" = (
 /obj/structure/rack/rogue/shelf/biggest,
@@ -18049,11 +18078,7 @@
 /turf/closed/mineral/rogue,
 /area/rogue/outdoors/mountains)
 "mOm" = (
-/obj/effect/landmark/start/steward,
-/obj/structure/chair/wood/rogue/chair_noble/purple{
-	dir = 1
-	},
-/turf/open/floor/rogue/hexstone,
+/turf/open/floor/rogue/metal/barograte,
 /area/rogue/indoors/town/steward)
 "mOo" = (
 /obj/machinery/light/rogue/firebowl/standing,
@@ -18836,7 +18861,7 @@
 /obj/item/paper/scroll,
 /obj/item/paper/scroll,
 /obj/item/paper/scroll,
-/turf/open/floor/rogue/carpet,
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/steward)
 "nrZ" = (
 /obj/structure/roguewindow/openclose{
@@ -20896,7 +20921,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 5
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/metal/barograte,
 /area/rogue/indoors/town/steward)
 "oQW" = (
 /obj/structure/fluff/railing/wood{
@@ -21613,10 +21638,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/river)
 "ptT" = (
-/obj/structure/fluff/walldeco/steward,
-/turf/open/floor/rogue/metal{
-	icon_state = "plating2"
-	},
+/obj/structure/bars,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "ptV" = (
 /obj/machinery/light/rogue/torchholder{
@@ -22697,11 +22720,12 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/smithy)
 "qnL" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
+/obj/structure/giantfur/small{
+	pixel_x = -30;
+	pixel_y = -10
 	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/steward)
 "qnN" = (
 /obj/structure/stairs{
 	dir = 1
@@ -23380,11 +23404,11 @@
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town/manor)
 "qPi" = (
-/obj/structure/roguewindow/stained,
-/obj/structure/bars,
-/obj/structure/feedinghole,
-/turf/closed/wall/mineral/rogue/stonebrick,
-/area/rogue/indoors/town/steward)
+/obj/structure/fluff/walldeco/steward{
+	dir = 1
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town)
 "qPl" = (
 /obj/structure/roguewindow/openclose{
 	icon_state = "woodwindowdir"
@@ -25442,10 +25466,8 @@
 	},
 /area/rogue/outdoors/town)
 "spo" = (
-/obj/structure/roguewindow/stained,
-/obj/structure/bars,
-/obj/item/roguemachine/mastermail,
-/turf/closed/wall/mineral/rogue/stonebrick,
+/obj/structure/fluff/wallclock/l,
+/turf/open/floor/rogue/metal/barograte,
 /area/rogue/indoors/town/steward)
 "spw" = (
 /obj/structure/mineral_door/wood{
@@ -28216,6 +28238,11 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/sewer)
+"ufs" = (
+/obj/structure/bars,
+/obj/structure/bars,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "ufv" = (
 /obj/effect/landmark/tram/queued_path/cargo_pre_enter{
 	platform_code = "cargo_pre_enter";
@@ -31778,12 +31805,8 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
 "wIi" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
-	},
 /obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/steward)
 "wIn" = (
 /obj/structure/table/wood{
@@ -56727,7 +56750,7 @@ lwU
 nYn
 nYn
 lwU
-oZQ
+nYn
 oZQ
 vgJ
 vgJ
@@ -56928,9 +56951,9 @@ mgj
 nYn
 mgj
 nYn
-oZQ
-oZQ
-oZQ
+nYn
+nYn
+nYn
 vgJ
 vgJ
 vgJ
@@ -57129,10 +57152,10 @@ vMb
 oZQ
 nYn
 oZQ
-dSR
-oZQ
-oZQ
-mLm
+xfD
+nYn
+nYn
+nYn
 vgJ
 vgJ
 vgJ
@@ -57331,10 +57354,10 @@ nYn
 nYn
 vMb
 nYn
-mLm
-mLm
+nYn
+nYn
 vMb
-oZQ
+nYn
 vgJ
 vgJ
 vgJ
@@ -57533,8 +57556,8 @@ nYn
 nYn
 nYn
 lwU
-mLm
-mLm
+nYn
+nYn
 vMb
 vMb
 vgJ
@@ -57735,8 +57758,8 @@ nYn
 nYn
 nYn
 vMb
-mLm
-mLm
+nYn
+nYn
 nYn
 vMb
 vgJ
@@ -57937,10 +57960,10 @@ lwU
 xfD
 nYn
 xfD
-dSR
-oZQ
-oZQ
-oZQ
+xfD
+nYn
+nYn
+nYn
 vgJ
 vgJ
 vgJ
@@ -58139,10 +58162,10 @@ xfD
 mgj
 xfD
 ilQ
-oZQ
-oZQ
-oZQ
-oZQ
+nYn
+nYn
+nYn
+nYn
 vgJ
 vgJ
 vgJ
@@ -58342,9 +58365,9 @@ dSR
 nYn
 oZQ
 xfD
-oZQ
-oZQ
-oZQ
+nYn
+nYn
+nYn
 vgJ
 vgJ
 vgJ
@@ -58545,7 +58568,7 @@ nYn
 nYn
 vMb
 nYn
-oZQ
+nYn
 oZQ
 vgJ
 vgJ
@@ -96716,13 +96739,13 @@ fBj
 dkS
 sgJ
 dkS
+uSV
 fBj
+uSV
 fBj
+uSV
 fBj
-fBj
-fBj
-fBj
-fBj
+uSV
 elp
 lsl
 lsl
@@ -96919,9 +96942,9 @@ dkS
 iAj
 dkS
 tDS
-tDS
-tDS
-tDS
+bvm
+jvH
+eys
 tDS
 tDS
 tDS
@@ -97121,16 +97144,16 @@ cNH
 cNH
 cNH
 cHi
+mov
+uSV
+jry
+qPi
 iSk
-iSk
-iSk
-iSk
-iSk
-lKX
-lsl
-lsl
-lsl
-lsl
+jLV
+jLV
+jLV
+jLV
+jLV
 lsl
 elp
 ehF
@@ -97323,17 +97346,17 @@ awF
 lCI
 fSW
 cHi
-cHi
-jry
-jry
+efh
+iQo
+hMz
 cHi
 oyq
 iSk
 iSk
 iSk
 iSk
-lsl
-lsl
+lKX
+jLV
 lsl
 lsl
 elp
@@ -97524,18 +97547,18 @@ cHi
 lzD
 vKO
 vKO
-ieD
-eys
-vKO
-vKO
-vKO
+mAr
+pYz
+cuB
+pYz
+spo
 cHi
 iSk
 iSk
 iSk
-cuB
-lsl
-elp
+iSk
+jdk
+ptT
 lsl
 jnz
 mBz
@@ -97728,16 +97751,16 @@ vKO
 ulo
 cGr
 oQP
-vKO
-vKO
 pYz
-efh
-tPF
-tPF
-tPF
-ptT
-elp
-lsl
+mOm
+pYz
+hMz
+iSk
+iSk
+iSk
+iSk
+jdk
+jLV
 lsl
 xcZ
 oXQ
@@ -97931,15 +97954,15 @@ qRf
 mls
 cHi
 cOl
-vKO
+qnL
 mOm
-iQo
-fBj
-fBj
-fBj
-fBj
-lsl
-ehF
+hMz
+iSk
+iSk
+iSk
+iSk
+jdk
+bDU
 lsl
 xcZ
 sWL
@@ -98133,15 +98156,15 @@ qRf
 aFX
 cHi
 wIi
-vKO
+mOm
 pYz
-hMz
-tDS
-tDS
-tDS
-tDS
-lsl
-ehF
+cHi
+iSk
+iSk
+iSk
+iSk
+lKX
+ufs
 ehF
 mev
 azo
@@ -98335,15 +98358,15 @@ vKO
 vKO
 cHi
 kpz
-vKO
+bbZ
 ddL
 cHi
 iSk
 iSk
 iSk
 iSk
-lsl
-lsl
+jdk
+jLV
 elp
 ehF
 lsl
@@ -137118,10 +137141,10 @@ rzJ
 rzJ
 rzJ
 rDr
-bbZ
-bbZ
-bbZ
-qnL
+acx
+acx
+acx
+acx
 acx
 acx
 acx
@@ -137320,10 +137343,10 @@ rzJ
 rzJ
 rzJ
 rDr
-vKO
-vKO
-jLV
-gQs
+acx
+acx
+acx
+acx
 acx
 acx
 acx
@@ -137522,10 +137545,10 @@ cHi
 mfF
 cHi
 cHi
-vKO
-vKO
-vKO
-gQs
+acx
+acx
+acx
+acx
 acx
 acx
 acx
@@ -137931,8 +137954,8 @@ cfD
 sfm
 cHi
 cHi
-qPi
-cHi
+acx
+acx
 acx
 acx
 acx
@@ -138132,9 +138155,9 @@ cfD
 sfm
 sfm
 qtB
-sfm
-sfm
-fPI
+gQs
+acx
+acx
 acx
 acx
 acx
@@ -138333,10 +138356,10 @@ aFX
 jtP
 sfm
 sfm
-sfm
-sfm
 sCl
-fPI
+gQs
+acx
+acx
 acx
 acx
 acx
@@ -138536,9 +138559,9 @@ jtP
 sfm
 sfm
 ndY
-sfm
-mAr
 fPI
+acx
+acx
 acx
 acx
 acx
@@ -138739,8 +138762,8 @@ gVe
 nrT
 cHi
 cHi
-spo
-cHi
+acx
+acx
 acx
 acx
 acx
@@ -139138,7 +139161,7 @@ vKO
 vKO
 vKO
 cHi
-bvm
+ovX
 acx
 acx
 acx
@@ -178129,7 +178152,7 @@ iBK
 iBK
 iBK
 iBK
-acx
+iBK
 acx
 acx
 acx
@@ -178332,8 +178355,8 @@ iBK
 iBK
 iBK
 iBK
-iBK
-iBK
+acx
+acx
 acx
 acx
 acx
@@ -178534,9 +178557,9 @@ iBK
 iBK
 iBK
 iBK
-iBK
-iBK
-iBK
+acx
+acx
+acx
 acx
 acx
 acx
@@ -178736,9 +178759,9 @@ iBK
 iBK
 iBK
 iBK
-iBK
-iBK
-iBK
+acx
+acx
+acx
 acx
 acx
 acx
@@ -178938,9 +178961,9 @@ iBK
 iBK
 iBK
 iBK
-iBK
-iBK
-iBK
+acx
+acx
+acx
 acx
 acx
 acx
@@ -179140,8 +179163,8 @@ iBK
 iBK
 iBK
 iBK
-iBK
-iBK
+acx
+acx
 acx
 acx
 acx
@@ -179341,7 +179364,7 @@ iBK
 iBK
 iBK
 iBK
-acx
+iBK
 acx
 acx
 acx

--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -139161,7 +139161,7 @@ vKO
 vKO
 vKO
 cHi
-ovX
+acx
 acx
 acx
 acx


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

This PR reworks the Steward and Gatekeeper's places to swap them both in order to allow access to the outside without the the problem of constant traffic through the gatekeep.

Adds a few more keys to the Stewards office, including:
>Walls, Soilson, Tailor's, Forrest Garrison, Clinic.

Also adds a few more additions to the Steward's office, Including:
>Meeting Room
>Reworked Balcony
>Bookshelfs
>Additional Scrolls, Parchments, Feathers
>Reworked Bedroom
>Reworked Nervemaster Room
>Halfcloak, Raincloak, and Extra (empty) Pouch

Gatekeep has been reworked as well, new additions include:
>One additional Weaponspawner
>One additional Armorspawner
>Deck of cards and Die
>Two crossbows
>Two Bolt Quivers

Unfortunately, this rework minimizes the small park in the center, reducing it to two trees. The bench and waterfountain have also been deleted.
![image](https://github.com/user-attachments/assets/6ad8af70-6d8c-4271-8197-2cb6a3969f7e)
![image](https://github.com/user-attachments/assets/0bb29bff-5f8b-43f4-999c-6ef541ba2e95)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

This rework opens up the Steward to be able to be normally accessible by the public, like the Merchant/Smithy. The Steward is supposed to coordinate the Keep's mammon, including handing out loans and key replacements. This task proved to be difficult with the constant traffic and hustle of the gate, hence the rework. The additional rooms the Steward has also opens up the door for more spaces to RP in. Hopefully with this update, the Steward will see more RP and fun.

The Gatekeep has also been reworked as a result of this, turning the atmosphere into a more shitty cramped area, as is expected of a gate. The common trend of weapon revoking is still honored here, with racks placed upstairs. Thieves now can break into the Gatekeep in a second way, through where previously how one would break into a Steward's Office. The racks stored up here allows thieves to also steal weaponry if the Gatekeep isn't attentive enough.

This update also reduces the amount of wells in Vanderlin to one. This makes acquiring water more tedious with the reduction of wells to the western side of the Town. Hopefully more usage of water barrels will come as a result of this.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
