### PR TITLE
Change of vamp/cult telepathy styles

### DIFF
--- a/code/modules/antagonists/roguetown/villain/vampirelord.dm
+++ b/code/modules/antagonists/roguetown/villain/vampirelord.dm
@@ -436,15 +436,17 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 	set category = "VAMPIRE"
 
 	var/datum/game_mode/chaosmode/C = SSticker.mode
+	var/mob/living/carbon/human/H = src
 	var/msg = input("Send a message.", "Command") as text|null
+	var/message = "<span style = \"font-size:110%; font-weight:bold\"><span style = 'color:#960000'>A message from </span><span style = 'color:#[H.voice_color]'>[src.real_name]</span><span class = 'hellspeak'>: [msg]</span></span>"
 	if(!msg)
 		return
 	for(var/datum/mind/V in C.vampires)
-		to_chat(V, span_boldnotice("A message from [src.real_name]:[msg]"))
+		to_chat(V, message)
 	for(var/datum/mind/D in C.deathknights)
-		to_chat(D, span_boldnotice("A message from [src.real_name]:[msg]"))
+		to_chat(D, message)
 	for(var/mob/dead/observer/rogue/arcaneeye/A in GLOB.mob_list)
-		to_chat(A, span_boldnotice("A message from [src.real_name]:[msg]"))
+		to_chat(A, message)
 
 /mob/living/carbon/human/proc/punish_spawn()
 	set name = "Punish Minion"

--- a/code/modules/antagonists/roguetown/villain/zizocult.dm
+++ b/code/modules/antagonists/roguetown/villain/zizocult.dm
@@ -183,6 +183,7 @@ GLOBAL_LIST_EMPTY(ritualslist)
 
 	if(stat >= UNCONSCIOUS || !can_speak_vocal())
 		return
+	var/mob/living/carbon/human/H = src
 	var/datum/game_mode/chaosmode/C = SSticker.mode
 	var/speak = input("What do you speak of?", "VANDERLIN") as text|null
 	if(!speak)
@@ -194,7 +195,7 @@ GLOBAL_LIST_EMPTY(ritualslist)
 	whisper("[speak]")
 
 	for(var/datum/mind/V in C.cultists)
-		to_chat(V, "<span class='boldnotice'>A message from [src.real_name]: \"[speak]\"</span>")
+		to_chat(V, "<span style = \"font-size:110%; font-weight:bold\"><span style = 'color:#8a13bd'>A message from </span><span style = 'color:#[H.voice_color]'>[src.real_name]</span>: [speak]</span>")
 		playsound_local(V.current, 'sound/vo/cult/skvor.ogg', 100)
 
 	testing("[key_name(src)] used cultist telepathy to say: [speak]")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
Just a slight change in styles of vampire and cultists telepathy text from godawful yellow to something like this

![scr1](https://github.com/user-attachments/assets/ae3ac735-7261-4fc7-86bd-eb82a0b573a3)
![scr2](https://github.com/user-attachments/assets/10898fe9-3697-4501-bda4-6cf78f3a268e)

<!-- Describe 
The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
Old yellow text was super easy to miss in the countless action messages that had almost the same color as telepathy. Now it would be easier to read it and determine from who message comes from, since it have the color of person's voice.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
