### PR TITLE
Fixes how water turfs deal with extinguish by forcing them through So…

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -111,7 +111,11 @@
 				T.pollution.smell_act(src)
 
 /mob/living/proc/handle_inwater(turf/open/water/W)
-	ExtinguishMob()
+	if(lying || W.water_level == 3)
+		SoakMob(FULL_BODY)
+	else
+		if(W.water_level == 2)
+			SoakMob(BELOW_CHEST)
 
 /mob/living/carbon/handle_inwater(turf/open/water/W)
 	..()


### PR DESCRIPTION
…akMob

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
Water tiles used to hard call Extinguish via the handle_inwater proc. This made walking on any water tile kill your torch. This changes it so it only happens if you are lying down on the water tile (by default all water tiles assume you are waist height anyway).

Some quirks: This now means to put yourself out with water you have to lie down in the water. If you want I guess I could try changing this around so if you are on fire just being in water extinguishes you but it would mean fucking around with the extinguish code itself because it will try to extinguish everything on the mob (this includes your inhand torch). You can lie down, go in and out of the water before you start to drown if you really want to maximize your use of water for fire purposes otherwise it waits for the carbon tick to do it. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
Crossing a river or being in the sewers with a torch is pointless. This makes it so you can enter both of those without fear of the torch going out. It might give people more false sense of security with the torch, until they fall over in water and everything goes dark.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
