### PR TITLE
(FIX/BALANCE) Lower STR requirement for wooden staff by 1 (MAGES IN AWE)

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -131,7 +131,7 @@
 	sharpness = IS_BLUNT
 	max_integrity = 200
 	wdefense = ULTMATE_PARRY
-	minstr = 6
+	minstr = 5
 	sellprice = 5
 
 /obj/item/rogueweapon/polearm/woodstaff/getonmobprop(tag)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

Lowers STR requirement of wooden staves from 6 to 5.

## Why It's Good For The Game

Apparently mages can start dropping their staves the moment they get hungry. We don't want to give mages strength, so lowering the STR requirement for the staff by 1 is an easy fix.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
