### PR TITLE
Nuked Jailor, Increased PQ requirements, added an additonal Tailor Slot

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/court_hand.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/court_hand.dm
@@ -3,7 +3,7 @@
 	total_positions = 2
 	spawn_positions = 2
 	tutorial = "Whether acquired by merit, shrewd negotiation or fulfilled bounties, you have found yourself under the underhanded employ of the Hand. Fulfill desires and whims of the court that they would rather not be publicly known. Your position is anything but secure, and any mistake can leave you disowned and charged like the petty criminal are. Garrison and Court members know who you are."
-	min_pq = 8
+	min_pq = 10
 	always_show_on_latechoices = FALSE
 	job_reopens_slots_on_death = FALSE
 	shows_in_list = FALSE

--- a/code/modules/jobs/job_types/roguetown/apprentices/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/apprentices/prince.dm
@@ -26,7 +26,7 @@
 	display_order = JDO_PRINCE
 	give_bank_account = TRUE
 	bypass_lastclass = TRUE
-	min_pq = 1
+	min_pq = 4
 
 	can_have_apprentices = FALSE
 

--- a/code/modules/jobs/job_types/roguetown/church/adept.dm
+++ b/code/modules/jobs/job_types/roguetown/church/adept.dm
@@ -23,7 +23,7 @@
 	advclass_cat_rolls = list(CTAG_ADEPT = 20)
 	display_order = JDO_SHEPHERD
 	bypass_lastclass = TRUE
-	min_pq = 0
+	min_pq = 5
 	can_have_apprentices = FALSE
 
 /datum/outfit/job/roguetown/adept

--- a/code/modules/jobs/job_types/roguetown/church/inquisitor.dm
+++ b/code/modules/jobs/job_types/roguetown/church/inquisitor.dm
@@ -20,7 +20,7 @@
 
 	outfit = /datum/outfit/job/roguetown/inquisitor
 	display_order = JDO_PURITAN
-	min_pq = 8
+	min_pq = 15
 	bypass_lastclass = TRUE
 	cmode_music = 'sound/music/cmode/church/CombatInquisitor.ogg'
 

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -23,7 +23,7 @@
 	display_order = JDO_PRIEST
 	give_bank_account = 115
 	cmode_music = 'sound/music/cmode/church/CombatAstrata.ogg'
-	min_pq = 10
+	min_pq = 20
 	selection_color = "#c2a45d"
 	spells = list(
 		/obj/effect/proc_holder/spell/self/convertrole/templar,

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -17,7 +17,7 @@
 	spawn_positions = 2
 	display_order = JDO_TEMPLAR
 	give_bank_account = 0
-	min_pq = 4
+	min_pq = 8
 
 /datum/outfit/job/roguetown/templar
 	name = "Templar"

--- a/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
@@ -24,7 +24,7 @@
 
 	outfit = /datum/outfit/job/roguetown/dungeoneer
 	give_bank_account = 50
-	min_pq = 6
+	min_pq = 10
 
 	cmode_music = 'sound/music/cmode/nobility/CombatDungeoneer.ogg'
 

--- a/code/modules/jobs/job_types/roguetown/garrison/forestwarden.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/forestwarden.dm
@@ -22,7 +22,7 @@
 	selection_color = "#0d6929"
 	outfit = /datum/outfit/job/roguetown/forestwarden
 	give_bank_account = 45
-	min_pq = 5
+	min_pq = 8
 	cmode_music = 'sound/music/cmode/garrison/CombatForestGarrison.ogg'
 
 /datum/outfit/job/roguetown/forestwarden/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/roguetown/garrison/jailor.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/jailor.dm
@@ -4,8 +4,8 @@
 	department_flag = GARRISON
 	display_order = JDO_JAILOR
 	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	tutorial = "Your eyes have laid bare upon true terror in the Crimson Valley Asylum - men, ripping apart one another for \
 	their own entertainment - not for sport, not for sadism, for blood. You now live in this kingdom - a quiet peaceful place \
 	compared to the Asylum you once warded, having once kept bloodthirsty churls locked in the dark."

--- a/code/modules/jobs/job_types/roguetown/nobility/captain.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/captain.dm
@@ -21,7 +21,7 @@
 	bypass_lastclass = TRUE
 	outfit = /datum/outfit/job/roguetown/captain
 	give_bank_account = 120
-	min_pq = 8
+	min_pq = 15
 
 	cmode_music = 'sound/music/cmode/antag/CombatSausageMaker.ogg'
 

--- a/code/modules/jobs/job_types/roguetown/nobility/hand.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/hand.dm
@@ -19,7 +19,7 @@
 	bypass_lastclass = TRUE
 	whitelist_req = FALSE
 	give_bank_account = 120
-	min_pq = 8
+	min_pq = 10
 
 /*
 /datum/job/roguetown/hand/special_job_check(mob/dead/new_player/player)

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -24,7 +24,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	tutorial = "Elevated upon your throne through a web of intrigue and political upheaval, you are the absolute authority of these lands and at the center of every plot within it. Every man, woman and child is envious of your position and would replace you in less than a heartbeat: Show them the error in their ways."
 	bypass_lastclass = TRUE
 	whitelist_req = FALSE
-	min_pq = 15
+	min_pq = 25
 	give_bank_account = 500
 	selection_color = "#7851A9"
 

--- a/code/modules/jobs/job_types/roguetown/other/mercenary.dm
+++ b/code/modules/jobs/job_types/roguetown/other/mercenary.dm
@@ -25,7 +25,7 @@
 	display_order = JDO_MERCENARY
 	bypass_lastclass = TRUE
 	give_bank_account = 3
-	min_pq = 2
+	min_pq = 5
 	outfit = null
 	outfit_female = null
 	advclass_cat_rolls = list(CTAG_MERCENARY = 20)

--- a/code/modules/jobs/job_types/roguetown/peasants/hunter.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/hunter.dm
@@ -19,7 +19,7 @@
 		"Half-Orc"
 	)
 	outfit = /datum/outfit/job/roguetown/hunter
-	min_pq = -100
+	min_pq = 0
 	give_bank_account = 15
 	display_order = JDO_HUNTER
 	total_positions = 4

--- a/code/modules/jobs/job_types/roguetown/peasants/jester.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/jester.dm
@@ -26,7 +26,7 @@
 	outfit = /datum/outfit/job/roguetown/jester
 	display_order = JDO_JESTER
 	bypass_lastclass = TRUE
-	min_pq = -20
+	min_pq = 5
 	give_bank_account = TRUE
 
 /datum/outfit/job/roguetown/jester/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/roguetown/serfs/tailor.dm
+++ b/code/modules/jobs/job_types/roguetown/serfs/tailor.dm
@@ -6,8 +6,8 @@
 	faction = "Station"
 	tutorial = "Cloth, linen, silk and leather. You've tirelessly studied and poured your life into \
 				sewing articles of protection, padding, and fashion for serf and noble alike."
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 2
+	spawn_positions = 2
 	allowed_races = ALL_PLAYER_RACES_BY_NAME
 	give_bank_account = TRUE
 	bypass_lastclass = TRUE

--- a/code/modules/jobs/job_types/roguetown/youngfolk/orphan.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/orphan.dm
@@ -14,7 +14,7 @@
 	outfit = /datum/outfit/job/roguetown/orphan
 	display_order = JDO_ORPHAN
 	show_in_credits = FALSE
-	min_pq = -30
+	min_pq = 2
 	cmode_music = 'sound/music/cmode/towner/CombatTowner.ogg'
 	can_have_apprentices = FALSE
 	bypass_lastclass = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

Increases PQ Requirements for certain roles as requested by Ook

Monarch: 25
Priest: 20
Captain, and sheriff when it is added: 15
Inquisitor: 15
Dungeoneer: 10
Hand: 10
Court Agent: 10
Templar: 8
Adept: 5
Orphan: 2
Prince: 4
Warden: 8
Mercenary: 5
Hunter: 0
Jester: 5

Adds an additional Job Slot for Tailor, for a total of 2

Removes Jailor in a very scuffed way (Just has 0 job slots available)

## Why It's Good For The Game

Increased PQ should help fix some moderation issues, as the roles now require a higher amount of overall player roleplay and playtime. No more bows for shitters with - PQ

Additonal job slot for Tailor should manage workload better

Jailor sucks, his life serves 0 purpose, therefore he has been nuked in the most scuffed way I can.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
