### PR TITLE
Fix profane dagger's examine text not working correctly

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -527,6 +527,8 @@
 
 	// The Assassin's profane dagger can sniff out their targets, even masked.
 	if(HAS_TRAIT(user, TRAIT_ASSASSIN) && ((has_flaw(/datum/charflaw/hunted) || HAS_TRAIT(src, TRAIT_ZIZOID_HUNTED))))
+		if (src == user)
+			return
 		for(var/obj/item/I in user.get_all_gear())
 			if(istype(I, /obj/item/rogueweapon/knife/dagger/steel/profane))
 				. += "profane dagger whispers, <span class='danger'>\"That's [real_name]! Strike their heart!\"</span>"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -527,7 +527,7 @@
 
 	// The Assassin's profane dagger can sniff out their targets, even masked.
 	if(HAS_TRAIT(user, TRAIT_ASSASSIN) && ((has_flaw(/datum/charflaw/hunted) || HAS_TRAIT(src, TRAIT_ZIZOID_HUNTED))))
-		for(var/obj/item/I in get_all_gear())
+		for(var/obj/item/I in user.get_all_gear())
 			if(istype(I, /obj/item/rogueweapon/knife/dagger/steel/profane))
 				. += "profane dagger whispers, <span class='danger'>\"That's [real_name]! Strike their heart!\"</span>"
 				break


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
Currently it checks if the examined atom has the dagger... Now it will check the assassin and not tell the assassin to stab themselves.

Sidenote I hate the examine code.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
Broken feature.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [] You tested this on a local server.
- [] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
