### PR TITLE
Knightly knights

### DIFF
--- a/code/modules/jobs/job_types/garrison/royalguard.dm
+++ b/code/modules/jobs/job_types/garrison/royalguard.dm
@@ -21,7 +21,7 @@
 	bypass_lastclass = TRUE
 
 	outfit = /datum/outfit/job/royalguard
-	give_bank_account = 30
+	give_bank_account = 60
 	min_pq = 8
 	selection_color = "#920909"
 
@@ -64,18 +64,16 @@
 	backr = /obj/item/storage/backpack/satchel
 	backl = /obj/item/weapon/shield/tower/metal
 	r_hand = /obj/item/weapon/polearm/halberd
-	if(prob(30))
-		head = /obj/item/clothing/head/helmet/visored/knight
-	else
-		head = /obj/item/clothing/head/helmet/sallet
+	head = /obj/item/clothing/head/helmet/visored/knight
+	gloves = /obj/item/clothing/gloves/plate
 
 	if(H.mind)
 		H.mind?.adjust_skillrank(/datum/skill/combat/bows, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/crossbows, 3, TRUE)
-		H.mind?.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/wrestling, 5, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE)
-		H.mind?.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
-		H.mind?.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/swords, 5, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/polearms, 5, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/axesmaces, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/shields, 4, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
Makes royal knights from expert(same as forest guard/men at arms) to masterlevel swords/polearm fighters and wrestlers and replaces the open helmet lottery with a full helmet and gauntlets for a fully covered knight + from 30(average guard pay) to 60 in their bank.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
These are supposed to be the kings chosen knights along with the captain whos more of a general. This will let them to be more of the kings champeons in terms of duels etc.

They also have squires attached to them so right now two fairly average fighters have their own errand boys who can only get 1up for their melee skill from them in return, Ie it will make the synergy of master and apprentice between squire and knight better.

Balance wise they are a bodyguard role or kings retainer role. So they dont usually go attack antags etc unless ordered which would leave the king open ie they are more of a last line of defence instead of part of the mob that rush antags.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
