### PR TITLE
More Info about Spouses

### DIFF
--- a/code/datums/heritage.dm
+++ b/code/datums/heritage.dm
@@ -384,7 +384,7 @@
 	set name = "List Family"
 	set category = "Memory"
 	if(spouse_mob)
-		to_chat(src, span_info("[spouse_mob.real_name] is the name of your lover."))
+		to_chat(src, span_info("[spouse_mob.real_name] the [spouse_mob.dna.species.id] [spouse_mob.mind.assigned_role] is your lover."))
 	if(family_datum)
 		family_datum.ListFamily(src)
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

+ Adds race and job information to the family list of who the players spouse is. So it will list Name, race, and Job titel of the spouse.

## Why It's Good For The Game

The family stuff is purley for RP. But currently, if you are married, you only know the name of your partner. You do not even get a hint where they could be on the map. So your shit out of luck if you want to find them, better hope you know them ooc or you run past them by accident.

this way it should be far far easier to find once spouse. Race and job of them, should already be common knowledge to the palyers character anyway. Being that your married and all.
This way you can even start RPing properly as married, even before you met your spouse that round.
And most importantly, you be able to find them very easily. If you know your spouse is the inkeeper, you can find them fast.

Yes, this is a spite pr. How did you know?

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
