### PR TITLE
Underdweller gear update

### DIFF
--- a/code/modules/jobs/job_types/other/merc_classes/underdweller.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/underdweller.dm
@@ -20,7 +20,6 @@
 		/obj/item/clothing/suit/roguetown/shirt/undershirt/sailor/red = 1))//sailor shirt
 	pants = /obj/item/clothing/under/roguetown/trou/leather
 	armor = /obj/item/clothing/suit/roguetown/armor/cuirass/iron
-	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/sailor/red
 	shirt = shirt_type
 	shoes = /obj/item/clothing/shoes/roguetown/boots/armor/light
 	belt = /obj/item/storage/belt/leather/mercenary

--- a/code/modules/jobs/job_types/other/merc_classes/underdweller.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/underdweller.dm
@@ -12,10 +12,17 @@
 
 /datum/outfit/job/mercenary/underdweller/pre_equip(mob/living/carbon/human/H)
 	..()
-	pants = /obj/item/clothing/pants/trou/leather
-	armor = /obj/item/clothing/armor/cuirass/iron
-	shirt = /obj/item/clothing/shirt/undershirt/sailor/red
-	shoes = /obj/item/clothing/shoes/simpleshoes/buckle
+
+	var/shirt_type = pickweight(list(
+		/obj/item/clothing/suit/roguetown/armor/chainmail/iron = 1,//iron maille
+		/obj/item/clothing/suit/roguetown/armor/gambeson = 4,//gambeson
+		/obj/item/clothing/suit/roguetown/armor/gambeson/light = 4,//light gambeson
+		/obj/item/clothing/suit/roguetown/shirt/undershirt/sailor/red = 1))//sailor shirt
+	pants = /obj/item/clothing/under/roguetown/trou/leather
+	armor = /obj/item/clothing/suit/roguetown/armor/cuirass/iron
+	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/sailor/red
+	shirt = shirt_type
+	shoes = /obj/item/clothing/shoes/roguetown/boots/armor/light
 	belt = /obj/item/storage/belt/leather/mercenary
 	beltr = /obj/item/weapon/knife/hunting
 	neck = /obj/item/clothing/neck/chaincoif/iron
@@ -50,6 +57,7 @@
 		H.mind?.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 
 		beltl = /obj/item/weapon/sword/sabre // Dark elves get a sabre as their primary weapon and swords skill, who woulda thought
+		head = /obj/item/clothing/head/helmet/leather//similar to the miner helm, except not as cool of course
 
 	H.merctype = 3
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

Upgrades underdweller gear by giving them light plate boots, and a maille/gambeson/lightgambeson/shirt (randomly chosen) instead of just the shirt.
Delf underdweller's are also given a leather helmet, since otherwise they start with none.

## Why It's Good For The Game

Underdweller is barely picked, due to having notably worse gear than other mercenary classes. This tries to allevate this issue by giving them some more armour, though still iron rather than steel as compared to other classes.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
