### PR TITLE
Removes "Cure rot" from the Priest

### DIFF
--- a/code/controllers/subsystem/devotion.dm
+++ b/code/controllers/subsystem/devotion.dm
@@ -110,7 +110,7 @@
 		return
 
 	var/datum/patron/A = H.patron
-	var/list/spelllist = list(/obj/effect/proc_holder/spell/targeted/touch/orison, A.t0, A.t1, A.t2, A.t3, /obj/effect/proc_holder/spell/invoked/cure_rot)
+	var/list/spelllist = list(/obj/effect/proc_holder/spell/targeted/touch/orison, A.t0, A.t1, A.t2, A.t3)
 	for(var/spell_type in spelllist)
 		if(!spell_type || H.mind.has_spell(spell_type))
 			continue


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

* Removes "cure rot" spell as a spell Priests gain on spawn.

## Why It's Good For The Game

Player culture around the priest is, pretty bad currently.
All priest players get to do in a round, is be the round defibrilator.
Dead are mindlessly piled next to the altar, because the priest can revive them without problem.
Why worry about rot, the priest can just get rid of it.

THe priest is every round working on a conga line of rotten and dead people, because they are only seen by players as a tool to get back into the round.
It is so bad, undead walk into the church to be cured of rot.

Death has incredibly little meaning curently, by how easy it is to undo.
Wich sucks. For the priest, and the overall experince.

Nay i say. Let death have an impact.
Death should have consequences.
Let the skill floor rise from the mariana trench, where it lays for too long.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
