### PR TITLE
(BALANCE) Eagle Beak, Estoc and Dagger Rebalance + Proper usage of weapon defines

### DIFF
--- a/code/__DEFINES/weapons.dm
+++ b/code/__DEFINES/weapons.dm
@@ -48,6 +48,7 @@
 #define AP_POLEARM_CHOP 20
 #define AP_SWORD_THRUST 20
 #define AP_SWORD_CHOP 5
+#define AP_WHIP_LASH 5
 
 //wdefense defines
 #define TERRIBLE_PARRY -1

--- a/code/game/objects/items/weapons/melee/axes.dm
+++ b/code/game/objects/items/weapons/melee/axes.dm
@@ -81,8 +81,6 @@
 	icon_state = "stoneaxe"
 	max_blade_int = 50
 	max_integrity = 50
-	wdefense = BAD_PARRY
-
 	wbalance = EASY_TO_DODGE
 	wlength = WLENGTH_SHORT
 	smeltresult = /obj/item/ash //is a wooden log and a stone hammered in the top
@@ -307,7 +305,7 @@
 	associated_skill = /datum/skill/combat/axesmaces
 	dropshrink = 0.95
 	minstr = 10
-	wdefense = 3
+	wdefense = GOOD_PARRY
 	axe_cut = 15
 	sellprice = 20
 
@@ -328,8 +326,8 @@
 
 /obj/item/weapon/axe/boneaxe
 	slot_flags = ITEM_SLOT_HIP | ITEM_SLOT_BACK
-	force = 18
-	force_wielded = 22
+	force = DAMAGE_AXE-2 //18 total
+	force_wielded = DAMAGE_AXE_WIELD-3 //22 total
 	possible_item_intents = list(/datum/intent/axe/cut,/datum/intent/axe/chop)
 	name = "bone axe"
 	desc = "A rough axe made of bones"
@@ -342,7 +340,7 @@
 	associated_skill = /datum/skill/combat/axesmaces
 	max_blade_int = 100
 	minstr = 8
-	wdefense = 1
+	wdefense = MEDIOCHRE_PARRY
 	w_class = WEIGHT_CLASS_BULKY
 	wlength = WLENGTH_SHORT
 	pickup_sound = 'sound/foley/equip/rummaging-03.ogg'

--- a/code/game/objects/items/weapons/melee/blunt.dm
+++ b/code/game/objects/items/weapons/melee/blunt.dm
@@ -118,8 +118,8 @@
 
 //................ Bell ringer ............... //
 /obj/item/weapon/mace/church
-	force = DAMAGE_MACE+3
-	force_wielded = DAMAGE_MACE_WIELD+3
+	force = DAMAGE_MACE+3 //23 total
+	force_wielded = DAMAGE_MACE_WIELD+3 //28 total
 	name = "bell ringer"
 	desc = "Faith is sometimes best administered with steel and blood."
 	icon_state = "churchmace"
@@ -145,8 +145,8 @@
 
 //................ Spiked club ............... //
 /obj/item/weapon/mace/spiked
-	force = DAMAGE_MACE+2
-	force_wielded = DAMAGE_MACE_WIELD+3
+	force = DAMAGE_MACE+2 //22 total
+	force_wielded = DAMAGE_MACE_WIELD+3 //28 total
 	name = "spiked mace"
 	icon_state = "spikedmace"
 	max_integrity = 200
@@ -154,8 +154,8 @@
 
 //................ Morningstar ............... //
 /obj/item/weapon/mace/steel/morningstar
-	force = DAMAGE_MACE+2
-	force_wielded = DAMAGE_MACE_WIELD+3
+	force = DAMAGE_MACE+2 //22 total
+	force_wielded = DAMAGE_MACE_WIELD+3 //28 total
 	name = "morningstar"
 	icon_state = "spiked_club_old"
 	max_integrity = 300
@@ -237,12 +237,12 @@
 
 //................ Wooden sword ............... //
 /obj/item/weapon/mace/woodclub/train_sword
-	force = 5
-	force_wielded = 8
+	force = DAMAGE_SWORD-15 //5 total
+	force_wielded = DAMAGE_SWORD-12 //8 total
 	name = "wooden sword"
 	desc = "Crude wood assembled into the shape of a sword, a terrible weapon to be on the recieving end of during a training spat."
 	icon_state = "wsword"
-	wbalance = 0
+	wbalance = DODGE_CHANCE_NORMAL
 	associated_skill = /datum/skill/combat/swords
 	wdefense = ULTMATE_PARRY
 	metalizer_result = /obj/item/weapon/sword/iron
@@ -379,8 +379,8 @@
 
 //................ Copper goden ............... //
 /obj/item/weapon/mace/goden/copper
-	force = 10
-	force_wielded = 20
+	force = DAMAGE_MACE-10 //10 total
+	force_wielded = DAMAGE_MACE_WIELD-5 //20 total
 	slowdown = 1
 	name = "copper warclub"
 	desc = "A two handed club, decorated with a crown of spikes. A barbaric besign, good enough to be used as a weapon."
@@ -395,17 +395,17 @@
 
 //................ Warhammers ............... //
 /obj/item/weapon/mace/warhammer
-	force = 20
+	force = DAMAGE_MACE
 	possible_item_intents = list(/datum/intent/mace/strike, /datum/intent/mace/smash, /datum/intent/mace/warhammer/impale)
 	gripped_intents = null
 	name = "iron warhammer"
 	desc = "Made to punch through armor and skull alike."
 	icon_state = "iwarhammer"
-	wbalance = -1
+	wbalance = EASY_TO_DODGE
 	melting_material = /datum/material/iron
 	melt_amount = 75
 	blade_dulling = DULLING_BASH
-	wdefense = 3
+	wdefense = GOOD_PARRY
 
 /obj/item/weapon/mace/warhammer/getonmobprop(tag)
 	if(tag)
@@ -419,14 +419,13 @@
 	return ..()
 
 /obj/item/weapon/mace/warhammer/steel
-	force = 25
+	force = DAMAGE_MACE+5 //25 total
 	possible_item_intents = list(/datum/intent/mace/strike, /datum/intent/mace/smash, /datum/intent/mace/warhammer/impale, /datum/intent/mace/warhammer/stab)
 	name = "steel warhammer"
 	desc = "A fine steel warhammer, makes a satisfying sound when paired with a knight's helm."
 	icon_state = "swarhammer"
 	melting_material = /datum/material/steel
 	melt_amount = 150
-	wdefense = 4
 
 /datum/intent/mace/warhammer/stab
 	name = "thrust"
@@ -435,7 +434,7 @@
 	attack_verb = list("thrusts", "stabs")
 	animname = "stab"
 	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
-	penfactor = 20
+	penfactor = AP_CLUB_STRIKE
 	damfactor = 0.8
 	item_damage_type = "stab"
 
@@ -450,6 +449,6 @@
 	chargedrain = 1
 	misscost = 1
 	no_early_release = TRUE
-	penfactor = 80
+	penfactor = AP_CLUB_SMASH+55 //80 in total
 	damfactor = 0.9
 	item_damage_type = "stab"

--- a/code/game/objects/items/weapons/melee/flail.dm
+++ b/code/game/objects/items/weapons/melee/flail.dm
@@ -125,7 +125,6 @@
 	bigboy = TRUE
 	gripsprite = TRUE
 	w_class = WEIGHT_CLASS_BULKY
-	wbalance = 0
 	wlength = WLENGTH_LONG
 	slot_flags = ITEM_SLOT_BACK
 	max_integrity = 500

--- a/code/game/objects/items/weapons/melee/knives.dm
+++ b/code/game/objects/items/weapons/melee/knives.dm
@@ -55,7 +55,7 @@
 	animname = "cut"
 	blade_class = BCLASS_CUT
 	hitsound = list('sound/combat/hits/bladed/smallslash (1).ogg', 'sound/combat/hits/bladed/smallslash (2).ogg', 'sound/combat/hits/bladed/smallslash (3).ogg')
-	penfactor = 10
+	penfactor = AP_SWORD_CHOP+5 //10, bad ap
 	chargetime = 0
 	swingdelay = 1
 	clickcd = 10	// between normal and fast
@@ -71,7 +71,7 @@
 	animname = "stab"
 	blade_class = BCLASS_STAB
 	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
-	penfactor = 30
+	penfactor = AP_SWORD_THRUST+10 //30, good AP
 	chargetime = 0
 	clickcd = CLICK_CD_FAST
 	swingdelay = 1
@@ -101,7 +101,7 @@
 	animname = "chop"
 	blade_class = BCLASS_CHOP
 	hitsound = list('sound/combat/hits/bladed/smallslash (1).ogg', 'sound/combat/hits/bladed/smallslash (2).ogg', 'sound/combat/hits/bladed/smallslash (3).ogg')
-	penfactor = 10
+	penfactor = AP_SWORD_CHOP
 	damfactor = 1.5
 	swingdelay = 1
 	clickcd = CLICK_CD_MELEE
@@ -181,7 +181,7 @@
 	return ..()
 
 /obj/item/weapon/knife/scissors/steel
-	force = 14
+	force = DAMAGE_KNIFE+1 //11 total, better than normal scissors by 1
 	max_integrity = 150
 	name = "steel scissors"
 	desc = "Scissors made of solid steel that may be used to salvage usable materials from clothing, more durable and a tad more deadly than their iron conterpart."
@@ -203,30 +203,29 @@
 	possible_item_intents = list(/datum/intent/dagger/cut, /datum/intent/dagger/chop/cleaver)
 	parrysound = list('sound/combat/parry/bladed/bladedmedium (1).ogg','sound/combat/parry/bladed/bladedmedium (2).ogg','sound/combat/parry/bladed/bladedmedium (3).ogg')
 	swingsound = list('sound/combat/wooshes/bladed/wooshmed (1).ogg','sound/combat/wooshes/bladed/wooshmed (2).ogg','sound/combat/wooshes/bladed/wooshmed (3).ogg')
-	throwforce = 15
+	throwforce = DAMAGE_DAGGER
 	max_integrity = 150
 	slot_flags = ITEM_SLOT_HIP
 	thrown_bclass = BCLASS_CHOP
 	w_class = WEIGHT_CLASS_NORMAL
 	melting_material = /datum/material/steel
 	melt_amount = 75
-	wbalance = 0 // Except this one, too huge and used to chop
+	wbalance = EASY_TO_DODGE // Except this one, too huge and used to chop
 	dropshrink = 0.9
 
 //................ Hack-Knife ............... //
 /obj/item/weapon/knife/cleaver/combat
 	name = "hack-knife"
 	desc = "A short blade that even the weakest of hands can aspire to do harm with."
-	force = 10
 	possible_item_intents = list(/datum/intent/dagger/cut, /datum/intent/dagger/chop)
 	icon_state = "combatknife"
-	throwforce = 16
+	throwforce = DAMAGE_DAGGER
 	max_integrity = 180
 	slot_flags = ITEM_SLOT_HIP
 	w_class = WEIGHT_CLASS_NORMAL
 	melting_material = /datum/material/iron
 	melt_amount = 75
-	wbalance = 1
+	wbalance = MEDIOCHRE_PARRY
 	sellprice = 15
 
 /obj/item/weapon/knife/cleaver/combat/getonmobprop(tag)
@@ -241,6 +240,7 @@
 //................ Iron Dagger ............... //
 /obj/item/weapon/knife/dagger
 	possible_item_intents = list(/datum/intent/dagger/cut, /datum/intent/dagger/thrust)
+	force = DAMAGE_DAGGER
 	name = "iron dagger"
 	desc = "Thin, sharp, pointed death."
 	icon_state = "idagger"
@@ -250,6 +250,7 @@
 //................ Steel Dagger ............... //
 /obj/item/weapon/knife/dagger/steel
 	name = "steel dagger"
+	force = DAMAGE_DAGGER+1 //13 total
 	desc = "A dagger made of refined steel."
 	icon_state = "sdagger"
 	melting_material = null
@@ -400,8 +401,6 @@
 
 //................ Stone Knife ............... //
 /obj/item/weapon/knife/stone
-	force = DAMAGE_KNIFE
-	throwforce = DAMAGE_KNIFE
 	possible_item_intents = list(/datum/intent/dagger/cut,/datum/intent/dagger/chop)
 	name = "stone knife"
 	desc = "A tool favored by the wood-elves, easy to make, useful for skinning the flesh of beast and man alike."
@@ -432,10 +431,8 @@
 	max_blade_int = 75
 	max_integrity = 75
 	swingsound = list('sound/combat/wooshes/bladed/wooshsmall (1).ogg','sound/combat/wooshes/bladed/wooshsmall (2).ogg','sound/combat/wooshes/bladed/wooshsmall (3).ogg')
-	associated_skill = /datum/skill/combat/knives
 	pickup_sound = 'sound/foley/equip/swordsmall2.ogg'
 	melting_material = /datum/material/copper
-	melt_amount = 50
 	sellprice = 10
 
 
@@ -443,11 +440,10 @@
 	name = "iron tossblade"
 	desc = ""
 	item_state = "bone_dagger"
-	force = 12
-	throwforce = 25
+	force = DAMAGE_KNIFE
+	throwforce = DAMAGE_DAGGER+13
 	throw_speed = 4
 	max_integrity = 50
-	wdefense = 1
 	icon_state = "throw_knifei"
 	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 25, "embedded_fall_chance" = 20)
 	melting_material = /datum/material/iron
@@ -455,29 +451,17 @@
 
 /obj/item/weapon/knife/throwingknife/steel
 	name = "steel tossblade"
-	desc = ""
-	item_state = "bone_dagger"
-	force = 12
-	throwforce = 25
-	throw_speed = 4
 	max_integrity = 100
-	wdefense = 1
 	icon_state = "throw_knifes"
 	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 30, "embedded_fall_chance" = 15)
-	melt_amount = 50
 
 /obj/item/weapon/knife/throwingknife/psydon
 	name = "psydonian tossblade"
 	desc = "An unconventional method of delivering silver to a heretic; but one PSYDON smiles at, all the same. Doubles as an 'actual' knife in a pinch."
-	item_state = "bone_dagger"
-	force = 12
-	throwforce = 25
-	throw_speed = 4
 	max_integrity = 150
-	wdefense = 3
+	wdefense = GOOD_PARRY
 	icon_state = "throw_knifes"
 	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 50, "embedded_fall_chance" = 0)
 	is_silver = TRUE
 	sellprice = 65
 	melting_material = /datum/material/silver
-	melt_amount = 50

--- a/code/game/objects/items/weapons/melee/polearms.dm
+++ b/code/game/objects/items/weapons/melee/polearms.dm
@@ -25,6 +25,7 @@
 	blade_dulling = DULLING_BASHCHOP
 	walking_stick = TRUE
 	wdefense = GREAT_PARRY
+	wbalance = DODGE_CHANCE_NORMAL
 	thrown_bclass = BCLASS_STAB
 	sellprice = 20
 
@@ -334,7 +335,7 @@
 	force_wielded = DAMAGE_SPEAR_WIELD
 	slowdown = 1
 	possible_item_intents = list(POLEARM_BASH, /datum/intent/polearm/chop) //bash is for nonlethal takedowns, only targets limbs
-	gripped_intents = list(POLEARM_BASH, POLEARM_THRUST, /datum/intent/mace/smash/heavy,/datum/intent/polearm/chop)
+	gripped_intents = list(POLEARM_BASH, POLEARM_THRUST, /datum/intent/mace/smash/heavy,/datum/intent/mace/warhammer/impale)
 	name = "eagle's beak"
 	desc = "A reinforced pole affixed with an ornate steel eagle's head, of which it's beak is intended to pierce with great harm."
 	icon_state = "eaglebeak"
@@ -398,14 +399,14 @@
 	max_blade_int = 200
 	melting_material = /datum/material/bronze
 	melt_amount = 75
-	force = 20
-	force_wielded = 25
+	force = DAMAGE_SPEAR+5 //20 total
+	force_wielded = DAMAGE_SPEAR_WIELD
 
 
 //scythe
 /obj/item/weapon/sickle/scythe
-	force = 10
-	force_wielded = 20
+	force = DAMAGE_SPEAR-5 //10 total
+	force_wielded = DAMAGE_SPEAR_WIELD-5 //20 total
 	possible_item_intents = list(SPEAR_CUT) //truly just a long knife
 	gripped_intents = list(SPEAR_CUT)
 	name = "scythe"
@@ -432,14 +433,14 @@
 	dropshrink = 0.75
 	blade_dulling = DULLING_BASHCHOP
 	walking_stick = TRUE
-	wdefense = 2
+	wdefense = AVERAGE_PARRY
 	thrown_bclass = BCLASS_CUT
 	throwforce = 25
 	sellprice = 10
 
 /obj/item/weapon/polearm/spear/bonespear
-	force = 18
-	force_wielded = 22
+	force = DAMAGE_SPEAR+3 //18 total
+	force_wielded = DAMAGE_SPEAR_WIELD-3 //22 total
 	name = "bone spear"
 	desc = "A spear made of bones."
 	// icon_state = "bonespear"
@@ -458,6 +459,5 @@
 	associated_skill = /datum/skill/combat/polearms
 	blade_dulling = DULLING_BASHCHOP
 	walking_stick = TRUE
-	wdefense = 4
 	max_integrity = 60
 	throwforce = 20

--- a/code/game/objects/items/weapons/melee/polearms.dm
+++ b/code/game/objects/items/weapons/melee/polearms.dm
@@ -334,7 +334,7 @@
 	force = DAMAGE_SPEAR
 	force_wielded = DAMAGE_SPEAR_WIELD
 	slowdown = 1
-	possible_item_intents = list(POLEARM_BASH, /datum/intent/polearm/chop) //bash is for nonlethal takedowns, only targets limbs
+	possible_item_intents = list(POLEARM_BASH, POLEARM_THRUST) //bash is for nonlethal takedowns, only targets limbs
 	gripped_intents = list(POLEARM_BASH, POLEARM_THRUST, /datum/intent/mace/smash/heavy,/datum/intent/mace/warhammer/impale)
 	name = "eagle's beak"
 	desc = "A reinforced pole affixed with an ornate steel eagle's head, of which it's beak is intended to pierce with great harm."

--- a/code/game/objects/items/weapons/melee/special.dm
+++ b/code/game/objects/items/weapons/melee/special.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/lordscepter
-	force = 20
-	force_wielded = 20
+	force = DAMAGE_MACE
+	force_wielded = DAMAGE_MACE
 	possible_item_intents = list(/datum/intent/lordbash, /datum/intent/lord_electrocute, /datum/intent/lord_silence)
 	gripped_intents = list(/datum/intent/lordbash)
 	name = "master's rod"
@@ -28,7 +28,7 @@
 	blade_class = BCLASS_BLUNT
 	icon_state = "inbash"
 	attack_verb = list("bashes", "strikes")
-	penfactor = 10
+	penfactor = AP_CLUB_STRIKE-10 //10 total, bad AP
 	item_damage_type = "blunt"
 
 /datum/intent/lord_electrocute
@@ -95,15 +95,15 @@
 				return
 
 /obj/item/weapon/mace/stunmace
-	force = 15
-	force_wielded = 15
+	force = DAMAGE_CLUB
+	force_wielded = DAMAGE_CLUB
 	name = "stunmace"
 	icon_state = "stunmace0"
 	desc = "A dwarven invention, a mace that bears tiny soul-gems that imbue the crown of the mace with lightning mana."
 	gripped_intents = null
 	w_class = WEIGHT_CLASS_NORMAL
 	possible_item_intents = list(/datum/intent/mace/strike/stunner, /datum/intent/mace/smash/stunner)
-	wbalance = 0
+	wbalance = DODGE_CHANCE_NORMAL
 	minstr = 5
 	wdefense = 0
 	var/charge = 100

--- a/code/game/objects/items/weapons/melee/swords.dm
+++ b/code/game/objects/items/weapons/melee/swords.dm
@@ -5,7 +5,7 @@
 /obj/item/weapon/sword
 	force = DAMAGE_SWORD
 	force_wielded = DAMAGE_SWORD_WIELD
-	throwforce = 10
+	throwforce = DAMAGE_SWORD-10
 	slot_flags = ITEM_SLOT_HIP
 	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust)
 	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust)
@@ -177,8 +177,8 @@
 
 //................ Silver Sword ............... //
 /obj/item/weapon/sword/silver
-	force = DAMAGE_SWORD-1
-	force_wielded = DAMAGE_SWORD_WIELD-1
+	force = DAMAGE_SWORD-1 //19 total
+	force_wielded = DAMAGE_SWORD_WIELD-1 //24 total
 	name = "silver sword"
 	desc = "A simple silver sword with an edge that gleams in moonlight."
 	icon_state = "sword_s"
@@ -206,8 +206,8 @@
 				H.Paralyze(10)
 
 /obj/item/weapon/sword/iron
-	force = DAMAGE_SWORD-1
-	force_wielded = DAMAGE_SWORD_WIELD-1
+	force = DAMAGE_SWORD-1 //19 total
+	force_wielded = DAMAGE_SWORD_WIELD-1 //24 total
 	desc = "A simple iron sword with a tested edge, sharp and true."
 	icon_state = "isword"
 	max_blade_int = 200
@@ -300,7 +300,7 @@
 
 
 /obj/item/weapon/sword/sabre/scythe
-	force = DAMAGE_SWORD-2
+	force = DAMAGE_SWORD-2 //18 total
 	name = "scythe sword"
 	desc = "A farming tool blade has been fastened to a shorter wooden handle to create an improvised weapon."
 	icon_state = "scytheblade"
@@ -450,7 +450,7 @@
 	max_blade_int = 400
 
 /obj/item/weapon/sword/rapier/silver
-	force = DAMAGE_SWORD-2
+	force = DAMAGE_SWORD-2 //18 total
 	name = "silver rapier"
 	desc = "An elegant silver rapier. Popular with lords and ladies in Valoria."
 	icon_state = "rapier_s"
@@ -465,7 +465,7 @@
 /obj/item/weapon/sword/khopesh
 	name = "ancient khopesh"
 	desc = "A bronze weapon of war from the era of Apotheosis. This blade is older than a few elven generations, but has been very well-maintained and still keeps a good edge."
-	force = 22 // Unique weapon from rare job, slightly more force than most one-handers
+	force = DAMAGE_SWORD+2 //22 total, Unique weapon from rare job, slightly more force than most one-handers
 	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/chop, /datum/intent/sword/strike)
 	gripped_intents = null
 	icon = 'icons/roguetown/weapons/64.dmi'
@@ -482,8 +482,8 @@
 	max_blade_int = 300
 	max_integrity = 300
 	minstr = 10 // Even though it's technically one-handed, you gotta have some muscle to wield this thing
-	wdefense = 3 // Lower than average sword defense (meant to pair with a shield)
-	wbalance = -1 // Likely weighted towards the blade, for deep cuts and chops
+	wdefense = GOOD_PARRY // Lower than average sword defense (meant to pair with a shield)
+	wbalance = EASY_TO_DODGE // Likely weighted towards the blade, for deep cuts and chops
 	sellprice = 200 // A noble collector would love to get his/her hands on one of these blades
 
 
@@ -531,8 +531,8 @@
 
 //................ Heirloom Sword ............... //
 /obj/item/weapon/sword/long/heirloom
-	force = DAMAGE_SWORD-2
-	force_wielded = DAMAGE_SWORD_WIELD-2
+	force = DAMAGE_SWORD-2 //18 total
+	force_wielded = DAMAGE_SWORD_WIELD-2 //23 total
 	icon_state = "heirloom"
 	name = "old sword"
 	desc = "An old steel sword with a heraldic green leather grip, mouldered by years of neglect."
@@ -544,8 +544,8 @@
 
 // Repurposing this unused sword for the Paladin job as a heavy counter against vampires.
 /obj/item/weapon/sword/long/judgement// this sprite is a one handed sword, not a longsword.
-	force = 15
-	force_wielded = 30
+	force = DAMAGE_SWORD-5 //15 total
+	force_wielded = DAMAGE_LONGSWORD_WIELD+2 //30 total
 	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike)
 	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust/long, /datum/intent/sword/strike, /datum/intent/sword/chop/long)
 	icon_state = "judgement"
@@ -567,8 +567,8 @@
 
 
 /obj/item/weapon/sword/long/vlord // this sprite is a one handed sword, not a longsword.
-	force = 18
-	force_wielded = 30
+	force = DAMAGE_SWORD-2 //18 total
+	force_wielded = DAMAGE_LONGSWORD_WIELD+2 //27 total
 	icon_state = "vlord"
 	name = "Jaded Fang"
 	desc = "An ancestral long blade with an ominous glow, serrated with barbs along it's edges. Stained with a strange green tint."
@@ -607,8 +607,8 @@
 
 
 /obj/item/weapon/sword/long/forgotten
-	force = 16 // Damage is .9 of a steel sword
-	force_wielded = 25
+	force = DAMAGE_SWORD-4 // Damage is .8 of a steel sword, 16 total
+	force_wielded = DAMAGE_SWORD_WIELD
 	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike)
 	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust/long, /datum/intent/sword/strike, /datum/intent/sword/chop/long)
 	icon_state = "forgotten"
@@ -617,8 +617,7 @@
 	max_blade_int = 240 // Integrity and blade retention is .8 of a steel sword
 	max_integrity = 400
 	smeltresult = /obj/item/ingot/silver
-	wbalance = -1
-	wdefense = 4
+	wbalance = EASY_TO_DODGE
 	sellprice = 90
 	last_used = 0
 	is_silver = TRUE
@@ -737,8 +736,8 @@
 // Copper Messer
 
 /obj/item/weapon/sword/coppermesser
-	force = 15 // Messers are heavy weapons, crude and STR based.
-	force_wielded = 20
+	force = DAMAGE_SWORD-5 // Messers are heavy weapons, crude and STR based. 15 total
+	force_wielded = DAMAGE_SWORD_WIELD
 	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/strike)
 	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/strike, /datum/intent/sword/chop)
 	icon_state = "cmesser"
@@ -758,7 +757,7 @@
 	slot_flags = ITEM_SLOT_BACK|ITEM_SLOT_HIP
 	dropshrink = 0.90
 	smeltresult = /obj/item/ingot/copper
-	wbalance = -1
+	wbalance = EASY_TO_DODGE
 	sellprice = 10
 
 /obj/item/weapon/sword/coppermesser/getonmobprop(tag)
@@ -775,8 +774,8 @@
 				return list("shrink" = 0.5,"sx" = -4,"sy" = -6,"nx" = 5,"ny" = -6,"wx" = 0,"wy" = -6,"ex" = -1,"ey" = -6,"nturn" = 100,"sturn" = 156,"wturn" = 90,"eturn" = 180,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
 /obj/item/weapon/sword/long/rider/copper
-	force = 10
-	force_wielded = 20 // Shitty Design, Shitty materials, SHITTY WEAPON
+	force = DAMAGE_SWORD-6 // 14 total
+	force_wielded = DAMAGE_SWORD_WIELD-5 // Shitty Design, Shitty materials, SHITTY WEAPON, 20 total
 	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/strike)
 	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/strike)
 	icon_state = "copperfalx"
@@ -812,19 +811,18 @@
 	desc = "A sword possessed of a quite long and tapered blade that is intended to be thrust between the \
 	gaps in an opponent's armor. The hilt is wrapped tight in black leather."
 	icon_state = "estoc"
-	force = 12
-	force_wielded = 25
+	force = DAMAGE_SWORD
+	force_wielded = DAMAGE_SWORD_WIELD
 	icon = 'icons/roguetown/weapons/64.dmi'
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
 	possible_item_intents = list(
-		/datum/intent/sword/chop,
+		/datum/intent/sword/thrust,
 		/datum/intent/sword/strike,
 	)
 	gripped_intents = list(
 		/datum/intent/sword/thrust/estoc,
 		/datum/intent/sword/lunge,
-		/datum/intent/sword/chop,
 		/datum/intent/sword/strike,
 	)
 	bigboy = TRUE
@@ -835,7 +833,7 @@
 	smeltresult = /obj/item/ingot/iron
 	associated_skill = /datum/skill/combat/swords
 	max_blade_int = 300
-	wdefense = 5
+	wbalance = DODGE_CHANCE_NORMAL //Worse than a rapier
 
 /obj/item/weapon/estoc/getonmobprop(tag)
 	. = ..()
@@ -892,7 +890,7 @@
 
 /datum/intent/sword/thrust/estoc
 	name = "thrust"
-	penfactor = 50
+	penfactor = AP_SWORD_THRUST+10 //30 in total
 	recovery = 20
 	clickcd = 10
 
@@ -905,15 +903,15 @@
 	blade_class = BCLASS_STAB
 	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
 	reach = 2
-	penfactor = 30
-	damfactor = 1.2
-	chargetime = 5
+	penfactor = AP_SWORD_THRUST+30 //50 in total
+	chargetime = 10
+	no_early_release = TRUE
 	recovery = 20
 	clickcd = 10
 
 
 /obj/item/weapon/sword/gladius
-	force = 22
+	force = DAMAGE_SWORD+2 //22 total
 	name = "Gladius"
 	desc = "A bronze short sword with a slightly wider end, and no guard. Compliments a shield."
 	icon_state = "gladius"
@@ -922,4 +920,4 @@
 	max_blade_int = 100
 	max_integrity = 200
 	dropshrink = 0.80
-	wdefense = 2
+	wdefense = AVERAGE_PARRY

--- a/code/game/objects/items/weapons/melee/whips.dm
+++ b/code/game/objects/items/weapons/melee/whips.dm
@@ -46,7 +46,7 @@
 	hitsound = list('sound/combat/hits/blunt/flailhit.ogg')
 	chargetime = 5
 	recovery = 5
-	penfactor = 5
+	penfactor = AP_WHIP_LASH
 	reach = 2
 	misscost = 7
 	icon_state = "inlash"
@@ -63,7 +63,7 @@
 	hitsound = list('sound/combat/hits/blunt/flailhit.ogg')
 	chargetime = 0
 	recovery = 5
-	penfactor = 10
+	penfactor = AP_WHIP_LASH+5 //10 total
 	reach = 1
 	icon_state = "incrack"
 	canparry = TRUE
@@ -71,7 +71,7 @@
 
 //................ Repenta En ............... //
 /obj/item/weapon/whip/antique
-	force = DAMAGE_WHIP+4
+	force = DAMAGE_WHIP+4 //24 total
 	name = "Repenta En"
 	desc = "An extremely well maintained whip, with a polished steel tip and gilded handle"
 	minstr = 7
@@ -82,7 +82,7 @@
 
 //................ Lashkiss Whip ............... //
 /obj/item/weapon/whip/spiderwhip
-	force = DAMAGE_WHIP+3
+	force = DAMAGE_WHIP+3 //23 total
 	name = "lashkiss whip"
 	desc = "A dark whip with segmented, ashen spines for a base. Claimed to be hewn from dendrified prisoners of terror."
 	icon_state = "spiderwhip"


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
Balances a few weapons and ensures all force, force_wielded, penfactor, wdefence and wbalance variables use the correct defines.

- Estoc's thrust now only has 30AP and gives the 50AP attack to Lunge. Removes the chop intent as it is meant to be an edgeless blade and adds a normal sword thrust to its one-handed intents. It is now easier to dodge as it is already a good weapon for armor users and it is now just as good as other swords at parrying. (why was it ultimate parry in the first place?) 
- Eagle Beak loses its chop (the sprite clearly shows a bec-de-corbin, it should be used to pick, thrust at people or smash their heads in) and gains the impale from the warhammer, making use of the "eagle beak" part of the weapon. (The lucerne is also affected as it is the iron version of the eagle beak)
- Daggers now correctly use the DAMAGE_DAGGER define. Iron daggers now deal 12 damage with steel daggers dealing 13 damage. The perfidious steel scissors have been nerfed so they are barely better than normal knives at stabbing. All other knives are unaffected. Also removed a bunch of redefines in knives.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Estoc is a sword that has all of these

1. Highest AP in swords, only bested by flails and impale warhammers
2. Ultimate Parry
3. Very Hard to Dodge
4. Only one with a spammeable high AP attack

It wasn't balanced at all and it showed. Now the estoc is still the best AP sword, but it is no longer the best sword or best weapon in the game, it serves its purpose as an armor piercing weapon without being overwhelming.

Eagle Beak clearly shows it is a hammer with teeth. That isn't a chop weapon and it didn't even use the "eagle beak" part of it. This change makes it a great weapon for AP and bludgeoning though decidedly worse against unarmored opponents, compared to the Halberd. The impale is awfully slow so it isn't great.

Daggers are terrible and they weren't actually using the actual dagger damage defines... Now they will deal a bit more damage while still being decidedly worse than even a shortsword in terms of damage.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
