### PR TITLE
Medicinecraft dream changes

### DIFF
--- a/code/datums/skills/craft.dm
+++ b/code/datums/skills/craft.dm
@@ -69,6 +69,7 @@
 /datum/skill/craft/medicine
 	name = "Medicinecraft"
 	desc = "Medicinecraft is a skill that represents your character's ability to perform medicine on others. The higher your skill in Medicinecraft, the better you can treat your patients and the faster you can perform surgery on them."
+	randomable_dream_xp = FALSE
 	dreams = list(
 		"...you exhume the last meal he ate... keeling over and examining the empty void, you see the inklings of a garden sprouting inside the cadaver..."
 	)

--- a/code/datums/skills/misc.dm
+++ b/code/datums/skills/misc.dm
@@ -65,6 +65,9 @@
 	name = "Medicine"
 	desc = "Medicine is a skill that represents your character's ability to heal others. The higher your skill in Medicine, the more effective your healing will be." //Placeholder description.
 	dream_cost_base = 3
+	dreams = list(
+		"...your hands move with practiced precision, needle and thread dancing through torn flesh like a tailor at their loom... the scent of blood and old herbs clings to you as you whisper a prayer to stave off infection... the battle rages on, but your patient will not fall today..."
+	)
 
 /datum/skill/misc/sewing
 	name = "Sewing"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
Makes the Medicinecraft skill not show up randomly as a skill in dreams, adds a dream description for the medicine skill.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
Medicinecraft seems to be a placeholder skill that serves literally 0 purpose and is referenced nowhere but you can still get it as a random dream XP wasting space and making people mistakenly take it without knowing any better which doesn't seem good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
