### PR TITLE
Fix ambushes

### DIFF
--- a/code/modules/mob/living/ambush.dm
+++ b/code/modules/mob/living/ambush.dm
@@ -4,18 +4,19 @@
 #define AMBUSH_CHANCE 5
 
 /mob/living/proc/ambushable()
-	if(MOBTIMER_FINISHED(src, MT_AMBUSHLAST, 5 MINUTES))
+	if(!mind)
 		return FALSE
 	if(stat) //what?
 		return FALSE
 	if(status_flags & GODMODE)
+		return FALSE
+	if(!MOBTIMER_FINISHED(src, MT_AMBUSHLAST, 5 MINUTES))
 		return FALSE
 	return ambushable
 
 /mob/living/proc/consider_ambush()
 	if(!prob(AMBUSH_CHANCE))
 		return
-
 	if(!MOBTIMER_FINISHED(src, MT_AMBUSHCHECK, 15 SECONDS))
 		return
 	MOBTIMER_SET(src, MT_AMBUSHCHECK)
@@ -30,68 +31,56 @@
 		return
 	if(!(T.type in AR.ambush_types))
 		return
-	var/campfires = 0
 	for(var/obj/machinery/light/fueled/RF in view(5, src))
 		if(RF.on)
-			campfires++
-	if(campfires > 0)
-		return
-	var/victims = 1
-	var/list/victimsa = list()
+			return
+	var/victims = 0
+	var/list/victims_list = list()
 	for(var/mob/living/V in view(5, src))
-		if(V != src)
-			if(V.ambushable())
-				victims++
-				victimsa += V
-			if(victims > 3)
-				return
+		if(V.ambushable())
+			victims++
+			LAZYADD(victims_list, V)
+		if(victims > 3)
+			return
 	var/list/possible_targets = list()
-	for(var/obj/structure/flora/tree/RT in view(5, src))
-		if(istype(RT,/obj/structure/table/wood/treestump))
-			continue
-		if(isturf(RT.loc))
-			testing("foundtree")
-			possible_targets += RT.loc
-//	for(var/obj/structure/flora/grass/bush/RB in range(7, src))
-//		if(can_see(src, RB))
-//			possible_targets += RB
-	for(var/obj/structure/flora/shroom_tree/RX in view(5, src))
-		if(isturf(RX.loc))
-			testing("foundshroom")
-			possible_targets += RX.loc
-	for(var/obj/structure/flora/newtree/RS in view(5, src))
-		if(!RS.density)
-			continue
-		if(isturf(RS.loc))
-			testing("foundshroom")
-			possible_targets += RS.loc
-	if(length(possible_targets))
-		MOBTIMER_SET(src, MT_AMBUSHLAST)
-		for(var/mob/living/V in victimsa)
-			MOBTIMER_SET(V, MT_AMBUSHLAST)
-		var/spawnedtype = pickweight(AR.ambush_mobs)
-		var/mustype = 1
-		for(var/i in 1 to CLAMP(victims*1,2,3))
-			var/spawnloc = pick(possible_targets)
-			if(spawnloc)
-				var/mob/spawnedmob = new spawnedtype(spawnloc)
-				if(istype(spawnedmob, /mob/living/simple_animal/hostile))
-					var/mob/living/simple_animal/hostile/M = spawnedmob
-					M.attack_same = FALSE
-					M.del_on_deaggro = 44 SECONDS
-					M.GiveTarget(src)
-				if(istype(spawnedmob, /mob/living/carbon/human))
-					var/mob/living/carbon/human/H = spawnedmob
-					H.del_on_deaggro = 44 SECONDS
-					H.last_aggro_loss = world.time
-					H.retaliate(src)
-					mustype = 2
-		if(mustype == 1)
-			playsound_local(src, pick('sound/misc/jumpscare (1).ogg','sound/misc/jumpscare (2).ogg','sound/misc/jumpscare (3).ogg','sound/misc/jumpscare (4).ogg'), 100)
-		else
-			playsound_local(src, pick('sound/misc/jumphumans (1).ogg','sound/misc/jumphumans (2).ogg','sound/misc/jumphumans (3).ogg'), 100)
-		shake_camera(src, 2, 2)
-		if(iscarbon(src))
-			var/mob/living/carbon/C = src
-			if(C.stress >= 30 && (prob(50)))
-				C.heart_attack()
+	for(var/obj/structure/table/wood/treestump in view(5, src))
+		LAZYADD(possible_targets, get_turf(treestump))
+	for(var/obj/structure/flora/tree/tree in view(5, src))
+		LAZYADD(possible_targets, get_turf(tree))
+	for(var/obj/structure/flora/shroom_tree/shroom in view(5, src))
+		LAZYADD(possible_targets, get_turf(shroom))
+	for(var/obj/structure/flora/newtree/ntree in view(5, src))
+		LAZYADD(possible_targets, get_turf(ntree))
+	if(!LAZYLEN(possible_targets))
+		return
+	//MOBTIMER_SET(src, MT_AMBUSHLAST)
+	for(var/mob/living/V as anything in victims_list)
+		MOBTIMER_SET(V, MT_AMBUSHLAST)
+	var/spawnedtype = pickweight(AR.ambush_mobs)
+	var/mustype = 1
+	for(var/i in 1 to CLAMP(victims, 2, 3))
+		var/spawnloc = safepick(possible_targets)
+		if(!spawnloc)
+			return
+		var/mob/spawnedmob = new spawnedtype(spawnloc)
+		if(istype(spawnedmob, /mob/living/simple_animal/hostile))
+			var/mob/living/simple_animal/hostile/M = spawnedmob
+			M.attack_same = FALSE
+			M.del_on_deaggro = 44 SECONDS
+			M.GiveTarget(src)
+		if(istype(spawnedmob, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = spawnedmob
+			H.del_on_deaggro = 44 SECONDS
+			H.last_aggro_loss = world.time
+			H.retaliate(src)
+			mustype = 2
+	if(mustype == 1)
+		playsound_local(src, pick('sound/misc/jumpscare (1).ogg','sound/misc/jumpscare (2).ogg','sound/misc/jumpscare (3).ogg','sound/misc/jumpscare (4).ogg'), 100)
+	else
+		playsound_local(src, pick('sound/misc/jumphumans (1).ogg','sound/misc/jumphumans (2).ogg','sound/misc/jumphumans (3).ogg'), 100)
+	shake_camera(src, 2, 2)
+
+	if(iscarbon(src))
+		var/mob/living/carbon/C = src
+		if(C.stress >= 30 && (prob(50)))
+			C.heart_attack()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
Fix ambushes not working.
Ambushes can't trigger on mobs with no mind so only alive, not in crit, not unconscious players are eligible to get ambushed.
Treestumps are now targets for ambush mobspawns again.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
Mobtimers broke ambushes and ambushes probably shouldn't happen on non players.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
