### PR TITLE
Arrows can be dipped in reagents, cloth and rope can be tied directly to belt slot

### DIFF
--- a/code/game/objects/items/natural/clothfibersthorn.dm
+++ b/code/game/objects/items/natural/clothfibersthorn.dm
@@ -58,7 +58,7 @@
 	throwforce = 0
 	firefuel = 5 MINUTES
 	resistance_flags = FLAMMABLE
-	slot_flags = ITEM_SLOT_MOUTH|ITEM_SLOT_HIP|ITEM_SLOT_MASK
+	slot_flags = ITEM_SLOT_MOUTH|ITEM_SLOT_HIP|ITEM_SLOT_MASK|ITEM_SLOT_BELT
 	body_parts_covered = null
 	experimental_onhip = TRUE
 	max_integrity = 20
@@ -71,10 +71,21 @@
 	var/bandage_effectiveness = 0.9
 	obj_flags = CAN_BE_HIT //enables splashing on by containers
 
+/obj/item/natural/cloth/mob_can_equip(mob/living/M, mob/living/equipper, slot, disable_warning, bypass_equip_delay_self)
+	. = ..()
+	if(.)
+		if(slot == SLOT_BELT && !equipper)
+			if(!do_after(M, 1.5 SECONDS, src))
+				return FALSE
+
 /obj/item/natural/cloth/equipped(mob/living/carbon/human/user, slot)
 	. = ..()
 	if(slot == SLOT_WEAR_MASK)
 		user.become_blind("blindfold_[REF(src)]")
+	else if(slot == SLOT_BELT)
+		user.temporarilyRemoveItemFromInventory(src)
+		user.equip_to_slot_if_possible(new /obj/item/storage/belt/leather/cloth(get_turf(user)), SLOT_BELT)
+		qdel(src)
 
 /obj/item/natural/cloth/dropped(mob/living/carbon/human/user)
 	..()
@@ -86,6 +97,7 @@
 		. += span_notice("It's wet!")
 
 /obj/item/natural/cloth/bandit
+	slot_flags = ITEM_SLOT_MOUTH|ITEM_SLOT_HIP|ITEM_SLOT_MASK
 	color = "#ff0000"
 
 // CLEANING

--- a/code/game/objects/items/ropechainbola.dm
+++ b/code/game/objects/items/ropechainbola.dm
@@ -5,7 +5,7 @@
 	gender = PLURAL
 	icon = 'icons/roguetown/items/misc.dmi'
 	icon_state = "rope"
-	slot_flags = ITEM_SLOT_HIP|ITEM_SLOT_WRISTS|ITEM_SLOT_NECK
+	slot_flags = ITEM_SLOT_HIP|ITEM_SLOT_WRISTS|ITEM_SLOT_NECK|ITEM_SLOT_BELT
 	throwforce = 3
 	w_class = WEIGHT_CLASS_SMALL
 	throw_speed = 1
@@ -16,6 +16,20 @@
 	firefuel = 5 MINUTES
 	drop_sound = 'sound/foley/dropsound/cloth_drop.ogg'
 	var/legcuff_multiplicative_slowdown = 3
+
+/obj/item/rope/mob_can_equip(mob/living/M, mob/living/equipper, slot, disable_warning, bypass_equip_delay_self)
+	. = ..()
+	if(.)
+		if(slot == SLOT_BELT && !equipper)
+			if(!do_after(M, 1.5 SECONDS, src))
+				return FALSE
+
+/obj/item/rope/equipped(mob/living/carbon/human/user, slot)
+	. = ..()
+	if(slot == SLOT_BELT)
+		user.temporarilyRemoveItemFromInventory(src)
+		user.equip_to_slot_if_possible(new /obj/item/storage/belt/leather/rope(get_turf(user)), SLOT_BELT)
+		qdel(src)
 
 /datum/intent/tie
 	name = "tie"

--- a/code/game/objects/items/weapons/melee/knives.dm
+++ b/code/game/objects/items/weapons/melee/knives.dm
@@ -7,6 +7,7 @@
 	possible_item_intents = list(/datum/intent/dagger/cut, /datum/intent/dagger/thrust, /datum/intent/dagger/chop)
 	slot_flags = ITEM_SLOT_HIP|ITEM_SLOT_MOUTH
 	icon = 'icons/roguetown/weapons/32.dmi'
+	icon_state = "huntingknife"
 	gripsprite = FALSE
 	dropshrink = 0.8
 	thrown_bclass = BCLASS_CUT
@@ -32,7 +33,8 @@
 
 /obj/item/weapon/knife/Initialize()
 	. = ..()
-	AddElement(/datum/element/tipped_item)
+	AddElement(/datum/element/tipped_item, _max_reagents = 10, _dip_amount = 5, _inject_amount = 0.5)
+
 /obj/item/weapon/knife/getonmobprop(tag)
 	. = ..()
 	if(tag)

--- a/code/game/objects/items/weapons/ranged/ammo.dm
+++ b/code/game/objects/items/weapons/ranged/ammo.dm
@@ -27,9 +27,13 @@
 	icon_state = "bolt"
 	dropshrink = 0.8
 	max_integrity = 10
-	force = 10
+	force = DAMAGE_KNIFE-2
 	embedding = list("embedded_pain_multiplier" = 3, "embedded_fall_chance" = 0)
 	firing_effect_type = null
+
+/obj/item/ammo_casing/caseless/bolt/Initialize()
+	. = ..()
+	AddElement(/datum/element/tipped_item, _max_reagents = 2, _dip_amount = 2, _attack_injects = FALSE)
 
 /obj/projectile/bullet/reusable/bolt
 	name = "bolt"
@@ -47,26 +51,13 @@
 	flag =  "piercing"
 	speed = 0.3
 	accuracy = 85 //Crossbows have higher accuracy
-
-//................ Poison Bolt ............... //
-/obj/item/ammo_casing/caseless/bolt/poison
-	name = "poison bolt"
-	desc = "A bolt dipped with a weak poison."
-	icon_state = "bolt_poison"
-	projectile_type = /obj/projectile/bullet/reusable/bolt/poison/weak
-
-/obj/projectile/bullet/reusable/bolt/poison
-	name = "poison bolt"
-	icon_state = "boltpoison_proj"
-	damage = BOLT_DAMAGE-10
-	range = 15
 	var/piercing = FALSE
 
-/obj/projectile/bullet/reusable/bolt/poison/Initialize()
+/obj/projectile/bullet/reusable/bolt/Initialize()
 	. = ..()
 	create_reagents(50, NO_REACT)
 
-/obj/projectile/bullet/reusable/bolt/poison/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/reusable/bolt/on_hit(atom/target, blocked = FALSE)
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
 		if(blocked != 100) // not completely blocked
@@ -86,22 +77,20 @@
 	return BULLET_ACT_HIT
 
 //................ Poison Bolt (weak) ............... //
-/obj/projectile/bullet/reusable/bolt/poison/weak
-	desc = "A bolt dipped with a weak poison."
+/obj/item/ammo_casing/caseless/bolt/poison
+	name = "poison bolt"
+	desc = "A bolt coated with a weak poison."
+	icon_state = "bolt_poison"
 
-/obj/projectile/bullet/reusable/bolt/poison/weak/Initialize()
+/obj/item/ammo_casing/caseless/bolt/poison/Initialize()
 	. = ..()
 	reagents.add_reagent(/datum/reagent/berrypoison, 2)
 
 //................ Poison Bolt (potent) ............... //
 /obj/item/ammo_casing/caseless/bolt/poison/potent
-	desc = "A bolt dipped with a potent poison."
-	projectile_type = /obj/projectile/bullet/reusable/bolt/poison/potent
+	desc = "A bolt coated with a potent poison."
 
-/obj/projectile/bullet/reusable/bolt/poison/potent
-	desc = "A bolt dipped with a potent poison."
-
-/obj/projectile/bullet/reusable/bolt/poison/potent/Initialize()
+/obj/item/ammo_casing/caseless/bolt/poison/potent/Initialize()
 	. = ..()
 	reagents.add_reagent(/datum/reagent/strongpoison, 2)
 
@@ -112,6 +101,10 @@
 	projectile_type = /obj/projectile/bullet/bolt/pyro
 	possible_item_intents = list(/datum/intent/mace/strike)
 	icon_state = "bolt_pyroclastic"
+
+/obj/item/ammo_casing/caseless/bolt/pyro/Initialize()
+	. = ..()
+	RemoveElement(/datum/element/tipped_item)
 
 /obj/projectile/bullet/bolt/pyro
 	name = "pyroclastic bolt"
@@ -135,7 +128,7 @@
 	. = ..()
 	if(ismob(target))
 		var/mob/living/M = target
-		M.adjust_fire_stacks(6)
+		M.fire_act(6)
 //		M.take_overall_damage(0,10) //between this 10 burn, the 10 brute, the explosion brute, and the onfire burn, my at about 65 damage if you stop drop and roll immediately
 	var/turf/T
 	if(isturf(target))
@@ -158,12 +151,16 @@
 	caliber = "arrow"
 	icon = 'icons/roguetown/weapons/ammo.dmi'
 	icon_state = "arrow"
-	force = 20
+	force = DAMAGE_KNIFE-2
 	dropshrink = 0.8
 	possible_item_intents = list(/datum/intent/dagger/cut, /datum/intent/dagger/thrust)
 	max_integrity = 20
 	embedding = list("embedded_pain_multiplier" = 3, "embedded_fall_chance" = 0)
 	firing_effect_type = null
+
+/obj/item/ammo_casing/caseless/arrow/Initialize()
+	. = ..()
+	AddElement(/datum/element/tipped_item, _max_reagents = 2, _dip_amount = 2, _attack_injects = FALSE)
 
 /obj/projectile/bullet/reusable/arrow
 	name = "arrow"
@@ -180,6 +177,29 @@
 	woundclass = BCLASS_STAB
 	flag =  "piercing"
 	speed = 0.4
+	var/piercing = FALSE
+
+/obj/projectile/bullet/reusable/arrow/Initialize()
+	. = ..()
+	create_reagents(50, NO_REACT)
+
+/obj/projectile/bullet/reusable/arrow/on_hit(atom/target, blocked = FALSE)
+	if(iscarbon(target))
+		var/mob/living/carbon/M = target
+		if(blocked != 100) // not completely blocked
+			if(M.can_inject(null, FALSE, def_zone, piercing)) // Pass the hit zone to see if it can inject by whether it hit the head or the body.
+				..()
+				reagents.reaction(M, INJECT)
+				reagents.trans_to(M, reagents.total_volume)
+				return BULLET_ACT_HIT
+			else
+				blocked = 100
+				target.visible_message(	span_danger("\The [src] was deflected!"), span_danger("My armor protected me against \the [src]!"))
+
+	..(target, blocked)
+	DISABLE_BITFIELD(reagents.flags, NO_REACT)
+	reagents.handle_reactions()
+	return BULLET_ACT_HIT
 
 //................ Stone Arrow ............... //
 /obj/item/ammo_casing/caseless/arrow/stone
@@ -195,78 +215,41 @@
 	armor_penetration = 0
 	damage = ARROW_DAMAGE-2
 
-
 //................ Poison Arrow ............... //
 /obj/item/ammo_casing/caseless/arrow/poison
 	name = "poison arrow"
-	desc = "An arrow with its tip drenched in a weak poison."
-	projectile_type = /obj/projectile/bullet/reusable/arrow/poison/weak
+	desc = "An arrow with its tip coated in a weak poison."
 	icon_state = "arrow_poison"
 
-/obj/projectile/bullet/reusable/arrow/poison
-	name = "poison arrow"
-	desc = "An arrow with its tip drenched in a powerful poison."
-	icon_state = "arrowpoison_proj"
-	damage = ARROW_DAMAGE-10
-	range = 15
-	var/piercing = FALSE
-
 /obj/projectile/bullet/reusable/arrow/poison/Initialize()
-	. = ..()
-	create_reagents(50, NO_REACT)
-
-/obj/projectile/bullet/reusable/arrow/poison/on_hit(atom/target, blocked = FALSE)
-	if(iscarbon(target))
-		var/mob/living/carbon/M = target
-		if(blocked != 100) // not completely blocked
-			if(M.can_inject(null, FALSE, def_zone, piercing)) // Pass the hit zone to see if it can inject by whether it hit the head or the body.
-				..()
-				reagents.reaction(M, INJECT)
-				reagents.trans_to(M, reagents.total_volume)
-				return BULLET_ACT_HIT
-			else
-				blocked = 100
-				target.visible_message(	span_danger("\The [src] was deflected!"), span_danger("My armor protected me against \the [src]!"))
-
-
-	..(target, blocked)
-	DISABLE_BITFIELD(reagents.flags, NO_REACT)
-	reagents.handle_reactions()
-	return BULLET_ACT_HIT
-
-//................ Poison Arrow (weak) ............... //
-/obj/projectile/bullet/reusable/arrow/poison/weak
-	desc = "An arrow with its tip drenched in a weak poison."
-
-/obj/projectile/bullet/reusable/arrow/poison/weak/Initialize()
 	. = ..()
 	reagents.add_reagent(/datum/reagent/berrypoison, 2)
 
 //................ Poison Arrow (potent) ............... //
 /obj/item/ammo_casing/caseless/arrow/poison/potent
-	desc = "An arrow with it's tip drenched in a potent poison."
-	projectile_type = /obj/projectile/bullet/reusable/arrow/poison/potent
+	desc = "An arrow with its tip coated in a potent poison."
 
-/obj/item/ammo_casing/caseless/arrow/poison/potent
-	desc = "An arrow with it's tip drenched in a powerful poison."
-
-/obj/projectile/bullet/reusable/arrow/poison/potent/Initialize()
+/obj/item/ammo_casing/caseless/arrow/poison/potent/Initialize()
 	. = ..()
 	reagents.add_reagent(/datum/reagent/strongpoison, 2)
 
 //................ Pyro Arrow ............... //
 /obj/item/ammo_casing/caseless/arrow/pyro
 	name = "pyroclastic arrow"
-	desc = "An arrow with its tip drenched in a flammable tincture."
+	desc = "An arrow with its tip smeared with a flammable tincture."
 	projectile_type = /obj/projectile/bullet/arrow/pyro
 	possible_item_intents = list(/datum/intent/mace/strike)
 	icon_state = "arrow_pyroclastic"
 	max_integrity = 10
-	force = 10
+	force = DAMAGE_KNIFE-2
+
+/obj/item/ammo_casing/caseless/arrow/pyro/Initialize()
+	. = ..()
+	RemoveElement(/datum/element/tipped_item)
 
 /obj/projectile/bullet/arrow/pyro
 	name = "pyroclastic arrow"
-	desc = "An arrow with its tip drenched in a flammable tincture."
+	desc = "An arrow with its tip smeared with a flammable tincture."
 	icon_state = "arrowpyro_proj"
 	damage = ARROW_DAMAGE-15
 	range = 15
@@ -286,8 +269,7 @@
 	. = ..()
 	if(ismob(target))
 		var/mob/living/M = target
-		M.adjust_fire_stacks(6)
-		M.IgniteMob()
+		M.fire_act(6)
 //		M.take_overall_damage(0,10) //between this 10 burn, the 10 brute, the explosion brute, and the onfire burn, my at about 65 damage if you stop drop and roll immediately
 	var/turf/T
 	if(isturf(target))
@@ -351,7 +333,7 @@
 	dropshrink = 0.5
 	possible_item_intents = list(/datum/intent/use)
 	max_integrity = 0
-	force = 20
+	force = 3
 
 //................ Cannon Ball ............... //
 /obj/projectile/bullet/reusable/cannonball
@@ -397,7 +379,7 @@
 	max_integrity = 1
 	randomspread = 0
 	variance = 0
-	force = 20
+	force = 10
 
 /obj/item/ammo_casing/caseless/cball/grapeshot
 	name = "berryshot"
@@ -405,13 +387,6 @@
 	icon_state = "grapeshot" // NEEDS SPRITE
 	dropshrink = 0.5
 	projectile_type = /obj/projectile/bullet/fragment
-
-
-
-/*------\
-| Darts |
-\------*/
-
 
 /*------\
 | Darts |
@@ -426,8 +401,12 @@
 	icon_state = "dart"
 	dropshrink = 0.9
 	max_integrity = 10
-	force = 10
+	force = DAMAGE_KNIFE/2
 	firing_effect_type = null
+
+/obj/item/ammo_casing/caseless/dart/Initialize()
+	. = ..()
+	AddElement(/datum/element/tipped_item, _max_reagents = 3, _dip_amount = 3, _attack_injects = FALSE)
 
 /obj/projectile/bullet/reusable/dart
 	name = "dart"
@@ -444,25 +423,13 @@
 	flag = "piercing"
 	speed = 0.3
 	accuracy = 50
-
-//................ Poison Dart ............... //
-/obj/item/ammo_casing/caseless/dart/poison
-	name = "poison dart"
-	desc = "A dart with its tip drenched in a weak poison."
-	projectile_type = /obj/projectile/bullet/reusable/dart/poison
-	icon_state = "dart_poison"
-
-/obj/projectile/bullet/reusable/dart/poison
-	name = "poison dart"
-	desc = "A dart with its tip drenched in a weak poison."
 	var/piercing = FALSE
 
-/obj/projectile/bullet/reusable/dart/poison/Initialize()
+/obj/projectile/bullet/reusable/dart/Initialize()
 	. = ..()
 	create_reagents(50, NO_REACT)
-	reagents.add_reagent(/datum/reagent/berrypoison, 3)
 
-/obj/projectile/bullet/reusable/dart/poison/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/reusable/dart/on_hit(atom/target, blocked = FALSE)
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
 		if(blocked != 100) // not completely blocked
@@ -479,6 +446,16 @@
 	DISABLE_BITFIELD(reagents.flags, NO_REACT)
 	reagents.handle_reactions()
 	return BULLET_ACT_HIT
+
+//................ Poison Dart (weak) ............... //
+/obj/item/ammo_casing/caseless/dart/poison
+	name = "poison dart"
+	desc = "A dart with its tip coated in a weak poison."
+	icon_state = "dart_poison"
+
+/obj/item/ammo_casing/caseless/dart/poison/Initialize()
+	. = ..()
+	reagents.add_reagent(/datum/reagent/berrypoison, 3)
 
 #undef BLOWDART_DAMAGE
 #undef ARROW_DAMAGE

--- a/code/game/objects/items/weapons/ranged/ammo.dm
+++ b/code/game/objects/items/weapons/ranged/ammo.dm
@@ -105,6 +105,7 @@
 /obj/item/ammo_casing/caseless/bolt/pyro/Initialize()
 	. = ..()
 	RemoveElement(/datum/element/tipped_item)
+	qdel(reagents)
 
 /obj/projectile/bullet/bolt/pyro
 	name = "pyroclastic bolt"
@@ -246,6 +247,7 @@
 /obj/item/ammo_casing/caseless/arrow/pyro/Initialize()
 	. = ..()
 	RemoveElement(/datum/element/tipped_item)
+	qdel(reagents)
 
 /obj/projectile/bullet/arrow/pyro
 	name = "pyroclastic arrow"

--- a/code/modules/clothing/belt/misc.dm
+++ b/code/modules/clothing/belt/misc.dm
@@ -85,12 +85,26 @@
 	salvage_result = /obj/item/rope
 	component_type = /datum/component/storage/concrete/grid/belt/cloth
 
+/obj/item/storage/belt/leather/rope/attack_self(mob/user)
+	. = ..()
+	to_chat(user, span_notice("You begin untying [src]."))
+	if(do_after(user, 1.5 SECONDS, src))
+		qdel(src)
+		user.put_in_active_hand(new salvage_result(get_turf(user)))
+
 /obj/item/storage/belt/leather/cloth
 	name = "cloth sash"
 	desc = "A simple cloth sash."
 	icon_state = "cloth"
 	salvage_result = /obj/item/natural/cloth
 	component_type = /datum/component/storage/concrete/grid/belt/cloth
+
+/obj/item/storage/belt/leather/cloth/attack_self(mob/user)
+	. = ..()
+	to_chat(user, span_notice("You begin untying [src]."))
+	if(do_after(user, 1.5 SECONDS, src))
+		qdel(src)
+		user.put_in_active_hand(new salvage_result(get_turf(user)))
 
 /obj/item/storage/belt/leather/cloth/lady
 	color = "#575160"

--- a/code/modules/crafting/quality_of_crafting/crafting.dm
+++ b/code/modules/crafting/quality_of_crafting/crafting.dm
@@ -71,37 +71,15 @@
 /datum/repeatable_crafting_recipe/crafting/blowgun
 	name = "blowgun"
 	requirements = list(
-		/obj/item/grown/log/tree/stick= 1,
+		/obj/item/grown/log/tree/small= 1,
 	)
 	tool_usage = list(
-		/obj/item/weapon/knife = list("starts to whittle", "start whittle", 'sound/items/wood_sharpen.ogg'),
+		/obj/item/weapon/knife = list("starts to whittle", "start whittling", 'sound/items/wood_sharpen.ogg'),
 	)
-	attacked_atom = /obj/item/grown/log/tree/stick
+	attacked_atom = /obj/item/grown/log/tree/small
 	starting_atom  = /obj/item/weapon/knife
 	output = /obj/item/gun/ballistic/revolver/grenadelauncher/blowgun
 	uses_attacked_atom = FALSE
-
-/datum/repeatable_crafting_recipe/crafting/clothsash
-	name = "cloth sash"
-	requirements = list(
-		/obj/item/natural/cloth= 1,
-		/obj/item/natural/fibers= 1,
-	)
-	starting_atom = /obj/item/natural/cloth
-	attacked_atom = /obj/item/natural/fibers
-	output = /obj/item/storage/belt/leather/cloth
-	uses_attacked_atom = TRUE
-
-/datum/repeatable_crafting_recipe/crafting/ropebelt
-	name = "rope belt"
-	requirements = list(
-		/obj/item/rope= 1,
-		/obj/item/natural/fibers= 1,
-	)
-	starting_atom = /obj/item/rope
-	attacked_atom = /obj/item/natural/fibers
-	output = /obj/item/storage/belt/leather/rope
-	uses_attacked_atom = TRUE
 
 /datum/repeatable_crafting_recipe/crafting/candle
 	name = "candle"
@@ -109,8 +87,8 @@
 		/obj/item/reagent_containers/food/snacks/fat= 1,
 		/obj/item/natural/fibers= 1,
 	)
-	starting_atom = /obj/item/reagent_containers/food/snacks/fat
-	attacked_atom = /obj/item/natural/fibers
+	starting_atom = /obj/item/natural/fibers
+	attacked_atom = /obj/item/reagent_containers/food/snacks/fat
 	output = /obj/item/candle/yellow
 	output_amount = 2
 	uses_attacked_atom = TRUE
@@ -133,7 +111,7 @@
 		/obj/item/grown/log/tree= 1,
 	)
 	tool_usage = list(
-		/obj/item/weapon/knife = list("starts to whittle", "start whittle", 'sound/items/wood_sharpen.ogg'),
+		/obj/item/weapon/knife = list("starts to whittle", "start whittling", 'sound/items/wood_sharpen.ogg'),
 	)
 	attacked_atom = /obj/item/grown/log/tree
 	starting_atom = /obj/item/weapon/knife
@@ -143,12 +121,12 @@
 	uses_attacked_atom = FALSE
 
 /datum/repeatable_crafting_recipe/crafting/spoon
-	name = "wooden spoon"
+	name = "wooden spoon (x2)"
 	requirements = list(
 		/obj/item/grown/log/tree= 1,
 	)
 	tool_usage = list(
-		/obj/item/weapon/knife = list("starts to whittle", "start whittle", 'sound/items/wood_sharpen.ogg'),
+		/obj/item/weapon/knife = list("starts to whittle", "start whittling", 'sound/items/wood_sharpen.ogg'),
 	)
 	attacked_atom = /obj/item/grown/log/tree
 	starting_atom = /obj/item/weapon/knife
@@ -163,7 +141,7 @@
 		/obj/item/grown/log/tree= 1,
 	)
 	tool_usage = list(
-		/obj/item/weapon/knife = list("starts to whittle", "start whittle", 'sound/items/wood_sharpen.ogg'),
+		/obj/item/weapon/knife = list("starts to whittle", "start whittling", 'sound/items/wood_sharpen.ogg'),
 	)
 	attacked_atom = /obj/item/grown/log/tree
 	starting_atom = /obj/item/weapon/knife
@@ -177,7 +155,7 @@
 		/obj/item/grown/log/tree/small = 1,
 	)
 	tool_usage = list(
-		/obj/item/weapon/knife = list("starts to whittle", "start whittle", 'sound/items/wood_sharpen.ogg'),
+		/obj/item/weapon/knife = list("starts to whittle", "start whittling", 'sound/items/wood_sharpen.ogg'),
 	)
 	attacked_atom = /obj/item/grown/log/tree/small
 	starting_atom = /obj/item/weapon/knife
@@ -187,12 +165,12 @@
 	uses_attacked_atom = FALSE
 
 /datum/repeatable_crafting_recipe/crafting/woodbowl
-	name = "wooden bowl"
+	name = "wooden bowl (x3)"
 	requirements = list(
 		/obj/item/grown/log/tree/small= 1,
 	)
 	tool_usage = list(
-		/obj/item/weapon/knife = list("starts to whittle", "start whittle", 'sound/items/wood_sharpen.ogg'),
+		/obj/item/weapon/knife = list("starts to whittle", "start whittling", 'sound/items/wood_sharpen.ogg'),
 	)
 	attacked_atom = /obj/item/grown/log/tree/small
 	starting_atom= /obj/item/weapon/knife
@@ -202,12 +180,12 @@
 	uses_attacked_atom = FALSE
 
 /datum/repeatable_crafting_recipe/crafting/woodcup
-	name = "wooden cup"
+	name = "wooden cup (x3)"
 	requirements = list(
 		/obj/item/grown/log/tree/small= 1,
 	)
 	tool_usage = list(
-		/obj/item/weapon/knife = list("starts to whittle", "start whittle", 'sound/items/wood_sharpen.ogg'),
+		/obj/item/weapon/knife = list("starts to whittle", "start whittling", 'sound/items/wood_sharpen.ogg'),
 	)
 	attacked_atom = /obj/item/grown/log/tree/small
 	starting_atom= /obj/item/weapon/knife
@@ -217,12 +195,12 @@
 	uses_attacked_atom = FALSE
 
 /datum/repeatable_crafting_recipe/crafting/woodtray
-	name = "wooden tray"
+	name = "wooden tray (x2)"
 	requirements = list(
 		/obj/item/grown/log/tree/small= 1,
 	)
 	tool_usage = list(
-		/obj/item/weapon/knife = list("starts to whittle", "start whittle", 'sound/items/wood_sharpen.ogg'),
+		/obj/item/weapon/knife = list("starts to whittle", "start whittling", 'sound/items/wood_sharpen.ogg'),
 	)
 	attacked_atom = /obj/item/grown/log/tree/small
 	starting_atom= /obj/item/weapon/knife
@@ -237,7 +215,7 @@
 		/obj/item/grown/log/tree/small= 1,
 	)
 	tool_usage = list(
-		/obj/item/weapon/knife = list("starts to whittle", "start whittle", 'sound/items/wood_sharpen.ogg'),
+		/obj/item/weapon/knife = list("starts to whittle", "start whittling", 'sound/items/wood_sharpen.ogg'),
 	)
 	attacked_atom = /obj/item/grown/log/tree/small
 	starting_atom= /obj/item/weapon/knife
@@ -258,7 +236,7 @@
 	craft_time = 2 SECONDS
 
 /datum/repeatable_crafting_recipe/crafting/arrow
-	name = "stone arrow"
+	name = "stone arrow (x2)"
 	requirements = list(
 		/obj/item/grown/log/tree/stick= 1,
 		/obj/item/natural/stone = 1,
@@ -270,26 +248,13 @@
 	craft_time = 1 SECONDS
 	uses_attacked_atom = TRUE
 
-/datum/repeatable_crafting_recipe/crafting/poisonarrow
-	name = "poison arrow"
-	requirements = list(
-		/obj/item/ammo_casing/caseless/arrow/stone= 1,
-		/obj/item/reagent_containers/food/snacks/produce/jacksberry/poison = 1,
-	)
-	starting_atom = /obj/item/ammo_casing/caseless/arrow/stone
-	attacked_atom = /obj/item/reagent_containers/food/snacks/produce/jacksberry/poison
-	output = /obj/item/ammo_casing/caseless/arrow/poison
-	output_amount = 1
-	craft_time = 1 SECONDS
-	uses_attacked_atom = TRUE
-
 /datum/repeatable_crafting_recipe/crafting/pipe
 	name = "wooden pipe"
 	requirements = list(
 		/obj/item/grown/log/tree/stick= 1,
 	)
 	tool_usage = list(
-		/obj/item/weapon/knife = list("starts to whittle", "start whittle", 'sound/items/wood_sharpen.ogg'),
+		/obj/item/weapon/knife = list("starts to whittle", "start whittling", 'sound/items/wood_sharpen.ogg'),
 	)
 	attacked_atom = /obj/item/grown/log/tree/stick
 	starting_atom  = /obj/item/weapon/knife
@@ -302,7 +267,7 @@
 		/obj/item/grown/log/tree/stick= 1,
 	)
 	tool_usage = list(
-		/obj/item/weapon/knife = list("starts to whittle", "start whittle", 'sound/items/wood_sharpen.ogg'),
+		/obj/item/weapon/knife = list("starts to whittle", "start whittling", 'sound/items/wood_sharpen.ogg'),
 	)
 	attacked_atom = /obj/item/grown/log/tree/stick
 	starting_atom  = /obj/item/weapon/knife
@@ -336,7 +301,7 @@
 		/obj/item/grown/log/tree/small= 1,
 	)
 	tool_usage = list(
-		/obj/item/weapon/knife = list("starts to whittle", "start whittle", 'sound/items/wood_sharpen.ogg'),
+		/obj/item/weapon/knife = list("starts to whittle", "start whittling", 'sound/items/wood_sharpen.ogg'),
 	)
 	attacked_atom = /obj/item/grown/log/tree/small
 	starting_atom= /obj/item/weapon/knife
@@ -350,7 +315,7 @@
 		/obj/item/grown/log/tree/small= 1,
 	)
 	tool_usage = list(
-		/obj/item/weapon/knife = list("starts to whittle", "start whittle", 'sound/items/wood_sharpen.ogg'),
+		/obj/item/weapon/knife = list("starts to whittle", "start whittling", 'sound/items/wood_sharpen.ogg'),
 	)
 	attacked_atom = /obj/item/grown/log/tree/small
 	starting_atom= /obj/item/weapon/knife
@@ -358,96 +323,19 @@
 	craft_time = 5 SECONDS
 	uses_attacked_atom = FALSE
 
-/datum/repeatable_crafting_recipe/crafting/poisonarrow_reagent
-	name = "poison arrow - Dipped"
-	requirements = list(
-		/obj/item/ammo_casing/caseless/arrow/stone= 1,
-	)
-	reagent_requirements = list(
-		/datum/reagent/berrypoison = 5,
-	)
-	starting_atom = /obj/item/ammo_casing/caseless/arrow/stone
-	attacked_atom = /obj/item/reagent_containers/glass
-	output = /obj/item/ammo_casing/caseless/arrow/poison
-	output_amount = 1
-	craft_time = 1 SECONDS
-	uses_attacked_atom = FALSE
-	subtypes_allowed = TRUE
-
-/datum/repeatable_crafting_recipe/crafting/potent_poisonarrow
-	name = "potent poison arrow"
-	requirements = list(
-		/obj/item/ammo_casing/caseless/arrow/stone= 1,
-	)
-	reagent_requirements = list(
-		/datum/reagent/strongpoison = 5,
-	)
-	starting_atom = /obj/item/ammo_casing/caseless/arrow/stone
-	attacked_atom = /obj/item/reagent_containers/glass
-	output = /obj/item/ammo_casing/caseless/arrow/poison/potent
-	output_amount = 1
-	craft_time = 1 SECONDS
-	uses_attacked_atom = FALSE
-	subtypes_allowed = TRUE
-
 /datum/repeatable_crafting_recipe/crafting/pyro_arrow
 	name = "pyroclastic arrow"
 	requirements = list(
-		/obj/item/ammo_casing/caseless/arrow/stone= 1,
+		/obj/item/ammo_casing/caseless/arrow= 1,
 		/obj/item/reagent_containers/food/snacks/produce/fyritius = 1,
 	)
-	starting_atom = /obj/item/ammo_casing/caseless/arrow/stone
+	starting_atom = /obj/item/ammo_casing/caseless/arrow
 	attacked_atom = /obj/item/reagent_containers/food/snacks/produce/fyritius
 	output = /obj/item/ammo_casing/caseless/arrow/pyro
 	craftdiff = 1
 	skillcraft = /datum/skill/craft/engineering
 	craft_time = 1 SECONDS
 	uses_attacked_atom = TRUE
-
-/datum/repeatable_crafting_recipe/crafting/poisonbolt
-	name = "poison bolt"
-	requirements = list(
-		/obj/item/ammo_casing/caseless/bolt= 1,
-		/obj/item/reagent_containers/food/snacks/produce/jacksberry/poison = 1,
-	)
-	starting_atom = /obj/item/ammo_casing/caseless/bolt
-	attacked_atom = /obj/item/reagent_containers/food/snacks/produce/jacksberry/poison
-	output = /obj/item/ammo_casing/caseless/bolt/poison
-	output_amount = 1
-	craft_time = 1 SECONDS
-	uses_attacked_atom = TRUE
-
-/datum/repeatable_crafting_recipe/crafting/poisonbolt_reagent
-	name = "poison bolt - Dipped"
-	requirements = list(
-		/obj/item/ammo_casing/caseless/bolt= 1,
-	)
-	reagent_requirements = list(
-		/datum/reagent/berrypoison = 5,
-	)
-	starting_atom = /obj/item/ammo_casing/caseless/bolt
-	attacked_atom = /obj/item/reagent_containers/glass
-	output = /obj/item/ammo_casing/caseless/bolt/poison
-	output_amount = 1
-	craft_time = 1 SECONDS
-	uses_attacked_atom = FALSE
-	subtypes_allowed = TRUE
-
-/datum/repeatable_crafting_recipe/crafting/potent_poisonbolt
-	name = "potent poison bolt"
-	requirements = list(
-		/obj/item/ammo_casing/caseless/bolt= 1,
-	)
-	reagent_requirements = list(
-		/datum/reagent/strongpoison = 5,
-	)
-	starting_atom = /obj/item/ammo_casing/caseless/bolt
-	attacked_atom = /obj/item/reagent_containers/glass
-	output = /obj/item/ammo_casing/caseless/bolt/poison/potent
-	output_amount = 1
-	craft_time = 1 SECONDS
-	uses_attacked_atom = FALSE
-	subtypes_allowed = TRUE
 
 /datum/repeatable_crafting_recipe/crafting/pyro_bolt
 	name = "pyroclastic bolt"
@@ -460,19 +348,6 @@
 	output = /obj/item/ammo_casing/caseless/bolt/pyro
 	craftdiff = 1
 	skillcraft = /datum/skill/craft/engineering
-	craft_time = 1 SECONDS
-	uses_attacked_atom = TRUE
-
-/datum/repeatable_crafting_recipe/crafting/poison_dart
-	name = "poison dart"
-	requirements = list(
-		/obj/item/ammo_casing/caseless/dart= 1,
-		/obj/item/reagent_containers/food/snacks/produce/jacksberry/poison = 1,
-	)
-	starting_atom = /obj/item/ammo_casing/caseless/dart
-	attacked_atom = /obj/item/reagent_containers/food/snacks/produce/jacksberry/poison
-	output = /obj/item/ammo_casing/caseless/dart/poison
-	output_amount = 1
 	craft_time = 1 SECONDS
 	uses_attacked_atom = TRUE
 
@@ -543,7 +418,7 @@
 		/obj/item/natural/wood/plank= 2,
 	)
 	tool_usage = list(
-		/obj/item/weapon/knife = list("starts to whittle", "start whittle", 'sound/items/wood_sharpen.ogg'),
+		/obj/item/weapon/knife = list("starts to whittle", "start whittling", 'sound/items/wood_sharpen.ogg'),
 	)
 	attacked_atom = /obj/item/natural/wood/plank
 	starting_atom  = /obj/item/weapon/knife

--- a/code/modules/crafting/quality_of_crafting/natural_items.dm
+++ b/code/modules/crafting/quality_of_crafting/natural_items.dm
@@ -41,6 +41,7 @@
 	output = /obj/item/ammo_casing/caseless/dart
 	craftdiff = 0
 	uses_attacked_atom = TRUE
+	output_amount = 2
 
 /datum/repeatable_crafting_recipe/survival/rope
 	name = "rope"

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -43,7 +43,6 @@
 /obj/item/ammo_casing/update_icon()
 	..()
 	icon_state = "[initial(icon_state)]"
-	desc = ""
 
 //proc to magically refill a casing with a new projectile
 /obj/item/ammo_casing/proc/newshot() //For energy weapons, syringe gun, shotgun shells and wands (!).

--- a/code/modules/reagents/reagent_containers/bottles/_bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottles/_bottle.dm
@@ -28,9 +28,9 @@ GLOBAL_LIST_INIT(wisdoms, world.file2list("strings/rt/wisdoms.txt"))
 
 
 /obj/item/reagent_containers/glass/bottle/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/paper) && !istype(I, /obj/item/paper/scroll))
-		if (!can_label_bottle)
-			return
+	if(I.type == /obj/item/paper)
+		if(!can_label_bottle)
+			return ..()
 		var/input = input(user, "What would you like to label this bottle as?", "", "") as text
 		if(!input)
 			if (original_name)
@@ -43,17 +43,15 @@ GLOBAL_LIST_INIT(wisdoms, world.file2list("strings/rt/wisdoms.txt"))
 			return ..()
 		if (!original_name)
 			original_name = name
-		to_chat(user, span_notice("You label this as a [input] [original_name]."))
-		name ="[input] [original_name]"
+		to_chat(user, span_notice("You label this as \a [input] [original_name]."))
+		name = "[input] [original_name]"
 		if (name != original_name)
 			if (original_icon_state == null)
 				original_icon_state = icon_state
 				icon_state = "[icon_state]_message"
-	if(reagents.total_volume)
-		return
 	if(closed)
 		return
-	if(istype(I, /obj/item/paper/scroll))
+	if(!reagents.total_volume && istype(I, /obj/item/paper/scroll))
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
 			var/obj/item/paper/scroll/P = I


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
- Arrows, bolts, and darts can be dipped in any reagent now. Poison projectile crafting recipes removed. Pyroclastic arrows and bolts unchanged.
- Cloth and rope can be equipped directly to the belt slot to tie a belt. Use cloth and rope belts inhand to untie them. Cloth and rope belt recipes removed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
Gets rid of some slapcrafting for more intuitive gameplay.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
