### PR TITLE
(BALANCE) Estoc Rebalancing

### DIFF
--- a/code/game/objects/items/weapons/melee/swords.dm
+++ b/code/game/objects/items/weapons/melee/swords.dm
@@ -907,7 +907,8 @@
 	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
 	reach = 2
 	penfactor = AP_SWORD_THRUST+30 //50 total
-	chargetime = 7
+	chargetime = 5
+	no_early_release = TRUE
 	recovery = 20
 	clickcd = 10
 

--- a/code/game/objects/items/weapons/melee/swords.dm
+++ b/code/game/objects/items/weapons/melee/swords.dm
@@ -835,7 +835,7 @@
 	smeltresult = /obj/item/ingot/iron
 	associated_skill = /datum/skill/combat/swords
 	max_blade_int = 300
-	wdefense = AVERAGE_PARRY
+	wdefense = GREAT_PARRY
 	wbalance = DODGE_CHANCE_NORMAL
 
 /obj/item/weapon/estoc/getonmobprop(tag)

--- a/code/game/objects/items/weapons/melee/swords.dm
+++ b/code/game/objects/items/weapons/melee/swords.dm
@@ -835,7 +835,8 @@
 	smeltresult = /obj/item/ingot/iron
 	associated_skill = /datum/skill/combat/swords
 	max_blade_int = 300
-	wdefense = 5
+	wdefense = 3
+	wbalance = DODGE_CHANCE_NORMAL
 
 /obj/item/weapon/estoc/getonmobprop(tag)
 	. = ..()

--- a/code/game/objects/items/weapons/melee/swords.dm
+++ b/code/game/objects/items/weapons/melee/swords.dm
@@ -835,7 +835,7 @@
 	smeltresult = /obj/item/ingot/iron
 	associated_skill = /datum/skill/combat/swords
 	max_blade_int = 300
-	wdefense = 3
+	wdefense = AVERAGE_PARRY
 	wbalance = DODGE_CHANCE_NORMAL
 
 /obj/item/weapon/estoc/getonmobprop(tag)
@@ -893,7 +893,7 @@
 
 /datum/intent/sword/thrust/estoc
 	name = "thrust"
-	penfactor = 30
+	penfactor = AP_SWORD_THRUST+10 //30 total
 	recovery = 20
 	clickcd = 10
 
@@ -906,7 +906,7 @@
 	blade_class = BCLASS_STAB
 	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
 	reach = 2
-	penfactor = 50
+	penfactor = AP_SWORD_THRUST+30 //50 total
 	chargetime = 7
 	recovery = 20
 	clickcd = 10

--- a/code/game/objects/items/weapons/melee/swords.dm
+++ b/code/game/objects/items/weapons/melee/swords.dm
@@ -892,7 +892,7 @@
 
 /datum/intent/sword/thrust/estoc
 	name = "thrust"
-	penfactor = 50
+	penfactor = 30
 	recovery = 20
 	clickcd = 10
 
@@ -905,9 +905,8 @@
 	blade_class = BCLASS_STAB
 	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
 	reach = 2
-	penfactor = 30
-	damfactor = 1.2
-	chargetime = 5
+	penfactor = 50
+	chargetime = 7
 	recovery = 20
 	clickcd = 10
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

Estoc's thrust now only has 30AP and gives the 50AP attack to Lunge. Removes the chop intent as it is meant to be an edgeless blade and adds a normal sword thrust to its one-handed intents. It is now easier to dodge as it is already a good weapon against armor users and it is now just as good as other swords at parrying. (why was it ultimate parry in the first place?)

## Why It's Good For The Game

Estoc is a sword that has all of these

    Highest AP in swords, only bested by flails and impale warhammers
    Ultimate Parry
    Very Hard to Dodge
    Only one with a spammeable high AP attack

It wasn't balanced at all and it showed. Now the estoc is still the best AP sword, but it is no longer the best sword or best weapon in the game, it serves its purpose as an armor piercing weapon without being overwhelming. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
