### PR TITLE
(BALANCE) Lucerne & Eagle Beak impale

### DIFF
--- a/code/game/objects/items/weapons/melee/polearms.dm
+++ b/code/game/objects/items/weapons/melee/polearms.dm
@@ -334,7 +334,7 @@
 	force_wielded = DAMAGE_SPEAR_WIELD
 	slowdown = 1
 	possible_item_intents = list(POLEARM_BASH, /datum/intent/polearm/chop) //bash is for nonlethal takedowns, only targets limbs
-	gripped_intents = list(POLEARM_BASH, POLEARM_THRUST, /datum/intent/mace/smash/heavy,/datum/intent/polearm/chop)
+	gripped_intents = list(POLEARM_BASH, POLEARM_THRUST, /datum/intent/mace/smash/heavy, /datum/intent/mace/warhammer/impale)
 	name = "eagle's beak"
 	desc = "A reinforced pole affixed with an ornate steel eagle's head, of which it's beak is intended to pierce with great harm."
 	icon_state = "eaglebeak"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

Eagle Beak loses its chop (the sprite clearly shows a bec-de-corbin, it should be used to pick, thrust at people or smash their heads in) and gains the impale from the warhammer, making use of the "eagle beak" part of the weapon. (The lucerne is also affected as it is the iron version of the eagle beak)

This will make them significantly better against armor as Impale is the highest AP attack in the game, but it takes a very long time to charge and it punishes misses. At the very least these weapons will at least be a good alternative to the halberd supremacy in regards to polearms.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Eagle Beak clearly shows it is a hammer with teeth. That isn't a chop weapon and it didn't even use the "eagle beak" part of it. This change makes it a great weapon for AP and bludgeoning though decidedly worse against unarmored opponents, compared to the Halberd. The impale is awfully slow so it isn't great.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
