### PR TITLE
Fixes bottle bombs so they always break on failure.

### DIFF
--- a/code/game/objects/items/bombs.dm
+++ b/code/game/objects/items/bombs.dm
@@ -10,7 +10,7 @@
 	throw_speed = 0.5
 	var/fuze = 50
 	var/lit = FALSE
-	var/prob2fail = 10
+	var/prob2fail = 5 // It should be lower I think
 	var/lit_state = "clear_bomb_lit"
 	grid_width = 32
 	grid_height = 64
@@ -62,15 +62,14 @@
 	if(T)
 		if(lit)
 			if(!skipprob && prob(prob2fail))
-				snuff()
+				playsound(T, 'sound/items/firesnuff.ogg', 100) //changed to always smash if it fails
+				new /obj/item/natural/glass/shard (T)
 			else
 				explosion(T, light_impact_range = 1, hotspot_range = 2, smoke = TRUE, soundin = pick('sound/misc/explode/bottlebomb (1).ogg','sound/misc/explode/bottlebomb (2).ogg'))
 		else
-			if(prob(prob2fail))
-				snuff()
-			else
-				playsound(T, 'sound/items/firesnuff.ogg', 100)
-				new /obj/item/natural/glass/shard (T)
+			playsound(T, 'sound/items/firesnuff.ogg', 100)
+			new /obj/item/natural/glass/shard (T)
+
 	qdel(src)
 
 /obj/item/bomb/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)

--- a/code/game/objects/items/bombs.dm
+++ b/code/game/objects/items/bombs.dm
@@ -10,7 +10,7 @@
 	throw_speed = 0.5
 	var/fuze = 50
 	var/lit = FALSE
-	var/prob2fail = 5 // It should be lower I think
+	var/prob2fail = 5
 	var/lit_state = "clear_bomb_lit"
 	grid_width = 32
 	grid_height = 64


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
Currently bottle bombs qdel even if they completely fail. The code calls the snuff proc which means there's no feedback for failure. This changes it so then on all fail states of being thrown a bottle bomb breaks and makes a glass shard. 

The prob chance used to also be a lot higher but I still lowered it a bit more too from what it was. I can undo that if you want but I feel the decent ones should work more often than not.

video:

https://github.com/user-attachments/assets/13d4e74f-fe1d-4c56-95b6-2605ca70d2ba


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
sometimes people throw a bomb and have no idea what happened to it due to the qdel with no feedback.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
