### PR TITLE
NUKES PQ gain from corpse handling

### DIFF
--- a/code/__DEFINES/playerquality.dm
+++ b/code/__DEFINES/playerquality.dm
@@ -1,4 +1,0 @@
-#define PQ_GAIN_BURIAL 0 //Vanderlin change
-#define PQ_GAIN_BURIAL_COIN 0
-#define PQ_GAIN_REVIVE 0
-#define PQ_GAIN_UNZOMBIFY 0

--- a/code/__DEFINES/playerquality.dm
+++ b/code/__DEFINES/playerquality.dm
@@ -1,4 +1,4 @@
 #define PQ_GAIN_BURIAL 0 //Vanderlin change
-#define PQ_GAIN_BURIAL_COIN 0.05
-#define PQ_GAIN_REVIVE 0.1
-#define PQ_GAIN_UNZOMBIFY 0.1
+#define PQ_GAIN_BURIAL_COIN 0
+#define PQ_GAIN_REVIVE 0
+#define PQ_GAIN_UNZOMBIFY 0

--- a/code/modules/mob/living/carbon/spirit/spirit.dm
+++ b/code/modules/mob/living/carbon/spirit/spirit.dm
@@ -172,10 +172,10 @@
 	return src
 
 /mob/proc/pacifyme(mob/user)
-	return pacify_corpse(src, user, coin_pq = 0)
+	return pacify_corpse(src, user)
 
 /// Proc that will search inside a given atom for any corpses and pacify them
-/proc/pacify_coffin(atom/movable/coffin, mob/user, deep = TRUE, burial_pq = PQ_GAIN_BURIAL)
+/proc/pacify_coffin(atom/movable/coffin, mob/user, deep = TRUE)
 	if(!coffin)
 		return FALSE
 	var/success = FALSE
@@ -195,14 +195,12 @@
 		for(var/atom/movable/stuffing in coffin)
 			if(isliving(stuffing) || istype(stuffing, /obj/item/bodypart/head))
 				continue
-			if(pacify_coffin(stuffing, user, deep, burial_pq = 0))
+			if(pacify_coffin(stuffing, user, deep))
 				success = TRUE
-	if(success && burial_pq && user?.ckey)
-		adjust_playerquality(burial_pq, user.ckey)
 	return success
 
 /// Proc that finds the client associated with a given corpse and either 1. Lets ghosts skip Underworld and return to lobby 2. Gives spirits a toll
-/proc/pacify_corpse(mob/living/corpse, mob/user, coin_pq = PQ_GAIN_BURIAL_COIN)
+/proc/pacify_corpse(mob/living/corpse, mob/user)
 	if(QDELETED(corpse) || QDELETED(corpse.mind) || (corpse.stat != DEAD))
 		testing("pacify_corpse fail ([corpse.mind?.key || "no key"])")
 		return FALSE
@@ -229,8 +227,6 @@
 					else
 						spirit.put_in_hands(new /obj/item/underworld/coin)
 						to_chat(spirit, span_rose("A coin falls from above into your hands!"))
-					if(coin_pq && user?.ckey)
-						adjust_playerquality(coin_pq, user.ckey)
 					return TRUE
 	else
 		ghost = corpse.ghostize(force_respawn = TRUE)

--- a/code/modules/spells/spell_types/invoked/acolyte/astrata.dm
+++ b/code/modules/spells/spell_types/invoked/acolyte/astrata.dm
@@ -62,8 +62,6 @@
 	miracle = TRUE
 	devotion_cost = 100
 //	req_inhand = list(/obj/item/coin/gold)
-	/// Amount of PQ gained for reviving people
-	var/revive_pq = PQ_GAIN_REVIVE
 
 /obj/effect/proc_holder/spell/invoked/revive/cast(list/targets, mob/living/user)
 	if(isliving(targets[1]))
@@ -102,8 +100,7 @@
 		target.update_body()
 		target.visible_message("<span class='notice'>[target] is revived by holy light!</span>", "<span class='green'>I awake from the void.</span>")
 		target.apply_status_effect(/datum/status_effect/debuff/revive)
-		if(target.mind && revive_pq && !HAS_TRAIT(target, TRAIT_IWASREVIVED) && user?.ckey)
-			adjust_playerquality(revive_pq, user.ckey)
+		if(target.mind && !HAS_TRAIT(target, TRAIT_IWASREVIVED))
 			ADD_TRAIT(target, TRAIT_IWASREVIVED, "[type]")
 		return ..()
 	return FALSE

--- a/code/modules/spells/spell_types/invoked/acolyte/pestra.dm
+++ b/code/modules/spells/spell_types/invoked/acolyte/pestra.dm
@@ -149,8 +149,6 @@
 	charge_max = 2 MINUTES
 	miracle = TRUE
 	devotion_cost = 100
-	/// Amount of PQ gained for curing zombos
-	var/unzombification_pq = PQ_GAIN_UNZOMBIFY
 
 /obj/effect/proc_holder/spell/invoked/cure_rot/cast(list/targets, mob/living/user)
 	if(isliving(targets[1]))
@@ -177,8 +175,7 @@
 			target.Unconscious(20 SECONDS)
 			target.emote("breathgasp")
 			target.Jitter(100)
-			if(unzombification_pq && !HAS_TRAIT(target, TRAIT_IWASUNZOMBIFIED) && user?.ckey)
-				adjust_playerquality(unzombification_pq, user.ckey)
+			if(!HAS_TRAIT(target, TRAIT_IWASUNZOMBIFIED))
 				ADD_TRAIT(target, TRAIT_IWASUNZOMBIFIED, "[type]")
 		var/datum/component/rot/rot = target.GetComponent(/datum/component/rot)
 		if(rot)

--- a/stonekeep.dme
+++ b/stonekeep.dme
@@ -94,7 +94,6 @@
 #include "code\__DEFINES\particle_weather.dm"
 #include "code\__DEFINES\particles.dm"
 #include "code\__DEFINES\patreon.dm"
-#include "code\__DEFINES\playerquality.dm"
 #include "code\__DEFINES\plexora.dm"
 #include "code\__DEFINES\pollution.dm"
 #include "code\__DEFINES\preferences.dm"


### PR DESCRIPTION
## About The Pull Request

PQ gain from revival, burial, and rot cure has been entirely removed.
PQ definition file with values used for these PQ gain functions has also been removed.

Traits that track whether a target was subject to revival or rot cure are retained. Currently I believe these are only used to track mechanical PQ but with the current coder hot topic being nerfing revivals in some way, I'm sure they can be made use of.

## Why It's Good For The Game

Host request ahead of a more fundamental realignment of how PQ works. Currently, PQ is meant to be good RP points, and playing as an Astrata acolyte does not automatically make you good at RP. If resurrection is made expensive or difficult in the future then perhaps that dedication should be rewarded mechanically again, but right now it is just holding middle click for a few seconds.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
