### PR TITLE
Organs rot, and must eat multiple organs for food buff

### DIFF
--- a/code/modules/crafting/alchemy/reagents.dm
+++ b/code/modules/crafting/alchemy/reagents.dm
@@ -363,6 +363,9 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 	if(!HAS_TRAIT(M, TRAIT_NASTY_EATER) && !HAS_TRAIT(M, TRAIT_ORGAN_EATER))
 		M.add_nausea(9)
 		M.adjustToxLoss(2)
+	else if(volume >= 1.5 && HAS_TRAIT(M, TRAIT_ORGAN_EATER))
+		M.apply_status_effect(/datum/status_effect/buff/foodbuff)
+		M.reagents.remove_reagent(/datum/reagent/organpoison, 1.5)
 	return ..()
 
 /datum/reagent/stampoison

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -31,6 +31,8 @@
 	/// List of Maniac datums that have inscribed on this heart
 	var/maniacs = list()
 
+	food_type = /obj/item/reagent_containers/food/snacks/organ/heart
+
 /obj/item/organ/heart/examine(mob/user)
 	. = ..()
 	if(IsAdminGhost(user) && inscryptions)

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -15,6 +15,7 @@
 	now_fixed = "<span class='warning'>My lungs seem to once again be able to hold air.</span>"
 	high_threshold_cleared = "<span class='info'>The constriction around my chest loosens as my breathing calms down.</span>"
 
+	food_type = /obj/item/reagent_containers/food/snacks/organ/lungs
 
 /obj/item/organ/lungs/on_life()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
- Organs rot in about 5 minutes to eat
- Graggarites must eat two stomach organs in quick succession to receive the food buff. Lungs and hearts meet the requirement with just one organ

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
Graggarites in shambles.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
