### PR TITLE
Doom poison band-aid

### DIFF
--- a/code/modules/crafting/alchemy/ingredients.dm
+++ b/code/modules/crafting/alchemy/ingredients.dm
@@ -219,7 +219,7 @@
 
 	major_pot = /datum/alch_cauldron_recipe/big_stamina_potion
 	med_pot = /datum/alch_cauldron_recipe/lck_potion
-	minor_pot = /datum/alch_cauldron_recipe/int_potion
+	minor_pot = /datum/alch_cauldron_recipe/doompoison
 
 /obj/item/alch/transisdust
 	name = "transis dust"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

Replaces Alchemical Ozium's Intelligence potion weight with a Doom poison one. There are still plenty of Int potion ingredients and now Doom poison is brewable too. (man makes worst PR in history, one single line change. asked to leave github forever)

## Why It's Good For The Game

Because now you can actually make something new with these ingredients instead of having two plants with useless weights. Also assassins don't have to cope if they run out of their own.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
closes issue #822 