### PR TITLE
Merchant List Update + Brigandine Edit

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -325,9 +325,10 @@ Thing can move up or down an armor class by significant changes to coverage & cr
 #define ARMOR_MAILLE		list("blunt" = 55, "slash" = 55, "stab" = 55, "piercing" = 40, "fire" = 0, "acid" = 0)
 #define ARMOR_MAILLE_GOOD	list("blunt" = 60, "slash" = 60, "stab" = 60, "piercing" = 45, "fire" = 0, "acid" = 0)
 #define ARMOR_SCALE			list("blunt" = 65, "slash" = 65, "stab" = 65, "piercing" = 65, "fire" = 0, "acid" = 0)
+#define ARMOR_BRIGANDINE	list("blunt" = 70, "slash" = 70, "stab" = 70, "piercing" = 50, "fire" = 0, "acid" = 0)
 
 // Heavy AC
-#define ARMOR_PLATE_BAD		list("blunt" = 70, "slash" = 70, "stab" = 70, "piercing" = 50, "fire" = 0, "acid" = 0)
+#define ARMOR_PLATE_BAD		list("blunt" = 75, "slash" = 75, "stab" = 75, "piercing" = 55, "fire" = 0, "acid" = 0)
 #define ARMOR_PLATE			list("blunt" = 85, "slash" = 85, "stab" = 85, "piercing" = 70, "fire" = 0, "acid" = 0)
 #define ARMOR_PLATE_GOOD	list("blunt" = 90, "slash" = 90, "stab" = 90, "piercing" = 85, "fire" = 0, "acid" = 0)
 

--- a/code/game/objects/items/gems.dm
+++ b/code/game/objects/items/gems.dm
@@ -114,7 +114,7 @@
 	slot_flags = ITEM_SLOT_MOUTH
 	dropshrink = 0.4
 	drop_sound = 'sound/items/gem.ogg'
-	sellprice = 554
+	sellprice = 454
 
 /obj/item/riddleofsteel/Initialize()
 	. = ..()

--- a/code/modules/cargo/supply_packs/armor.dm
+++ b/code/modules/cargo/supply_packs/armor.dm
@@ -70,7 +70,7 @@
 
 /datum/supply_pack/armor/studleather_masterwork
 	name = "Masterwork Leather Armor"
-	cost = 53
+	cost = 63
 	contains = /obj/item/clothing/armor/leather/masterwork
 
 /datum/supply_pack/armor/chainmail_iron
@@ -124,7 +124,7 @@
 	contains = /obj/item/clothing/gloves/chain/iron
 
 /datum/supply_pack/armor/plate_gloves
-	name = "Heavy Plate Gloves" // get gpt to analyze prices. explain what an ingot is worth, average coinage of persons and etc
+	name = "Heavy Plate Gloves"
 	cost = 34
 	contains = /obj/item/clothing/gloves/plate
 

--- a/code/modules/cargo/supply_packs/armor.dm
+++ b/code/modules/cargo/supply_packs/armor.dm
@@ -5,51 +5,91 @@
 
 /datum/supply_pack/armor/skullcap
 	name = "Skullcap Helmet"
-	cost = 30
+	cost = 27
 	contains = /obj/item/clothing/head/helmet/skullcap
+
+/datum/supply_pack/armor/poth
+	name = "Pot Helmet"
+	cost = 29
+	contains = /obj/item/clothing/head/helmet/ironpot
+
+/datum/supply_pack/armor/nasalh
+	name = "Nasal Helmet"
+	cost = 31
+	contains = /obj/item/clothing/head/helmet/nasal
 
 /datum/supply_pack/armor/sallet
 	name = "Sallet Helmet"
-	cost = 30
+	cost = 35
 	contains = /obj/item/clothing/head/helmet/sallet
+
+/datum/supply_pack/armor/visorsallet
+	name = "Visored Sallet"
+	cost = 67
+	contains = /obj/item/clothing/head/helmet/visored/sallet
+
+/datum/supply_pack/armor/hounskull
+	name = "Hounskull Helmet"
+	cost = 70
+	contains = /obj/item/clothing/head/helmet/visored/hounskull
 
 /datum/supply_pack/armor/buckethelm
 	name = "Great Helm"
-	cost = 70
+	cost = 73
 	contains = /obj/item/clothing/head/helmet/heavy/bucket
 
 /datum/supply_pack/armor/imask
 	name = "Iron Facemask"
-	cost = 20
+	cost = 31
 	contains = /obj/item/clothing/face/facemask
+
+/datum/supply_pack/armor/smask
+	name = "Steel Facemask"
+	cost = 39
+	contains = /obj/item/clothing/face/facemask/steel
 
 /datum/supply_pack/armor/chaincoif_iron
 	name = "Iron Chain Coif"
-	cost = 20
+	cost = 27
 	contains = /obj/item/clothing/neck/chaincoif/iron
 
 /datum/supply_pack/armor/gambeson
 	name = "Cloth Gambeson"
-	cost = 14
+	cost = 24
 	contains = /obj/item/clothing/armor/gambeson
 
 /datum/supply_pack/armor/leather_armor
 	name = "Leather Armor"
-	cost = 20
+	cost = 26
 	contains = /obj/item/clothing/armor/leather
 
 /datum/supply_pack/armor/studleather
 	name = "Studded Leather Armor"
-	cost = 30
+	cost = 33
 	contains = /obj/item/clothing/armor/leather/splint
+
+/datum/supply_pack/armor/studleather_masterwork
+	name = "Masterwork Leather Armor"
+	cost = 53
+	contains = /obj/item/clothing/armor/leather/masterwork
 
 /datum/supply_pack/armor/chainmail_iron
 	name = "Iron Chainmail"
-	cost = 22
+	cost = 35
 	contains = /obj/item/clothing/armor/chainmail/iron
 
+/datum/supply_pack/armor/chainmail_hauberk
+	name = "Hauberk"
+	cost = 55
+	contains = /obj/item/clothing/armor/chainmail/hauberk
+
+/datum/supply_pack/armor/cuirass_iron
+	name = "Iron Cuirass"
+	cost = 45
+	contains = /obj/item/clothing/armor/cuirass/iron
+
 /datum/supply_pack/armor/cuirass
-	name = "Breastplate"
+	name = "Steel Cuirass"
 	cost = 50
 	contains = /obj/item/clothing/armor/cuirass
 
@@ -58,32 +98,52 @@
 	cost = 100
 	contains = /obj/item/clothing/armor/brigandine
 
+/datum/supply_pack/armor/coatofplates
+	name = "Coat Of Plates"
+	cost = 110
+	contains = /obj/item/clothing/armor/brigandine/coatplates
+
 /datum/supply_pack/armor/leather_bracers
 	name = "Leather Bracers"
-	cost = 6
+	cost = 15
 	contains = /obj/item/clothing/wrists/bracers/leather
 
 /datum/supply_pack/armor/bracers
 	name = "Steel Bracers"
-	cost = 25
+	cost = 29
 	contains = /obj/item/clothing/wrists/bracers
 
 /datum/supply_pack/armor/angle_gloves
 	name = "Heavy Leather Gloves"
-	cost = 15
+	cost = 16
 	contains = /obj/item/clothing/gloves/angle
 
 /datum/supply_pack/armor/chain_gloves_iron
 	name = "Iron Chain Gloves"
-	cost = 20
+	cost = 26
 	contains = /obj/item/clothing/gloves/chain/iron
+
+/datum/supply_pack/armor/plate_gloves
+	name = "Heavy Plate Gloves" // get gpt to analyze prices. explain what an ingot is worth, average coinage of persons and etc
+	cost = 34
+	contains = /obj/item/clothing/gloves/plate
 
 /datum/supply_pack/armor/chainlegs_iron
 	name = "Iron Chain Chausses"
-	cost = 20
+	cost = 29
 	contains = /obj/item/clothing/pants/chainlegs/iron
+
+/datum/supply_pack/armor/chainlegs_steel
+	name = "Steel Chain Chausses"
+	cost = 33
+	contains = /obj/item/clothing/pants/chainlegs
 
 /datum/supply_pack/armor/light_armor_boots
 	name = "Iron Boots"
-	cost = 20
+	cost = 27
 	contains = /obj/item/clothing/shoes/boots/armor/light
+
+/datum/supply_pack/armor/steel_boots
+	name = "Plate Boots"
+	cost = 32
+	contains = /obj/item/clothing/shoes/boots/armor

--- a/code/modules/cargo/supply_packs/food.dm
+++ b/code/modules/cargo/supply_packs/food.dm
@@ -64,12 +64,12 @@
 
 /datum/supply_pack/food/grenzelbeer
 	name = "Grenzelhoftian Bitter Beer"
-	cost = 15
+	cost = 19
 	contains = /obj/item/reagent_containers/glass/bottle/beer/hagwoodbitter
 
 /datum/supply_pack/food/elfbeer
 	name = "Elvish Beer"
-	cost = 30
+	cost = 33
 	contains = /obj/item/reagent_containers/glass/bottle/beer/aurorian
 
 /datum/supply_pack/food/elfcab
@@ -79,47 +79,47 @@
 
 /datum/supply_pack/food/butterhair
 	name = "Dwarvish Butterhairs"
-	cost = 40
+	cost = 41
 	contains = /obj/item/reagent_containers/glass/bottle/beer/butterhairs
 
 /datum/supply_pack/food/stonebeard
 	name = "Stonebeards Reserve"
-	cost = 35
+	cost = 37
 	contains = /obj/item/reagent_containers/glass/bottle/beer/stonebeardreserve
 
 /datum/supply_pack/food/voddena
 	name = "Dwarven Voddena"
-	cost = 30
+	cost = 35
 	contains = /obj/item/reagent_containers/glass/bottle/beer/voddena
 
 /datum/supply_pack/food/winezybantu
 	name = "Zybantu Wine"
-	cost = 15
+	cost = 20
 	contains = /obj/item/reagent_containers/glass/bottle/wine
 
 /datum/supply_pack/food/winegrenzel
 	name = "Grenzelhoftian Sour Wine"
-	cost = 20
+	cost = 25
 	contains = /obj/item/reagent_containers/glass/bottle/wine/sourwine
 
 /datum/supply_pack/food/winevalorred
 	name = "Valorian Red Wine"
-	cost = 40
+	cost = 45
 	contains = /obj/item/reagent_containers/glass/bottle/redwine
 
 /datum/supply_pack/food/winevalorwhite
 	name = "Valorian White Wine"
-	cost = 30
+	cost = 35
 	contains = /obj/item/reagent_containers/glass/bottle/whitewine
 
 /datum/supply_pack/food/elfred
 	name = "Elvish Red Wine"
-	cost = 103
+	cost = 154
 	contains = /obj/item/reagent_containers/glass/bottle/elfred
 
 /datum/supply_pack/food/elfblue
 	name = "Valmora Blue Wine"
-	cost = 165
+	cost = 305
 	contains = /obj/item/reagent_containers/glass/bottle/elfblue
 
 /datum/supply_pack/food/meat

--- a/code/modules/cargo/supply_packs/food.dm
+++ b/code/modules/cargo/supply_packs/food.dm
@@ -5,36 +5,36 @@
 
 /datum/supply_pack/food/healthpot
 	name = "Healing Potion"
-	cost = 14
+	cost = 24
 	contains = /obj/item/reagent_containers/glass/bottle/healthpot
 
 /datum/supply_pack/food/manapot
 	name = "Manna Potion"
-	cost = 14
+	cost = 18
 	contains = /obj/item/reagent_containers/glass/bottle/manapot
 
 /datum/supply_pack/food/stronghealthpot
 
 	name = "Strong Healing Potion"
-	cost = 28
+	cost = 38
 	contains = /obj/item/reagent_containers/glass/bottle/stronghealthpot
 
 /datum/supply_pack/food/strongmanapot
 
 	name = "Strong Manna Potion"
-	cost = 28
+	cost = 32
 	contains = /obj/item/reagent_containers/glass/bottle/strongmanapot
 
 /datum/supply_pack/food/antidote
 
 	name = "Antidote Potion"
-	cost = 14
+	cost = 16
 	contains = /obj/item/reagent_containers/glass/bottle/antidote
 
 /datum/supply_pack/food/diseasecure
 
 	name = "Disease Cure Potion"
-	cost = 28
+	cost = 32
 	contains = /obj/item/reagent_containers/glass/bottle/diseasecure
 
 /datum/supply_pack/food/water
@@ -64,32 +64,32 @@
 
 /datum/supply_pack/food/grenzelbeer
 	name = "Grenzelhoftian Bitter Beer"
-	cost = 20
+	cost = 15
 	contains = /obj/item/reagent_containers/glass/bottle/beer/hagwoodbitter
 
 /datum/supply_pack/food/elfbeer
 	name = "Elvish Beer"
-	cost = 35
+	cost = 30
 	contains = /obj/item/reagent_containers/glass/bottle/beer/aurorian
 
 /datum/supply_pack/food/elfcab
 	name = "Elvish Fireleaf"
-	cost = 40
+	cost = 35
 	contains = /obj/item/reagent_containers/glass/bottle/beer/fireleaf
 
 /datum/supply_pack/food/butterhair
 	name = "Dwarvish Butterhairs"
-	cost = 50
+	cost = 40
 	contains = /obj/item/reagent_containers/glass/bottle/beer/butterhairs
 
 /datum/supply_pack/food/stonebeard
 	name = "Stonebeards Reserve"
-	cost = 45
+	cost = 35
 	contains = /obj/item/reagent_containers/glass/bottle/beer/stonebeardreserve
 
 /datum/supply_pack/food/voddena
 	name = "Dwarven Voddena"
-	cost = 40
+	cost = 30
 	contains = /obj/item/reagent_containers/glass/bottle/beer/voddena
 
 /datum/supply_pack/food/winezybantu
@@ -99,27 +99,27 @@
 
 /datum/supply_pack/food/winegrenzel
 	name = "Grenzelhoftian Sour Wine"
-	cost = 25
+	cost = 20
 	contains = /obj/item/reagent_containers/glass/bottle/wine/sourwine
 
 /datum/supply_pack/food/winevalorred
 	name = "Valorian Red Wine"
-	cost = 50
+	cost = 40
 	contains = /obj/item/reagent_containers/glass/bottle/redwine
 
 /datum/supply_pack/food/winevalorwhite
 	name = "Valorian White Wine"
-	cost = 35
+	cost = 30
 	contains = /obj/item/reagent_containers/glass/bottle/whitewine
 
 /datum/supply_pack/food/elfred
 	name = "Elvish Red Wine"
-	cost = 165
+	cost = 103
 	contains = /obj/item/reagent_containers/glass/bottle/elfred
 
 /datum/supply_pack/food/elfblue
 	name = "Valmora Blue Wine"
-	cost = 320
+	cost = 165
 	contains = /obj/item/reagent_containers/glass/bottle/elfblue
 
 /datum/supply_pack/food/meat
@@ -134,7 +134,7 @@
 
 /datum/supply_pack/food/cheese
 	name = "Cheese Wheel"
-	cost = 30
+	cost = 25
 	contains = /obj/item/reagent_containers/food/snacks/cheddar
 
 /datum/supply_pack/food/salami

--- a/code/modules/cargo/supply_packs/instruments.dm
+++ b/code/modules/cargo/supply_packs/instruments.dm
@@ -5,7 +5,7 @@
 
 /datum/supply_pack/instruments/mbox
 	name = "Dwarven Music Box"
-	cost = 90
+	cost = 150
 	contains = /obj/item/dmusicbox
 
 /datum/supply_pack/instruments/flute

--- a/code/modules/cargo/supply_packs/instruments.dm
+++ b/code/modules/cargo/supply_packs/instruments.dm
@@ -5,12 +5,12 @@
 
 /datum/supply_pack/instruments/mbox
 	name = "Dwarven Music Box"
-	cost = 150
+	cost = 90
 	contains = /obj/item/dmusicbox
 
 /datum/supply_pack/instruments/flute
 	name = "Flute"
-	cost = 10
+	cost = 15
 	contains = /obj/item/instrument/flute
 
 /datum/supply_pack/instruments/harp
@@ -40,7 +40,7 @@
 
 /datum/supply_pack/instruments/hurdygurdy
 	name = "Hurdy-Gurdy"
-	cost = 30
+	cost = 25
 	contains = list(/obj/item/instrument/hurdygurdy)
 
 /datum/supply_pack/instruments/viola
@@ -50,5 +50,5 @@
 
 /datum/supply_pack/instruments/vocals
 	name = "Vocalist's Talisman"
-	cost = 40
+	cost = 35
 	contains = list(/obj/item/instrument/vocals)

--- a/code/modules/cargo/supply_packs/narcotics.dm
+++ b/code/modules/cargo/supply_packs/narcotics.dm
@@ -43,3 +43,13 @@
 	name = "Perfume"
 	cost = 25
 	contains = list(/obj/item/perfume/random)
+
+/datum/supply_pack/narcotics/poison
+	name = "Poison"
+	cost = 25
+	contains = /obj/item/reagent_containers/glass/bottle/poison
+
+/datum/supply_pack/narcotics/spoison
+	name = "Stamina Poison"
+	cost = 22
+	contains = /obj/item/reagent_containers/glass/bottle/stampoison

--- a/code/modules/cargo/supply_packs/rawmat.dm
+++ b/code/modules/cargo/supply_packs/rawmat.dm
@@ -5,7 +5,7 @@
 
 /datum/supply_pack/rawmats/glass
 	name = "Glass Panes"
-	cost = 50
+	cost = 30
 	contains = list(
 		/obj/item/natural/glass,
 		/obj/item/natural/glass,
@@ -17,9 +17,8 @@
 
 /datum/supply_pack/rawmats/copper
 	name = "Copper Ore"
-	cost = 50
+	cost = 45
 	contains = list(
-		/obj/item/ore/copper,
 		/obj/item/ore/copper,
 		/obj/item/ore/copper,
 		/obj/item/ore/copper,
@@ -28,9 +27,8 @@
 
 /datum/supply_pack/rawmats/tin
 	name = "Tin Ore"
-	cost = 80
+	cost = 45
 	contains = list(/obj/item/ore/tin,
-		/obj/item/ore/tin,
 		/obj/item/ore/tin,
 		/obj/item/ore/tin,
 		/obj/item/ore/tin
@@ -38,7 +36,7 @@
 
 /datum/supply_pack/rawmats/iron
 	name = "Iron Ore"
-	cost = 80
+	cost = 65
 	contains = list(
 		/obj/item/ore/iron,
 		/obj/item/ore/iron,
@@ -59,7 +57,7 @@
 
 /datum/supply_pack/rawmats/cloth
 	name = "Fiber Strands"
-	cost = 4
+	cost = 8
 	contains = list(
 		/obj/item/natural/fibers,
 		/obj/item/natural/fibers,
@@ -70,7 +68,7 @@
 
 /datum/supply_pack/rawmats/cloth
 	name = "Cloth"
-	cost = 10
+	cost = 15
 	contains = list(
 		/obj/item/natural/cloth,
 		/obj/item/natural/cloth,
@@ -92,7 +90,7 @@
 
 /datum/supply_pack/rawmats/silk
 	name = "Silk"
-	cost = 25
+	cost = 28
 	contains = list(
 		/obj/item/natural/silk,
 		/obj/item/natural/silk,
@@ -114,7 +112,7 @@
 
 /datum/supply_pack/rawmats/sinew
 	name = "Animal Bone and Sinew"
-	cost = 15
+	cost = 20
 	contains = list(
 		/obj/item/alch/bone,
 		/obj/item/alch/bone,
@@ -125,7 +123,7 @@
 	)
 /datum/supply_pack/rawmats/riddle_of_steel
 	name = "Riddle of Steel"
-	cost = 1500
+	cost = 1100
 	contains = list(
 		/obj/item/riddleofsteel
 	)

--- a/code/modules/cargo/supply_packs/tools.dm
+++ b/code/modules/cargo/supply_packs/tools.dm
@@ -45,25 +45,24 @@
 
 /datum/supply_pack/tools/flint
 	name = "Flint"
-	cost = 20
+	cost = 10
 	contains = /obj/item/flint
 
 /datum/supply_pack/tools/dyebin
 	name = "Fine dyes"
-	cost = 200
+	cost = 150
 	contains = /obj/structure/dye_bin
-
 
 /datum/supply_pack/tools/candles
 	name = "Candles"
-	cost = 10
+	cost = 8
 	contains = list(/obj/item/candle/yellow,
 	/obj/item/candle/yellow,
 	/obj/item/candle/yellow)
 
 /datum/supply_pack/tools/lamptern
 	name = "Iron Lamptern"
-	cost = 12
+	cost = 20
 	contains = /obj/item/flashlight/flare/torch/lantern
 
 /datum/supply_pack/tools/pick
@@ -73,7 +72,7 @@
 
 /datum/supply_pack/tools/tongs
 	name = "Tongs"
-	cost = 20
+	cost = 15
 	contains = /obj/item/weapon/tongs
 
 /datum/supply_pack/tools/hammer
@@ -103,17 +102,17 @@
 
 /datum/supply_pack/tools/bottle
 	name = "Glass Bottle"
-	cost = 3
+	cost = 2
 	contains = /obj/item/reagent_containers/glass/bottle
 
 /datum/supply_pack/tools/alch_bottle
 	name = "Alchemy Bottle"
-	cost = 1
+	cost = 3
 	contains = /obj/item/reagent_containers/glass/alchemical
 
 /datum/supply_pack/tools/alch_bottles
-	name = "Bulk Alchemy Bottles" //Buy 8 now get 1 free!
-	cost = 8
+	name = "Bulk Alchemy Bottles"
+	cost = 20
 	contains = list(/obj/item/reagent_containers/glass/alchemical,/obj/item/reagent_containers/glass/alchemical,/obj/item/reagent_containers/glass/alchemical,
 	/obj/item/reagent_containers/glass/alchemical,/obj/item/reagent_containers/glass/alchemical,/obj/item/reagent_containers/glass/alchemical,
 	/obj/item/reagent_containers/glass/alchemical,/obj/item/reagent_containers/glass/alchemical,/obj/item/reagent_containers/glass/alchemical)
@@ -125,7 +124,7 @@
 
 /datum/supply_pack/tools/fryingpan
 	name = "Frying Pan"
-	cost = 12
+	cost = 10
 	contains = /obj/item/cooking/pan
 
 /datum/supply_pack/tools/pot
@@ -144,17 +143,17 @@
 
 /datum/supply_pack/tools/wpipe
 	name = "Westman Pipe"
-	cost = 10
+	cost = 5
 	contains = /obj/item/clothing/face/cigarette/pipe/westman
 
 /datum/supply_pack/tools/fishingrod
 	name = "Fishing Rod"
-	cost = 12
+	cost = 10
 	contains = /obj/item/fishingrod
 
 /datum/supply_pack/tools/bait
-	name = "Deluxe Fishing Bait"
-	cost = 6
+	name = "Fishing Grub"
+	cost = 4
 	contains = /obj/item/fishing/bait/deluxe
 
 /datum/supply_pack/tools/fishingline
@@ -189,12 +188,12 @@
 
 /datum/supply_pack/tools/surgerybag
 	name = "Set of Surgical Tools"
-	cost = 100
+	cost = 65
 	contains = /obj/item/storage/backpack/satchel/surgbag
 
 /datum/supply_pack/tools/glassware_set
 	name = "Set of Glassware Cups"
-	cost = 34 // These glasses are really expensive
+	cost = 28 // These glasses are really expensive
 	contains = list(/obj/item/reagent_containers/glass/cup/glassware, /obj/item/reagent_containers/glass/cup/glassware, /obj/item/reagent_containers/glass/cup/glassware)
 
 /datum/supply_pack/tools/glassware_set
@@ -204,5 +203,5 @@
 
 /datum/supply_pack/tools/glassware_set
 	name = "Set of Glassware Shot Glasses"
-	cost = 28 // These glasses are really expensive
+	cost = 26 // These glasses are really expensive
 	contains = list(/obj/item/reagent_containers/glass/cup/glassware/shotglass, /obj/item/reagent_containers/glass/cup/glassware/shotglass, /obj/item/reagent_containers/glass/cup/glassware/shotglass,)

--- a/code/modules/cargo/supply_packs/weapons.dm
+++ b/code/modules/cargo/supply_packs/weapons.dm
@@ -5,33 +5,38 @@
 
 /datum/supply_pack/weapons/shortsword
 	name = "Iron Short Sword"
-	cost = 15
+	cost = 25
 	contains = /obj/item/weapon/sword/short
 
 /datum/supply_pack/weapons/sword
-	name = "Iron Sword"
-	cost = 18
-	contains = /obj/item/weapon/sword/iron
+	name = "Steel Sword"
+	cost = 30
+	contains = /obj/item/weapon/sword
 
 /datum/supply_pack/weapons/greatsword
-	name = "Iron Greatsword"
-	cost = 54
+	name = "Iron Zweihander"
+	cost = 55
 	contains = /obj/item/weapon/sword/long/greatsword/zwei
 
 /datum/supply_pack/weapons/mace
-	name = "Iron Mace"
-	cost = 20
-	contains = /obj/item/weapon/mace
+	name = "Steel Mace"
+	cost = 28
+	contains = /obj/item/weapon/mace/steel
 
 /datum/supply_pack/weapons/greatmace
 	name = "Iron Warclub"
-	cost = 28
+	cost = 26
 	contains = /obj/item/weapon/mace/goden
 
 /datum/supply_pack/weapons/axe
-	name = "Iron Axe"
-	cost = 20
-	contains = /obj/item/weapon/axe/iron
+	name = "Steel Axe"
+	cost = 29
+	contains = /obj/item/weapon/axe/steel
+
+/datum/supply_pack/weapons/halberd
+	name = "Halberd"
+	cost = 51
+	contains = /obj/item/weapon/polearm/halberd
 
 /datum/supply_pack/weapons/huntingknife
 	name = "Iron Hunting Knife"
@@ -39,9 +44,9 @@
 	contains = /obj/item/weapon/knife/hunting
 
 /datum/supply_pack/weapons/dagger
-	name = "Iron Dagger"
-	cost = 12
-	contains = /obj/item/weapon/knife/dagger
+	name = "Steel Dagger"
+	cost = 26
+	contains = /obj/item/weapon/knife/dagger/steel
 
 /datum/supply_pack/weapons/spear
 	name = "Iron Spear"
@@ -49,9 +54,9 @@
 	contains = /obj/item/weapon/polearm/spear
 
 /datum/supply_pack/weapons/flail
-	name = "Iron Flail"
-	cost = 20
-	contains = /obj/item/weapon/flail
+	name = "Steel Flail"
+	cost = 30
+	contains = /obj/item/weapon/flail/sflail
 
 /datum/supply_pack/weapons/whip
 	name = "Leather Whip"
@@ -84,22 +89,27 @@
 
 /datum/supply_pack/weapons/crossbow
 	name = "Crossbow"
-	cost = 40
+	cost = 45
 	contains = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
 
 /datum/supply_pack/weapons/bow
-	name = "Bow"
+	name = "Hunting Bow"
 	cost = 30
 	contains = /obj/item/gun/ballistic/revolver/grenadelauncher/bow
 
+/datum/supply_pack/weapons/bow2
+	name = "Longbow"
+	cost = 35
+	contains = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/long
+
 /datum/supply_pack/weapons/rbow
 	name = "Imported Recurve Bow"
-	cost = 20
+	cost = 30
 	contains = list(/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve)
 
 /datum/supply_pack/weapons/quivers
 	name = "Empty Quiver"
-	cost = 8
+	cost = 5
 	contains = /obj/item/ammo_holder/quiver
 
 /datum/supply_pack/weapons/arrowquiver
@@ -109,15 +119,15 @@
 
 /datum/supply_pack/weapons/boltquiver
 	name = "Quiver of Bolts"
-	cost = 60
+	cost = 35
 	contains = /obj/item/ammo_holder/quiver/bolts
 
 /datum/supply_pack/weapons/arrows
 	name = "Arrow"
-	cost = 2
+	cost = 3
 	contains = /obj/item/ammo_casing/caseless/arrow
 
 /datum/supply_pack/weapons/bolts
 	name = "Crossbow Bolt"
-	cost = 3
+	cost = 2
 	contains = /obj/item/ammo_casing/caseless/bolt

--- a/code/modules/cargo/supply_packs/weapons.dm
+++ b/code/modules/cargo/supply_packs/weapons.dm
@@ -8,8 +8,13 @@
 	cost = 25
 	contains = /obj/item/weapon/sword/short
 
+/datum/supply_pack/weapons/sword_iron
+	name = "Iron Arming Sword"
+	cost = 27
+	contains = /obj/item/weapon/sword/iron
+
 /datum/supply_pack/weapons/sword
-	name = "Steel Sword"
+	name = "Steel Arming Sword"
 	cost = 30
 	contains = /obj/item/weapon/sword
 
@@ -19,7 +24,12 @@
 	contains = /obj/item/weapon/sword/long/greatsword/zwei
 
 /datum/supply_pack/weapons/mace
-	name = "Steel Mace"
+	name = "Iron Mace"
+	cost = 28
+	contains = /obj/item/weapon/mace
+
+/datum/supply_pack/weapons/smace
+	name = "Flanged Steel Mace"
 	cost = 28
 	contains = /obj/item/weapon/mace/steel
 
@@ -29,6 +39,11 @@
 	contains = /obj/item/weapon/mace/goden
 
 /datum/supply_pack/weapons/axe
+	name = "Iron Axe"
+	cost = 26
+	contains = /obj/item/weapon/axe
+
+/datum/supply_pack/weapons/saxe
 	name = "Steel Axe"
 	cost = 29
 	contains = /obj/item/weapon/axe/steel
@@ -40,10 +55,15 @@
 
 /datum/supply_pack/weapons/huntingknife
 	name = "Iron Hunting Knife"
-	cost = 10
+	cost = 17
 	contains = /obj/item/weapon/knife/hunting
 
 /datum/supply_pack/weapons/dagger
+	name = "Iron Dagger"
+	cost = 22
+	contains = /obj/item/weapon/knife/dagger
+
+/datum/supply_pack/weapons/sdagger
 	name = "Steel Dagger"
 	cost = 26
 	contains = /obj/item/weapon/knife/dagger/steel
@@ -54,8 +74,13 @@
 	contains = /obj/item/weapon/polearm/spear
 
 /datum/supply_pack/weapons/flail
+	name = "Military Flail"
+	cost = 29
+	contains = /obj/item/weapon/flail
+
+/datum/supply_pack/weapons/sflail
 	name = "Steel Flail"
-	cost = 30
+	cost = 32
 	contains = /obj/item/weapon/flail/sflail
 
 /datum/supply_pack/weapons/whip

--- a/code/modules/clothing/armor/misc.dm
+++ b/code/modules/clothing/armor/misc.dm
@@ -47,7 +47,7 @@
 	clothing_flags = CANT_SLEEP_IN
 
 	armor_class = AC_HEAVY
-	armor = ARMOR_PLATE_BAD
+	armor = ARMOR_BRIGANDINE
 	body_parts_covered = COVERAGE_ALL_BUT_LEGS
 	max_integrity = INTEGRITY_STRONGEST
 	prevent_crits = ALL_EXCEPT_STAB
@@ -117,6 +117,8 @@
 	icon_state = "coat_of_plates"
 	blocksound = PLATEHIT
 	sellprice = VALUE_SNOWFLAKE_STEEL
+	armor = ARMOR_PLATE_BAD
+	// add armor plate bad from defines
 
 	max_integrity = INTEGRITY_STRONG
 


### PR DESCRIPTION
Updates merchant list pricing to be more logical, following the in-game economy setup by players and the prices we typically see from Smiths. Alongside pricing that makes sense for the amount of work that goes into any item, and it's actual mechanical values.

Examples are Armor being priced slightly higher then what Smiths will charge, but still alongside the general idea of ingot and ore values.

Health potions being priced higher so that the Wizard, Apothecary and Feldscher's skills in alchemy are not devalued. This is also important for ensuring that magical potions in a dark fantasy setting, are not outright seen as commonplace mundane items. In future I will be doing some extensive work on alchemy and potions once the Maintainers are done with their fancy overhauls.

The merchant alongside these price edits has more items to sell, including poisons, more armors, more weapons and better quality in terms of what they have on offer.

Updated the Brigandine also in Define and the value for brig/coat of plates. For history nerds, the Brigandine is actually less protective then a Coat of Plates since it uses smaller overlapping plates as opposed to the Coats larger more durable ones. So now the Brigandine has lower protection, but higher integrity then a Coat of Plates.

Updated the sales price of riddle of steel so that it is more often sold to the Court or used for it's actual purposes. It's buy price in the merchant vendor is also 1100 from 1500. 1500 mammon is basically the entire court's budget which is excessive. I still highly doubt anyone will ever buy this.

Also this has been tested locally twice and is functional.