### PR TITLE
Removes Int Buff From Steam Armor

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -811,10 +811,10 @@
 /datum/status_effect/buff/powered_steam_armor
 	id = "powered_steam"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/powered_steam_armor
-	effectedstats = list(STATKEY_END = 2, STATKEY_CON = 2, STATKEY_INT = 2, STATKEY_STR = 2, STATKEY_SPD = 2)
+	effectedstats = list(STATKEY_END = 2, STATKEY_CON = 2, STATKEY_STR = 2, STATKEY_SPD = 2)
 	duration = -1
 
 /atom/movable/screen/alert/status_effect/buff/powered_steam_armor
 	name = "Powered Steam Armor"
-	desc = "The armor is powered I feel unstoppable."
+	desc = "The armor is powered. I feel unstoppable."
 	icon_state = "buff"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

Removes the intelligence buff from steam armor and adds a period to the description of the buff.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game

Steamknight armor giving a boost to intelligence when powered doesn't make much sense, as it is supposed to provide substantial physical buffs. I would also argue the speed buff is unnecessary since the armor no longer slows you down when powered, but that's not included in this PR.

The tag should be fix or balance change. I feel like the int buff is an oversight, but I'll leave that to whoever reviews PRs. I can't seem to add the tag myself.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
