### PR TITLE
No more microdosing Moondust

### DIFF
--- a/code/modules/reagents/reagent_containers/powder.dm
+++ b/code/modules/reagents/reagent_containers/powder.dm
@@ -176,6 +176,7 @@
 	animate(pixel_y = -1, time = 1, flags = ANIMATION_RELATIVE)
 
 /datum/reagent/moondust/on_mob_end_metabolize(mob/living/M)
+	M.remove_status_effect(/datum/status_effect/buff/moondust)
 	animate(M.client)
 
 /datum/reagent/moondust/on_mob_life(mob/living/carbon/M)
@@ -223,6 +224,7 @@
 /datum/reagent/moondust_purest/on_mob_end_metabolize(mob/living/M)
 	animate(M.client)
 	M.clear_fullscreen("purest_kaif")
+	M.remove_status_effect(/datum/status_effect/buff/moondust_purest)
 
 /datum/reagent/moondust_purest/on_mob_life(mob/living/carbon/M)
 	if(M.reagents.has_reagent(/datum/reagent/moondust))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->
This pr makes it so that it shares the same functionality of spice and swampweed, meaning if they run out in your system the effects go away immediately.
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
There's a specific interaction that prevents you from taking both kinds of moondust by knocking you out, which is circumvented by just taking a small dose for both, letting you reach a -1 action modifier.

This fixes both micro dosing and the particular interaction only punishing those who don't know how to use a pipe or how to boil a pot.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
