### PR TITLE
Fixed Butler Racelock

### DIFF
--- a/code/modules/jobs/job_types/peasants/butler.dm
+++ b/code/modules/jobs/job_types/peasants/butler.dm
@@ -22,8 +22,6 @@
 		"Elf",
 		"Half-Elf",
 		"Dwarf",
-		"Tiefling",
-		"Dark Elf",
 		"Aasimar"
 	)
 


### PR DESCRIPTION
## About The Pull Request

Removes inhumen races from the Butler role. Tieflings & dark-elves may no longer be a butler.

## Why It's Good For The Game

The Butler has intimate knowledge of the Keep, including secret corridors. Additionally, he holds the esteemed position as the head of the household staff & is practically family to the Royal Family. It makes no sense whatsoever for inhumen races to have been promoted to such an esteemed position.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.