### PR TITLE
Gives leylines absorb to archivist and magic book to the magicians that were missed.

### DIFF
--- a/code/datums/migrants/waves/heartfell_wave.dm
+++ b/code/datums/migrants/waves/heartfell_wave.dm
@@ -208,7 +208,6 @@
 	allowed_patrons = list(/datum/patron/divine/noc)
 /datum/outfit/job/heartfelt/magos/pre_equip(mob/living/carbon/human/H)
 	..()
-	H.mana_pool.set_intrinsic_recharge(MANA_ALL_LEYLINES)
 	neck = /obj/item/clothing/neck/talkstone
 	cloak = /obj/item/clothing/cloak/black_cloak
 	armor = /obj/item/clothing/shirt/robe/black

--- a/code/datums/migrants/waves/heartfell_wave.dm
+++ b/code/datums/migrants/waves/heartfell_wave.dm
@@ -208,6 +208,7 @@
 	allowed_patrons = list(/datum/patron/divine/noc)
 /datum/outfit/job/heartfelt/magos/pre_equip(mob/living/carbon/human/H)
 	..()
+	H.mana_pool.set_intrinsic_recharge(MANA_ALL_LEYLINES)
 	neck = /obj/item/clothing/neck/talkstone
 	cloak = /obj/item/clothing/cloak/black_cloak
 	armor = /obj/item/clothing/shirt/robe/black
@@ -215,6 +216,7 @@
 	shoes = /obj/item/clothing/shoes/shortboots
 	belt = /obj/item/storage/belt/leather/plaquesilver
 	beltl = /obj/item/flashlight/flare/torch/lantern
+	beltr = /obj/item/book/granter/spellbook/expert
 	id = /obj/item/clothing/ring/gold
 	r_hand = /obj/item/weapon/polearm/woodstaff
 	backl = /obj/item/storage/backpack/satchel

--- a/code/modules/jobs/job_types/adventurer/types/combat/dredge.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/dredge.dm
@@ -436,11 +436,12 @@
 			Like a wounded bird, I endure the rain with grace. With my sword I take fate into my own hands and strangle it.")
 			)
 		if("Mage")
+			H.mana_pool.set_intrinsic_recharge(MANA_ALL_LEYLINES)
 			r_hand = /obj/item/weapon/polearm/woodstaff
 			head = /obj/item/clothing/head/roguehood/mage
 			armor = /obj/item/clothing/shirt/robe/mage
 			beltl = /obj/item/reagent_containers/glass/bottle/manapot
-			beltr = /obj/item/weapon/knife/dagger
+			beltr = /obj/item/book/granter/spellbook/apprentice
 			H.mind?.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
 			H.mind?.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
 			H.mind?.adjust_skillrank(/datum/skill/craft/alchemy, 2, TRUE)

--- a/code/modules/jobs/job_types/adventurer/types/combat/dredge.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/dredge.dm
@@ -436,7 +436,6 @@
 			Like a wounded bird, I endure the rain with grace. With my sword I take fate into my own hands and strangle it.")
 			)
 		if("Mage")
-			H.mana_pool.set_intrinsic_recharge(MANA_ALL_LEYLINES)
 			r_hand = /obj/item/weapon/polearm/woodstaff
 			head = /obj/item/clothing/head/roguehood/mage
 			armor = /obj/item/clothing/shirt/robe/mage

--- a/code/modules/jobs/job_types/nobility/archivist.dm
+++ b/code/modules/jobs/job_types/nobility/archivist.dm
@@ -32,6 +32,7 @@
 
 /datum/outfit/job/archivist/pre_equip(mob/living/carbon/human/H)
 	..()
+	H.mana_pool.set_intrinsic_recharge(MANA_ALL_LEYLINES)
 	if(H.dna.species.id == "Dwarf")
 		shirt = /obj/item/clothing/shirt/undershirt/puritan
 		armor = /obj/item/clothing/armor/leather/jacket/apothecary
@@ -63,7 +64,6 @@
 		H.grant_language(/datum/language/hellspeak)
 		H.grant_language(/datum/language/oldpsydonic)
 		H.grant_language(/datum/language/orcish)
-		H.mana_pool.set_intrinsic_recharge(MANA_ALL_LEYLINES)
 		
 		H.mind?.adjust_skillrank(/datum/skill/misc/reading, 6, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)

--- a/code/modules/jobs/job_types/nobility/archivist.dm
+++ b/code/modules/jobs/job_types/nobility/archivist.dm
@@ -64,7 +64,6 @@
 		H.grant_language(/datum/language/hellspeak)
 		H.grant_language(/datum/language/oldpsydonic)
 		H.grant_language(/datum/language/orcish)
-		
 		H.mind?.adjust_skillrank(/datum/skill/misc/reading, 6, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/craft/alchemy, 3, TRUE)

--- a/code/modules/jobs/job_types/nobility/archivist.dm
+++ b/code/modules/jobs/job_types/nobility/archivist.dm
@@ -47,6 +47,7 @@
 	shoes = /obj/item/clothing/shoes/boots
 	belt = /obj/item/storage/belt/leather/plaquesilver
 	beltl = /obj/item/storage/keyring/archivist
+	beltr = /obj/item/book/granter/spellbook/apprentice
 	backl = /obj/item/storage/backpack/satchel
 	neck = /obj/item/clothing/neck/psycross/noc
 	backpack_contents = list(/obj/item/literary/apprentice = 1)
@@ -62,6 +63,8 @@
 		H.grant_language(/datum/language/hellspeak)
 		H.grant_language(/datum/language/oldpsydonic)
 		H.grant_language(/datum/language/orcish)
+		H.mana_pool.set_intrinsic_recharge(MANA_ALL_LEYLINES)
+		
 		H.mind?.adjust_skillrank(/datum/skill/misc/reading, 6, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/craft/alchemy, 3, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

closes: https://github.com/Vanderlin-Tales-Of-Wine/Vanderlin/issues/1073

Gives leylines absorb to those magicians that were missed such as, Archivist, Heartfell Mage and Dredger Mage roll, also give them their respective books.

## Why It's Good For The Game

Much like any adventurer these mages have acess to the bare minimum besides that spawning as a magician without the basic items generate a very boring gameplay to catch up to everyone, chalk, plants stuff like that is easy to get and fast, but things as baptism and making a book can take a long time.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
