### PR TITLE
Fixes Monarch is Always Dead Through Coronation

### DIFF
--- a/code/modules/jobs/job_types/church/priest.dm
+++ b/code/modules/jobs/job_types/church/priest.dm
@@ -139,7 +139,7 @@
 			consort_job?.remove_spells(HL)
 
 	coronated.mind.set_assigned_role(/datum/job/lord)
-	coronated.job = lord_job.get_informed_title(coronated)
+	coronated.job = "Monarch" //Monarch is used when checking if the ruler is alive, not "King" or "Queen". Can also pass it on and have the title change properly later.
 	lord_job?.add_spells(coronated)
 	SSticker.rulermob = coronated
 	GLOB.badomens -= OMEN_NOLORD


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

Changes the assigned job of the one getting crowned to "Monarch" so that they are properly counted for end-of-round results. Sequel to https://github.com/Vanderlin-Tales-Of-Wine/Vanderlin/pull/1166

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game

I noticed that in some rounds the town was still abandoned even though there was a monarch present. This is one such edge case where coronation did not properly give the mob.job of "Monarch", which is what the monarch check is looking for. I can't say there are no other edge cases, but I did test this and it works as intended.

I do think the system needs a refactor on the whole. There is also SSticker.rulermob, who is the monarch, I guess. Not sure why that's not used for tracking elsewhere, but whatever.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
