### PR TITLE
[ADMIN] Patron Change, Roll Stats, Admin Heal Move

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -18,7 +18,7 @@ GLOBAL_PROTECT(admin_verbs_default)
 	/client/proc/ghost_up,
 	/datum/admins/proc/start_vote,
 	/datum/admins/proc/show_player_panel,
-	/datum/admins/proc/admin_heal,
+	/datum/admins/proc/admin_fix,
 	/datum/admins/proc/admin_curse,
 	/datum/admins/proc/admin_sleep,
 	/client/proc/ghost_down,

--- a/stonekeep.dme
+++ b/stonekeep.dme
@@ -703,6 +703,7 @@
 #include "code\datums\gods\faiths\forgotten.dm"
 #include "code\datums\gods\faiths\inhumen_pantheon.dm"
 #include "code\datums\gods\patrons\atheism.dm"
+#include "code\datums\gods\patrons\blessings.dm"
 #include "code\datums\gods\patrons\curses.dm"
 #include "code\datums\gods\patrons\divine_pantheon.dm"
 #include "code\datums\gods\patrons\forgotten.dm"

--- a/stonekeep.dme
+++ b/stonekeep.dme
@@ -703,7 +703,6 @@
 #include "code\datums\gods\faiths\forgotten.dm"
 #include "code\datums\gods\faiths\inhumen_pantheon.dm"
 #include "code\datums\gods\patrons\atheism.dm"
-#include "code\datums\gods\patrons\blessings.dm"
 #include "code\datums\gods\patrons\curses.dm"
 #include "code\datums\gods\patrons\divine_pantheon.dm"
 #include "code\datums\gods\patrons\forgotten.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

This PR introduces a centralized `admin_fix()` tool for quick admin correction actions. Currently supports:
- **Fix Patron**: Safely removes and re-applies a player's patron, rerunning their associated traits and effects.
- **Fix Stats**: Resets and rerolls the target's stats via the game’s core system, respecting fix level.
- **Admin Heal**: Restores health and revives the mob (delegated to `admin_heal()` proc).

Also includes:
- Proper `GLOB.mob_list` scoping
- Clear user feedback and admin logging
- Input validation and access control via `check_rights()`
- Fully documented `///` style compliant with `autodoc.txt`

## Why It's Good For The Game

- Gives admins a fast, menu-driven way to resolve common character issues (trait bugs, stat corruptions, misassigned patrons).
- Modular design allows future additions (e.g., "Fix Family", "Fix Mutations").
- All fixes are self-logged for transparency and audit.
- Fully safe with null checks and feedback for both admins and players.


**FUTURE: I want to ideally add this to the Player Panel, or VV. Right now it's only a Right Click. This removes Admin Heal from the Right Click, and puts Fix in Right Click. So it's still the same level of bloat, but 3 extra tools.**
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.