### PR TITLE
Fixes intent overlay bug when placing pans and cauldrons into hearths… #1200

### DIFF
--- a/code/game/objects/lighting/rogue_fires.dm
+++ b/code/game/objects/lighting/rogue_fires.dm
@@ -353,41 +353,50 @@
 	if(!attachment)
 		if(istype(W, /obj/item/cooking/pan) || istype(W, /obj/item/reagent_containers/glass/bucket/pot))
 			playsound(get_turf(user), 'sound/foley/dropsound/shovel_drop.ogg', 40, TRUE, -1)
-			attachment = W
-			W.forceMove(src)
-			update_icon()
+
+			if(user.transferItemToLoc(W, src, silent = TRUE))
+				attachment = W
+				update_icon()
 			return
+
 	else
 		if(istype(W, /obj/item/reagent_containers/glass/bowl))
 			to_chat(user, "<span class='notice'>Remove the pot from the hearth first.</span>")
 			return
+
 		if(istype(attachment, /obj/item/cooking/pan))
 			if(W.type in subtypesof(/obj/item/reagent_containers/food/snacks))
 				var/obj/item/reagent_containers/food/snacks/S = W
-				if(istype(W, /obj/item/reagent_containers/food/snacks/egg)) // added
+
+				if(istype(W, /obj/item/reagent_containers/food/snacks/egg))
 					if(W.icon_state != "rawegg")
 						playsound(get_turf(user), 'sound/foley/eggbreak.ogg', 100, TRUE, -1)
 						if(!do_after(user, 25))
 							return
-						W.icon_state = "rawegg" // added
+						W.icon_state = "rawegg"
 					rawegg = TRUE
+
 				if(!food)
-					S.forceMove(src)
-					food = S
-					update_icon()
-					if(on)
-						playsound(src.loc, 'sound/misc/frying.ogg', 80, FALSE, extrarange = 5)
+					if(user.transferItemToLoc(S, src, silent = TRUE))
+						food = S
+						update_icon()
+						if(on)
+							playsound(src.loc, 'sound/misc/frying.ogg', 80, FALSE, extrarange = 5)
 					return
-// New concept = boil at least 33 water, add item, it turns into food reagent volume 33 of the appropriate type
+
 		else if(istype(attachment, /obj/item/reagent_containers/glass/bucket/pot))
 			var/obj/item/reagent_containers/glass/bucket/pot/pot = attachment
+
 			if(!pot.reagents.has_reagent(/datum/reagent/water, 33))
 				to_chat(user, "<span class='notice'>Not enough water.</span>")
 				return TRUE
+
 			if(pot.reagents.chem_temp < 374)
 				to_chat(user, "<span class='warning'>[pot] isn't boiling!</span>")
 				return
+
 			pot.attempt_pot_recipes(W, user)
+
 	. = ..()
 
 //////////////////////////////////


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

This PR is a general bugfix sweep focused on player-reported issues.

### Fixes Included:
- ** #1200** — Fixes intent UI overlays not clearing when placing a pan or cauldron into a hearth. Now uses `transferItemToLoc()` to properly update hand state and intent visuals.

## Why It's Good For The Game

**#1200** —
- Improves user experience by ensuring hands/inventory accurately reflect held items
- Removes misleading UI overlays after item transfers
- Cleans up internal logic for item movement consistency
- Matches behavior used by tables and other containers

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
