### PR TITLE
(BALANCE) Makes Exiled Warrior Mercenary not as shit.

### DIFF
--- a/code/modules/jobs/job_types/other/merc_classes/exiled.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/exiled.dm
@@ -30,7 +30,7 @@
 		H.mind?.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/craft/traps, 3, TRUE) // Valor pleases you, Crom.
 
-	beltr = /obj/item/weapon/sword/arming // Arming is steel IIRC?
+	beltr = /obj/item/weapon/sword/arming
 	neck = /obj/item/clothing/neck/coif
 	pants = /obj/item/clothing/pants/loincloth
 	gloves = /obj/item/clothing/gloves/leather

--- a/code/modules/jobs/job_types/other/merc_classes/exiled.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/exiled.dm
@@ -17,26 +17,28 @@
 		H.mind?.adjust_skillrank(/datum/skill/misc/swimming, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)
-		H.mind?.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)	// Minimal armor, expected to have big sword.
-		H.mind?.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/craft/tanning, 1, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/axesmaces, 2, TRUE) // Cut those trees #Morbiussweep
 		H.mind?.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
-		H.mind?.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/misc/sewing, 2, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/craft/traps, 3, TRUE) // Valor pleases you, Crom.
 
-	beltr = /obj/item/weapon/sword/iron
+	beltr = /obj/item/weapon/sword/arming // Arming is steel IIRC?
 	neck = /obj/item/clothing/neck/coif
 	pants = /obj/item/clothing/pants/loincloth
 	gloves = /obj/item/clothing/gloves/leather
 	belt = /obj/item/storage/belt/leather/mercenary
-	beltl = /obj/item/weapon/mace/cudgel
+	beltl = /obj/item/weapon/axe/iron
 	head = /obj/item/clothing/head/helmet/leather
 	armor = /obj/item/clothing/armor/leather/hide
+	shirt = /obj/item/clothing/armor/gambeson
 	shoes = /obj/item/clothing/shoes/boots/leather
 	wrists = /obj/item/clothing/wrists/bracers/leather
 	cloak = /obj/item/clothing/cloak/raincloak/furcloak/brown
@@ -44,11 +46,13 @@
 	backpack_contents = list(/obj/item/storage/belt/pouch/coins/poor)
 
 	H.change_stat(STATKEY_STR, 1)
-	H.change_stat(STATKEY_END, 1)
+	H.change_stat(STATKEY_END, 2)
 	H.change_stat(STATKEY_CON, 2)
 	H.change_stat(STATKEY_SPD, -1) // fat fuck
-	H.change_stat(STATKEY_INT, 1) // Conan! What is best in life?
+	H.change_stat(STATKEY_INT, 3) // Conan! What is best in life?
 	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_CRITICAL_RESISTANCE, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_NOPAINSTUN, TRAIT_GENERIC)
 	if(H.dna?.species)
 		H.dna.species.soundpack_m = new /datum/voicepack/male/warrior()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

**Changes the following about Exiled Mercenary:**

- Iron Sword to Shortsword (Apparently this is a steel weapon, fyi)

- Wrestling/Unarmed to 3 (Same as Barbarian)

- Changes Cudgel to Axe (For woodcutting)

- Endurance 1->2

- Int 1->3 (Conan was smart. Smart horc.)

- Gives Gambeson for a shirt.

- Adds Critical Resistance / No-Pain-Stun trait to compete with Barbarian.

- Gives Medicine and Sewing 2.

## Why It's Good For The Game

Exiled Mercenary (apparently) sucked to play and was just a worse Barbarian. This (hopefully) makes it not as unfun to pick. Plus, it's (currently) the only mercenary with critical resistance.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
