### PR TITLE
Reduced Steel Production from 4 to 3.

### DIFF
--- a/code/game/objects/lighting/smelter.dm
+++ b/code/game/objects/lighting/smelter.dm
@@ -198,6 +198,7 @@
 
 					if(steelalloy == 7)
 						testing("STEEL ALLOYED")
+						maxore = 3
 						alloy = /obj/item/ingot/steel
 					else if(bronzealloy == 7)
 						testing("BRONZE ALLOYED")
@@ -227,6 +228,7 @@
 								ore -= I
 								ore += R
 								qdel(I)
+					maxore = initial(maxore)
 					playsound(src,'sound/misc/smelter_fin.ogg', 100, FALSE)
 					visible_message("<span class='notice'>\The [src] finished smelting.</span>")
 					cooking = 31


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

Changed Steel production from 4 to 3.

## Why It's Good For The Game

This will make iron slightly cheaper than steel rather than steel being the cheaper of the two options. Currently there is no reason to utilize iron weapons/armor at all.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x ] You tested this on a local server.
- [x ] This code did not runtime during testing.
- [x ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
