### PR TITLE
Fixes two-handed weapon damage not being improved by quality.

### DIFF
--- a/code/modules/crafting/anvil_recipes/_anvil_recipe.dm
+++ b/code/modules/crafting/anvil_recipes/_anvil_recipe.dm
@@ -170,6 +170,7 @@
 	if(istype(I, /obj/item/weapon))
 		var/obj/item/weapon/W = I
 		W.force *= modifier
+		W.force_wielded *= modifier
 		W.throwforce *= modifier
 		W.blade_int *= modifier
 		W.max_blade_int *= modifier


### PR DESCRIPTION


## About The Pull Request

Makes it so that the quality of your weapon doesn't only impact one-handed damage, but also affects two-handed damage. Before this your one-handed damage scaled for greatswords and such but the two-handed did not.

## Why It's Good For The Game

It's a bug fix, doesn't really make sense that one-handed improve but two-handed do not.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
