### PR TITLE
Lets mana fountain regen mana again

### DIFF
--- a/code/datums/mana/mana_battery.dm
+++ b/code/datums/mana/mana_battery.dm
@@ -221,6 +221,6 @@
 	maximum_mana_capacity = 1000
 	softcap = 1000
 	amount = 0
-	ethereal_recharge_rate = 0
+	ethereal_recharge_rate = 1
 	intrinsic_recharge_sources = MANA_ALL_PYLONS
 	draws_beams = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

+ changes passive mana gen of the mana fountain from 0 to 1

## Why It's Good For The Game

Mana fountain not generating ANY weak mana potion on its own, sucks hard.
It means you have to brew mana potion by hand, to build pylons. And fun fact, if crafting the amethys fails, the mana potion is wasted. Try that now with 9u mana potion for every 1 small quarz. Shit sucks.
The mage guild should have some advantage over adv mages.

iir the mana fountain was supposed to generate very little on its own to begin with, but i could be wrong.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
