### PR TITLE
Gives the rogue mage a spellbook and leyline absorption.

### DIFF
--- a/code/modules/crafting/anvil_recipes/_anvil_recipe.dm
+++ b/code/modules/crafting/anvil_recipes/_anvil_recipe.dm
@@ -170,6 +170,7 @@
 	if(istype(I, /obj/item/weapon))
 		var/obj/item/weapon/W = I
 		W.force *= modifier
+		W.force_wielded *= modifier
 		W.throwforce *= modifier
 		W.blade_int *= modifier
 		W.max_blade_int *= modifier

--- a/code/modules/crafting/anvil_recipes/_anvil_recipe.dm
+++ b/code/modules/crafting/anvil_recipes/_anvil_recipe.dm
@@ -170,7 +170,6 @@
 	if(istype(I, /obj/item/weapon))
 		var/obj/item/weapon/W = I
 		W.force *= modifier
-		W.force_wielded *= modifier
 		W.throwforce *= modifier
 		W.blade_int *= modifier
 		W.max_blade_int *= modifier

--- a/code/modules/jobs/job_types/adventurer/types/antag/roguemage.dm
+++ b/code/modules/jobs/job_types/adventurer/types/antag/roguemage.dm
@@ -9,6 +9,7 @@
 
 /datum/outfit/job/bandit/roguemage/pre_equip(mob/living/carbon/human/H)
 	..()
+	H.mana_pool.set_intrinsic_recharge(MANA_ALL_LEYLINES)
 	shoes = /obj/item/clothing/shoes/simpleshoes
 	pants = /obj/item/clothing/pants/trou/leather
 	shirt = /obj/item/clothing/shirt/shortshirt
@@ -16,7 +17,7 @@
 	belt = /obj/item/storage/belt/leather/rope
 	beltr = /obj/item/reagent_containers/glass/bottle/manapot
 	backr = /obj/item/storage/backpack/satchel
-	backpack_contents = list(/obj/item/needle/thorn = 1, /obj/item/natural/cloth = 1)
+	backpack_contents = list(/obj/item/needle/thorn = 1, /obj/item/natural/cloth = 1, /obj/item/book/granter/spellbook/apprentice = 1)
 	mask = /obj/item/clothing/face/facemask/steel //idk if this makes it so they cant cast but i want all of the bandits to have the same mask
 	neck = /obj/item/clothing/neck/coif
 	head = /obj/item/clothing/head/helmet/leather/volfhelm


### PR DESCRIPTION

## About The Pull Request

Adds the trait intrinsic recharge to rogue mage so they can recover mana from leylines, aswell as adding an apprentice spellbook to their satchel.

## Why It's Good For The Game

Didn't really make sense that a proper former mage isn't baptized nor has atleast a weak spellbook, also spellcasting is pretty much all you get as a rogue mage.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
