### PR TITLE
Collectable Treasures tweak

### DIFF
--- a/code/datums/stock/bounties.dm
+++ b/code/datums/stock/bounties.dm
@@ -8,7 +8,7 @@
 	name = "Collectable Treasures"
 	desc = "Treasures are sent to the vault, where they accrue value over time. Payout is a percentage is based on the price of the treasure, with taxes removed from the payout after."
 	item_type = /obj/item
-	payout_price = 10
+	payout_price = 25
 	transport_item = /area/rogue/indoors/town/vault
 	percent_bounty = TRUE
 
@@ -54,4 +54,10 @@
 		if(istype(I, /obj/item/reagent_containers/glass/cup))
 			return TRUE
 		if(istype(I, /obj/item/gem))
+			return TRUE
+		if(istype(I, /obj/item/painting))
+			return TRUE
+		if(istype(I, /obj/item/clothing/ring))
+			return TRUE
+		if(istype(I, /obj/item/clothing/face/facemask/goldmask))
 			return TRUE


### PR DESCRIPTION

## About The Pull Request

- Raises base collectable treasure percentage to 25 from 10 as it will encourage more people to actually use it while being unable to reach merchant/steward.

- Adds paintings, rings and goldmask to the bounty list on collectable treasure list.

## Why It's Good For The Game

We have a feature which remains unused for mostly 90% of the time, it needs to be fixed, encouraging players to actually use it.

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

