### PR TITLE
Plated Armors Are Weak Against Blunt, not Stab

### DIFF
--- a/code/modules/clothing/armor/plate.dm
+++ b/code/modules/clothing/armor/plate.dm
@@ -9,11 +9,12 @@
 	equip_sound = 'sound/foley/equip/equip_armor_plate.ogg'
 	sellprice = VALUE_STEEL_ARMOR
 	clothing_flags = CANT_SLEEP_IN
-
+	//Plate doesn't protect a lot against blunt
+    
 	armor_class = AC_HEAVY
 	armor = ARMOR_PLATE
 	body_parts_covered = COVERAGE_ALL_BUT_ARMS
-	prevent_crits = ALL_EXCEPT_STAB
+	prevent_crits = ALL_EXCEPT_BLUNT 
 	max_integrity = INTEGRITY_STRONGEST
 	do_sound_plate = TRUE
 
@@ -29,7 +30,6 @@
 
 	armor = ARMOR_PLATE
 	body_parts_covered = COVERAGE_FULL
-
 
 //................ Iron Plate Armor ............... //
 /obj/item/clothing/armor/plate/iron


### PR DESCRIPTION


## About The Pull Request

Changes a variable that makes plate armors not protect against stabbing crits, and instead made them not protect against blunt crits.

## Why It's Good For The Game

Stabbing is king. Making plate armor's only weakness stabbing makes it even worse. Making plate armor weak to blunt not only makes sense (maces and hammers are meant to smash plate armor), but it will also hopefully mean maces and other blunt weapons get a little more love. That, and KOing knights through their tincans.

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
