### PR TITLE
Fixes Skeletons Bleeding on You During Combat

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -532,9 +532,9 @@
 /mob/living/carbon/get_blood_dna_list()
 	if(isnull(dna)) // Xenos
 		return ..()
-	var/datum/blood_type/blood = get_blood_type()
-	if(isnull(blood)) // Skeletons?
+	if(NOBLOOD in dna.species.species_traits) //no skeletons bleeding
 		return null
+	var/datum/blood_type/blood = get_blood_type()
 	return list("[dna.unique_enzymes]" = blood.type)
 
 ///to add a mob's dna info into an object's blood_dna list.

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/creacher/skeleton.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/creacher/skeleton.dm
@@ -153,6 +153,9 @@
 	cut_overlay("peace_overlay")
 	. = ..()
 
+/mob/living/simple_animal/hostile/skeleton/get_blood_dna_list() //We do not want skeletons bleeding.
+//Could be a more global bitflag or something, but it's only relevant for this subtype.
+	return null
 
 /datum/intent/simple/claw/skeleton_unarmed
 	attack_verb = list("claws", "strikes", "punches")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

Small change to prevent skeletons from bleeding on clothing and weapons during combat. Correctly sets the NOBLOOD exception and makes an override proc for simple animal skeletons.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game

I was getting tired of having to wash off skeleton blood, so I fixed it. Bleeding and blood in general are spaghetti code, so this is only a touch-up to fix the listed issue.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
