### PR TITLE
Vampire Lord Enhancements

### DIFF
--- a/code/modules/antagonists/villain/vampire/_vampire.dm
+++ b/code/modules/antagonists/villain/vampire/_vampire.dm
@@ -39,7 +39,7 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 	)
 
 	var/vitae = 1000
-	var/vmax = 2000
+	var/vmax = 3000
 
 	COOLDOWN_DECLARE(last_transform)
 	var/disguised = FALSE //! spawn

--- a/code/modules/antagonists/villain/vampire/lord.dm
+++ b/code/modules/antagonists/villain/vampire/lord.dm
@@ -11,6 +11,7 @@
 	var/ascended = FALSE
 	var/obj/effect/proc_holder/spell/targeted/shapeshift/bat/batform //attached to the datum itself to avoid cloning memes, and other duplicates
 	var/obj/effect/proc_holder/spell/targeted/shapeshift/gaseousform/gas
+	var/obj/effect/proc_holder/spell/targeted/mansion_portal/portal
 
 /datum/antagonist/vampire/lord/apply_innate_effects(mob/living/mob_override)
 	. = ..()
@@ -25,7 +26,8 @@
 /datum/antagonist/vampire/lord/on_gain()
 	owner.purge_combat_knowledge()
 	. = ..()
-
+	portal = new()
+	owner.current.AddSpell(portal)
 	addtimer(CALLBACK(owner.current, TYPE_PROC_REF(/mob/living/carbon/human, choose_name_popup), "[name]"), 5 SECONDS)
 
 /datum/antagonist/vampire/lord/after_gain()

--- a/code/modules/antagonists/villain/vampire/lord.dm
+++ b/code/modules/antagonists/villain/vampire/lord.dm
@@ -39,6 +39,10 @@
 		owner.current.RemoveSpell(batform)
 		QDEL_NULL(batform)
 
+	if(!isnull(portal))
+		owner.current.RemoveSpell(portal)
+		QDEL_NULL(portal)
+
 	owner.current.verbs -= /mob/living/carbon/human/proc/demand_submission
 	owner.current.verbs -= /mob/living/carbon/human/proc/punish_spawn
 

--- a/code/modules/spells/spell_types/invoked/vampire.dm
+++ b/code/modules/spells/spell_types/invoked/vampire.dm
@@ -25,3 +25,36 @@
 		/datum/attunement/polymorph = 0.5,
 		/datum/attunement/aeromancy = 0.3,
 	)
+
+/obj/effect/proc_holder/spell/targeted/mansion_portal
+	name = "Mansion Portal"
+	desc = "Create a portal to return to MY mansion"
+	invocation = ""
+	recharge_time = 15 MINUTES
+	cooldown_min = 15 MINUTES
+	max_targets = 0
+	cast_without_targets = TRUE
+	associated_skill = /datum/skill/magic/blood
+
+/obj/effect/proc_holder/spell/targeted/mansion_portal/cast(list/targets,mob/user = usr)
+	var/obj/structure/vampire/portalmaker/destination
+	for(var/obj/structure/vampire/portalmaker/P in GLOB.vampire_objects)
+		destination = P
+		break
+	if(!destination)
+		to_chat(user, span_warning("It cannot be, Nothing happens."))
+		return FALSE
+
+	var/obj/effect/portal/vampire/portal = new /obj/effect/portal/vampire(get_turf(user), user, 15 MINUTES, null, FALSE, get_turf(destination), FALSE)
+	portal.RegisterSignal(destination, COMSIG_PARENT_QDELETING, TYPE_PROC_REF(/obj/effect/portal/vampire, handle_portalmaker_destruction))
+	return TRUE
+
+/obj/effect/portal/vampire
+	name = "Eerie Portal"
+	icon = 'icons/roguetown/topadd/death/vamp-lord.dmi'
+	icon_state = "portal"
+	density = FALSE
+
+/obj/effect/portal/vampire/proc/handle_portalmaker_destruction()
+	visible_message(span_boldnotice("[src] shudders before rapidly closing."))
+	qdel(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
Title, also increases vampire max blood by 50%. Playtesting shows they typically run out of blood within a single day, and it's not ideal to constantly need to kill people just to not starve to death.

This PR allows the vampire lord to innately summon a portal on their location(900 second cooldown and duration). This portal when stepped on allows any character, vampire or human to transport themselves to the Vampire Castle(Specifically the Rift Gate). This allows the Lord and their retinue to avoid the pesky issue of constantly dying in the Murderwood on their way home. It also adds the unique RP opportunity for people to besiege their castle via the portal, or be invited for lavish feasts / parties.

Imagine a round where in which the Vampire Lord holds a masquerade ball, the entrance to which is found in the upstairs room of the Tavern. The guests are invited only to find themselves the night's dinner, with very few being turned into vampires. The following day they descend on the city, either through the portal(if it's still up) or via the murderwood on a long trek toward the apocalypse.

## Why It's Good For The Game

Vampire is by the far the weakest antagonist, they often die from the sun or because they run out of blood. It's incredibly arduous, and annoying to play due to the extreme distances you must travel to reach the castle. As a result they often just end up living in the sewers like hobos, praying that the night will come so they can scrounge together enough blood to barely survive until the next. They never, ever win. I doubt this PR would make them strong enough to be a true threat, but at least they can have fun now.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.