### PR TITLE
Steward stat changes

### DIFF
--- a/code/modules/jobs/job_types/nobility/steward.dm
+++ b/code/modules/jobs/job_types/nobility/steward.dm
@@ -53,7 +53,6 @@
 		H.mind?.adjust_skillrank(/datum/skill/misc/lockpicking, 6, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/labor/mathematics, 5, TRUE)
 		H.change_stat(STATKEY_STR, -2)
-		H.change_stat(STATKEY_INT, 8)
+		H.change_stat(STATKEY_INT, 5)
 		H.change_stat(STATKEY_CON, -2)
-		H.change_stat(STATKEY_SPD, -2)
 	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)


### PR DESCRIPTION
Faster but dumber

## About The Pull Request

Steward gets the -2 SPD debuff removed, but there +8 INT goes down to +5 INT.

## Why It's Good For The Game

The stewards entire job is running around and managing the economy, which is AGONY when you have 8 SPD at your best, 7 when you're drunk or hungry or thirsty, 6 when you're tired, etc. To counter this, I lowered the INT by 3, the steward still gets great INT, but not THAT great. It doesn't make sense that the coin counting guy is smarter than the archivist, who knows every language and various spells.

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
