### PR TITLE
Servant +1 sewing skill

### DIFF
--- a/code/modules/jobs/job_types/apprentices/servant.dm
+++ b/code/modules/jobs/job_types/apprentices/servant.dm
@@ -31,7 +31,7 @@
 		H.mind?.adjust_skillrank(/datum/skill/labor/butchering, 1, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE)
-		H.mind?.adjust_skillrank(/datum/skill/misc/sewing, 2, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/misc/sewing, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/stealing, 3, TRUE)


### PR DESCRIPTION
Servants currently can't use the dye bin in their own quarters

## About The Pull Request

Servants get +1 sewing skill so they can use the dye bin in their own quarters of the keep

## Why It's Good For The Game

Keep servants can customize the colors of their own outfits, and color outfits for the royals

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

