### PR TITLE
misc fixes and updates for rosewood

### DIFF
--- a/_maps/map_files/rosewood/rosewood.dmm
+++ b/_maps/map_files/rosewood/rosewood.dmm
@@ -4607,6 +4607,11 @@
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
 /turf/open/floor/cobble,
 /area/rogue/indoors/town/warehouse)
+"cBi" = (
+/obj/machinery/light/fueled/wallfire/candle/blue/l,
+/obj/structure/fermentation_keg/random/water,
+/turf/open/floor/churchmarble,
+/area/rogue/indoors/town/clinic_large)
 "cBr" = (
 /obj/structure/table/wood{
 	icon_state = "largetable";
@@ -7688,12 +7693,10 @@
 /turf/open/floor/church,
 /area/rogue/indoors/town/church/chapel)
 "ekm" = (
-/obj/structure/table/wood/reinf_long,
-/obj/structure/bars/bent,
 /obj/structure/fake_machine/atm{
 	pixel_y = 0
 	},
-/turf/open/floor/grass/cold,
+/turf/closed/wall/mineral/stone/moss,
 /area/rogue/outdoors/town)
 "ekx" = (
 /obj/structure/chair/bench/throne,
@@ -8831,9 +8834,7 @@
 /turf/open/floor/carpet,
 /area/rogue/indoors/town/tavern)
 "eWb" = (
-/obj/structure/fake_machine/vendor{
-	keycontrol = "tavern"
-	},
+/obj/structure/fake_machine/vendor/inn,
 /turf/closed/wall/mineral/wooddark,
 /area/rogue/indoors/town/tavern)
 "eWf" = (
@@ -10062,8 +10063,8 @@
 /obj/structure/mineral_door/wood{
 	name = "Apothecary"
 	},
-/obj/effect/mapping_helpers/door/access/town/apothecary,
 /obj/effect/mapping_helpers/door/locker,
+/obj/effect/mapping_helpers/door/access/town/bathhouse,
 /turf/open/floor/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
 "fFP" = (
@@ -11905,6 +11906,11 @@
 	desc = "You think you can climb this durable wall"
 	},
 /area/rogue/indoors/town/shop)
+"gJT" = (
+/obj/structure/mineral_door/wood,
+/obj/effect/mapping_helpers/door/access/town/bathhouse,
+/turf/open/floor/tile/bath,
+/area/rogue/indoors/town/bath)
 "gKl" = (
 /obj/structure/mineral_door/wood{
 	lockid = "roomhunt";
@@ -15637,7 +15643,7 @@
 /obj/structure/mineral_door/wood/window{
 	name = "Bathhouse"
 	},
-/obj/effect/mapping_helpers/door/access/town/apothecary,
+/obj/effect/mapping_helpers/door/access/town/bathhouse,
 /turf/open/floor/tile/bfloorz,
 /area/rogue/indoors/town/bath)
 "iOL" = (
@@ -17817,8 +17823,8 @@
 /area/rogue/outdoors/rtfield/safe)
 "kbu" = (
 /obj/structure/mineral_door/wood,
-/obj/effect/mapping_helpers/door/access/town/apothecary,
 /obj/effect/mapping_helpers/door/locker,
+/obj/effect/mapping_helpers/door/access/town/bathhouse,
 /turf/open/floor/tile/bath,
 /area/rogue/indoors/town/bath)
 "kby" = (
@@ -19026,8 +19032,6 @@
 /obj/structure/mineral_door/swing_door{
 	keylock = 1
 	},
-/obj/effect/mapping_helpers/door/access/town/butcher,
-/obj/effect/mapping_helpers/door/locker,
 /turf/open/floor/ruinedwood/turned/darker,
 /area/rogue/indoors/soilsons)
 "kNi" = (
@@ -26462,9 +26466,7 @@
 /turf/open/floor/blocks/newstone/alt,
 /area/rogue/indoors/town)
 "oOV" = (
-/obj/structure/fake_machine/vendor{
-	keycontrol = "nightmaiden"
-	},
+/obj/structure/fake_machine/vendor/apothecary,
 /turf/closed/wall/mineral/craftstone{
 	climbdiff = 3;
 	name = "Grooved Wall";
@@ -26682,14 +26684,8 @@
 	},
 /area/rogue/under/town/basement)
 "oTP" = (
-/obj/structure/table/wood/reinf_long{
-	dir = 1
-	},
-/obj/structure/fake_machine/vendor{
-	keycontrol = "soilson"
-	},
-/obj/structure/bars/bent,
-/turf/open/floor/dirt/road,
+/obj/structure/fake_machine/vendor/soilson,
+/turf/closed/wall/mineral/stone/moss,
 /area/rogue/outdoors/town)
 "oTR" = (
 /obj/structure/mineral_door/wood/donjon{
@@ -28233,6 +28229,14 @@
 /obj/structure/table/wood/reinf_long{
 	dir = 4
 	},
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_y = 1;
+	pixel_x = 5
+	},
+/obj/item/toy/cards/deck{
+	pixel_y = 6;
+	pixel_x = -10
+	},
 /turf/open/floor/churchmarble,
 /area/rogue/indoors/town/clinic_large)
 "pMW" = (
@@ -28536,6 +28540,14 @@
 "pVV" = (
 /turf/open/floor/blocks/stonered,
 /area/rogue/indoors/town/shop)
+"pVW" = (
+/obj/structure/fake_machine/vendor/blacksmith,
+/turf/closed/wall/mineral/craftstone{
+	climbdiff = 3;
+	name = "Grooved Wall";
+	desc = "You think you can climb this durable wall"
+	},
+/area/rogue/indoors/town/smithy)
 "pWq" = (
 /obj/effect/landmark/start/fisher{
 	dir = 4
@@ -31190,6 +31202,10 @@
 "rzR" = (
 /obj/structure/table/wood/reinf_long{
 	dir = 8
+	},
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_y = 5;
+	pixel_x = -4
 	},
 /turf/open/floor/churchmarble,
 /area/rogue/indoors/town/clinic_large)
@@ -36123,6 +36139,9 @@
 /area/rogue/indoors/town)
 "upI" = (
 /obj/structure/closet/crate/chest/neu_fancy,
+/obj/item/key/apothecary,
+/obj/item/key/bathhouse,
+/obj/item/key/bathhouse,
 /turf/open/floor/ruinedwood/spiralfade,
 /area/rogue/indoors/town/bath)
 "upU" = (
@@ -37384,6 +37403,18 @@
 "uVj" = (
 /obj/structure/bed/inn,
 /obj/structure/closet/crate/crafted_closet/inn,
+/obj/item/key/clinic{
+	pixel_y = 3;
+	pixel_x = 6
+	},
+/obj/item/key/clinic{
+	pixel_x = -6
+	},
+/obj/item/key/clinic{
+	pixel_y = -3;
+	pixel_x = 5
+	},
+/obj/item/broom,
 /turf/open/floor/churchmarble,
 /area/rogue/indoors/town/clinic_large)
 "uVk" = (
@@ -37635,8 +37666,8 @@
 /obj/structure/mineral_door/wood{
 	name = "Apothecary"
 	},
-/obj/effect/mapping_helpers/door/access/town/apothecary,
 /obj/effect/mapping_helpers/door/locker,
+/obj/effect/mapping_helpers/door/access/town/bathhouse,
 /turf/open/floor/cobble,
 /area/rogue/indoors/town/bath)
 "vci" = (
@@ -38121,8 +38152,10 @@
 /obj/structure/table/wood/reinf_long{
 	dir = 4
 	},
-/obj/item/weapon/surgery/hammer,
-/obj/item/weapon/surgery/scalpel,
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_y = 2;
+	pixel_x = 5
+	},
 /turf/open/floor/church,
 /area/rogue/indoors/town/clinic_large)
 "vnP" = (
@@ -38571,8 +38604,6 @@
 /obj/structure/mineral_door/swing_door{
 	keylock = 1
 	},
-/obj/effect/mapping_helpers/door/access/town/butcher,
-/obj/effect/mapping_helpers/door/locker,
 /turf/open/floor/dirt,
 /area/rogue/indoors/soilsons)
 "vAf" = (
@@ -39208,8 +39239,8 @@
 /obj/structure/mineral_door/wood/donjon/stone{
 	name = "Feldsher's office"
 	},
-/obj/effect/mapping_helpers/door/access/town/clinic,
 /obj/effect/mapping_helpers/door/locker,
+/obj/effect/mapping_helpers/door/access/town/doctor,
 /turf/open/floor/churchmarble,
 /area/rogue/indoors/town/clinic_large)
 "vSt" = (
@@ -40088,7 +40119,14 @@
 /obj/structure/table/wood/reinf_long{
 	dir = 8
 	},
-/obj/item/weapon/surgery/hemostat,
+/obj/item/key/feldsher{
+	pixel_y = 3;
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/glass/bottle/water{
+	pixel_y = 9;
+	pixel_x = 14
+	},
 /turf/open/floor/church,
 /area/rogue/indoors/town/clinic_large)
 "wrG" = (
@@ -41656,6 +41694,17 @@
 	},
 /turf/open/floor/blocks/bluestone,
 /area/rogue/indoors/town)
+"xnO" = (
+/obj/structure/rack/shelf/biggest,
+/obj/item/weapon/surgery/retractor,
+/obj/item/weapon/surgery/saw,
+/obj/item/weapon/surgery/scalpel,
+/obj/item/weapon/surgery/hammer,
+/obj/item/weapon/surgery/bonesetter,
+/obj/item/reagent_containers/glass/bottle/healthpot,
+/obj/item/reagent_containers/glass/bottle/diseasecure,
+/turf/open/floor/churchmarble,
+/area/rogue/indoors/town/clinic_large)
 "xnX" = (
 /obj/item/clothing/head/peaceflower{
 	pixel_x = 3;
@@ -42013,12 +42062,8 @@
 /turf/open/floor/cobble,
 /area/rogue/indoors)
 "xAk" = (
-/obj/structure/table/wood/reinf_long,
-/obj/structure/bars/bent,
-/obj/structure/fake_machine/vendor{
-	keycontrol = "butcher"
-	},
-/turf/open/floor/snow/patchy,
+/obj/structure/fake_machine/vendor/butcher,
+/turf/closed/wall/mineral/stone/moss,
 /area/rogue/outdoors/town)
 "xAs" = (
 /obj/structure/toilet,
@@ -51729,7 +51774,7 @@ qJl
 dQT
 dQT
 dQT
-cgZ
+gJT
 dQT
 dQT
 dQT
@@ -103662,7 +103707,7 @@ cXg
 cXg
 vlA
 iWf
-gqW
+pVW
 pmI
 buO
 cwC
@@ -104478,7 +104523,7 @@ nkN
 jnM
 jnM
 qMg
-nxh
+pVW
 iWf
 uHZ
 iWf
@@ -134995,7 +135040,7 @@ ksA
 wFC
 gdN
 kRW
-lNu
+kRW
 uSy
 wFC
 sjR
@@ -135364,7 +135409,7 @@ iNo
 sRp
 dHO
 dHO
-sRp
+cBi
 iNo
 grI
 grI
@@ -135967,7 +136012,7 @@ huA
 huA
 huA
 iNo
-ngP
+xnO
 cLY
 vnH
 fEd

--- a/code/game/objects/items/keyrings.dm
+++ b/code/game/objects/items/keyrings.dm
@@ -268,7 +268,7 @@
 	keys = list(/obj/item/key/veteran, /obj/item/key/walls, /obj/item/key/elder, /obj/item/key/butcher, /obj/item/key/soilson, /obj/item/key/manor)
 
 /obj/item/storage/keyring/feldsher
-	keys = list(/obj/item/key/feldsher, /obj/item/key/manor, /obj/item/key/clinic)
+	keys = list(/obj/item/key/feldsher, /obj/item/key/manor, /obj/item/key/clinic, /obj/item/key/bathhouse)
 
 /obj/item/storage/keyring/physicker
 	keys = list(/obj/item/key/clinic)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
Peddlers to subtypes.
Feldsher room brought up to the vanderlin one (full toolset two potions spare keys) and gets a bathhouse key on keyring.
Clinic gets mugs and cards.
Blacksmith gets peddlers.
Apothecary gets spare keys and doors to bathhouse keys.

![image](https://github.com/user-attachments/assets/81f363d3-a763-4bc1-b9e3-a4e429043d69)
![image](https://github.com/user-attachments/assets/7903204f-d685-445b-abf6-2a726ba82725)
![image](https://github.com/user-attachments/assets/e5938e27-7b5e-46b0-94f8-bc586c3a407d)
![image](https://github.com/user-attachments/assets/80abbf07-a58c-473c-86c8-d4436932b592)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
Feldsher needs clinic keys because physickers now lack them.
Apothecary has spare keys for apprentices or doctors.
Subtyped peddlers needed for proper access.
Feldsher stuff parity with vanderlin.
Doctors get to play cards too...

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
