### PR TITLE
Ports lashing wounds & scarring crit from stonekeep.

### DIFF
--- a/code/_globalvars/lists/wounds.dm
+++ b/code/_globalvars/lists/wounds.dm
@@ -44,3 +44,7 @@ GLOBAL_LIST_INIT(stab_bclasses, list(
 GLOBAL_LIST_INIT(charring_bclasses, list(
 	BCLASS_BURN,
 ))
+
+GLOBAL_LIST_INIT(whipping_bclasses, list(
+	BCLASS_LASHING,
+))

--- a/code/datums/wounds/slashes.dm
+++ b/code/datums/wounds/slashes.dm
@@ -132,3 +132,47 @@
 /datum/wound/slash/incision/cauterize_wound()
 	qdel(src)
 	return TRUE
+
+/datum/wound/lashing
+	name = "lashing"
+	whp = 40
+	sewn_whp = 12
+	bleed_rate = 0.8
+	sewn_bleed_rate = 0.02
+	clotting_rate = 0.02
+	sewn_clotting_rate = 0.02
+	clotting_threshold = 0.2
+	sewn_clotting_threshold = 0.1
+	woundpain = 10
+	sewn_woundpain = 4
+	sew_threshold = 50
+	can_sew = TRUE
+	can_cauterize = TRUE
+
+/datum/wound/lashing/small
+	name = "superficial lashing"
+	whp = 15
+	sewn_whp = 5
+	bleed_rate = 0.4
+	sewn_bleed_rate = 0.01
+	clotting_rate = 0.02
+	sewn_clotting_rate = 0.02
+	clotting_threshold = 0.1
+	sewn_clotting_threshold = 0.05
+	woundpain = 6
+	sewn_woundpain = 2
+	sew_threshold = 30
+
+/datum/wound/lashing/large
+	name = "excruciating lashing"
+	whp = 60
+	sewn_whp = 15
+	bleed_rate = 2 //Intended for combat, might kill if used for punishment. Force can be controlled by not charging the whip lash fully.
+	sewn_bleed_rate = 0.05
+	clotting_rate = 0.02
+	sewn_clotting_rate = 0.02
+	clotting_threshold = 0.4
+	sewn_clotting_threshold = 0.1
+	woundpain = 20
+	sewn_woundpain = 10
+	sew_threshold = 75

--- a/code/datums/wounds/slashes.dm
+++ b/code/datums/wounds/slashes.dm
@@ -135,9 +135,9 @@
 
 /datum/wound/lashing
 	name = "lashing"
-	whp = 40
+	whp = 30
 	sewn_whp = 12
-	bleed_rate = 0.8
+	bleed_rate = 0.6
 	sewn_bleed_rate = 0.02
 	clotting_rate = 0.02
 	sewn_clotting_rate = 0.02
@@ -145,7 +145,7 @@
 	sewn_clotting_threshold = 0.1
 	woundpain = 10
 	sewn_woundpain = 4
-	sew_threshold = 50
+	sew_threshold = 65
 	can_sew = TRUE
 	can_cauterize = TRUE
 
@@ -153,26 +153,26 @@
 	name = "superficial lashing"
 	whp = 15
 	sewn_whp = 5
-	bleed_rate = 0.4
+	bleed_rate = 0.2
 	sewn_bleed_rate = 0.01
 	clotting_rate = 0.02
 	sewn_clotting_rate = 0.02
 	clotting_threshold = 0.1
 	sewn_clotting_threshold = 0.05
-	woundpain = 6
+	woundpain = 8
 	sewn_woundpain = 2
 	sew_threshold = 30
 
 /datum/wound/lashing/large
 	name = "excruciating lashing"
-	whp = 60
+	whp = 45
 	sewn_whp = 15
-	bleed_rate = 2 //Intended for combat, might kill if used for punishment. Force can be controlled by not charging the whip lash fully.
+	bleed_rate = 1.2 //Intended for combat, might kill if used for punishment. Force can be controlled by not charging the whip lash fully.
 	sewn_bleed_rate = 0.05
 	clotting_rate = 0.02
 	sewn_clotting_rate = 0.02
 	clotting_threshold = 0.4
 	sewn_clotting_threshold = 0.1
-	woundpain = 20
-	sewn_woundpain = 10
-	sew_threshold = 75
+	woundpain = 22
+	sewn_woundpain = 14
+	sew_threshold = 95

--- a/code/datums/wounds/special.dm
+++ b/code/datums/wounds/special.dm
@@ -274,3 +274,33 @@
 			"The testicles are destroyed!",
 			"The testicles are eviscerated!",
 		)
+
+/datum/wound/scarring
+	name = "permanent scarring"
+	check_name = "<span class='userdanger'><B>SCARRED</B></span>"
+	severity = WOUND_SEVERITY_SEVERE
+	crit_message = list(
+		"The whiplash cuts deep!",
+		"The tissue is irreversibly rended!",
+		"The %BODYPART is thoroughly disfigured!",
+	)
+	sound_effect = 'sound/combat/crit.ogg'
+	whp = 80
+	woundpain = 30
+	can_sew = FALSE
+	can_cauterize = FALSE
+	disabling = TRUE
+	critical = TRUE
+	sleep_healing = 0
+	var/gain_emote = "paincrit"
+
+/datum/wound/scarring/on_mob_gain(mob/living/affected)
+	. = ..()
+	affected.emote("scream", TRUE)
+	affected.Slowdown(20)
+	shake_camera(affected, 2, 2)
+
+/datum/wound/scarring/can_stack_with(datum/wound/other)
+	if(istype(other, /datum/wound/scarring))
+		return FALSE
+	return TRUE

--- a/code/modules/mob/living/living_wounds.dm
+++ b/code/modules/mob/living/living_wounds.dm
@@ -135,6 +135,14 @@
 					added_wound = /datum/wound/puncture
 				if(1 to 10)
 					added_wound = /datum/wound/puncture/small
+		if(BCLASS_LASHING)
+			switch(dam)
+				if(20 to INFINITY)
+					added_wound = /datum/wound/lashing/large
+				if(10 to 20)
+					added_wound = /datum/wound/lashing
+				if(1 to 10)
+					added_wound = /datum/wound/lashing/small
 		if(BCLASS_BITE)
 			switch(dam)
 				if(20 to INFINITY)

--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -160,6 +160,14 @@
 					added_wound = /datum/wound/puncture
 				if(1 to 10)
 					added_wound = /datum/wound/puncture/small
+		if(BCLASS_LASHING)
+			switch(dam)
+				if(20 to INFINITY)
+					added_wound = /datum/wound/lashing/large
+				if(10 to 20)
+					added_wound = /datum/wound/lashing
+				if(1 to 10)
+					added_wound = /datum/wound/lashing/small
 		if(BCLASS_BITE)
 			switch(dam)
 				if(20 to INFINITY)
@@ -194,6 +202,8 @@
 		crit_classes += "fracture"
 	if(bclass in GLOB.artery_bclasses)
 		crit_classes += "artery"
+	if(bclass in GLOB.whipping_bclasses)
+		crit_classes += "scarring"
 
 	switch(pick(crit_classes))
 		if("dislocation")
@@ -223,6 +233,12 @@
 			used = round(damage_dividend * 20 + (dam / 6), 1)
 			if(prob(used))
 				attempted_wounds += /datum/wound/artery
+		if("scarring")
+			if(user && istype(user.rmb_intent, /datum/rmb_intent/strong))
+				dam += 10
+			used = round(damage_dividend * 20 + (dam / 6), 1)
+			if(prob(used))
+				attempted_wounds += /datum/wound/scarring
 
 	for(var/wound_type in shuffle(attempted_wounds))
 		var/datum/wound/applied = add_wound(wound_type, silent, crit_message)
@@ -250,6 +266,8 @@
 		crit_classes += "fracture"
 	if(bclass in GLOB.artery_bclasses)
 		crit_classes += "artery"
+	if(bclass in GLOB.whipping_bclasses)
+		crit_classes += "scarring"
 
 	switch(pick(crit_classes))
 		if("cbt")
@@ -284,6 +302,12 @@
 				if((zone_precise == BODY_ZONE_PRECISE_STOMACH) && !resistance)
 					attempted_wounds += /datum/wound/slash/disembowel
 				attempted_wounds += /datum/wound/artery/chest
+		if("scarring")
+			if(user && istype(user.rmb_intent, /datum/rmb_intent/strong))
+				dam += 10
+			used = round(damage_dividend * 20 + (dam / 6), 1)
+			if(prob(used))
+				attempted_wounds += /datum/wound/scarring
 
 	for(var/wound_type in shuffle(attempted_wounds))
 		var/datum/wound/applied = add_wound(wound_type, silent, crit_message)


### PR DESCRIPTION
## About The Pull Request
Ports some of the whip behavior from  (#https://github.com/Darkrp-community/OpenKeep/pull/1081)
Whips have been falling behind quite a lot compared to flails, right now there's a lot more incentive to just abandon your whip as the gatemaster or the anthraxi and just get a steel flail considering that the steel flail can crit, can inflict hematomas and has much better armor penetration.

This adds lashing wounds which deal a bit more pain than slashing wounds and take slightly longer to sew, aswell as a scarring lashing crit that inflicts pain and disables the limb.

Reminder that lashing crits are mostly stopped by all armor considering it's still a minor crit. Even pants will protect against it in the current state.

## Why It's Good For The Game
It would grant players a larger weapon variety if they're playing as a flail/whip using class.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.