### PR TITLE
Cheap Dye Crafting Fix

### DIFF
--- a/code/modules/crafting/quality_of_crafting/crafting.dm
+++ b/code/modules/crafting/quality_of_crafting/crafting.dm
@@ -519,6 +519,6 @@
 		/obj/item/ash = 1,
 		/obj/item/reagent_containers/food/snacks/produce/jacksberry = 2,
 	)
-	starting_atom = /obj/item/ash
-	attacked_atom = /obj/item/reagent_containers/food/snacks/produce/jacksberry
+	starting_atom = /obj/item/reagent_containers/food/snacks/produce/jacksberry
+	attacked_atom = /obj/item/ash
 	uses_attacked_atom = TRUE

--- a/code/modules/crafting/quality_of_crafting/crafting.dm
+++ b/code/modules/crafting/quality_of_crafting/crafting.dm
@@ -511,3 +511,14 @@
 	attacked_atom = /obj/item/natural/cloth
 	uses_attacked_atom = TRUE
 	subtypes_allowed = TRUE
+
+/datum/repeatable_crafting_recipe/crafting/cheapdye
+	name = "cheap dyes"
+	output = /obj/item/dye_pack/cheap
+	requirements = list(
+		/obj/item/ash = 1,
+		/obj/item/reagent_containers/food/snacks/produce/jacksberry = 2,
+	)
+	starting_atom = /obj/item/ash
+	attacked_atom = /obj/item/reagent_containers/food/snacks/produce/jacksberry
+	uses_attacked_atom = TRUE

--- a/code/modules/crafting/slapcrafting/orderless/pies.dm
+++ b/code/modules/crafting/slapcrafting/orderless/pies.dm
@@ -161,19 +161,3 @@
 	finished_cooked_smell = /datum/pollutant/food/meat_pie
 	finished_filling_color = "#b44f44"
 	superior_cooked_type = /obj/item/reagent_containers/food/snacks/pie/cooked/meat/meat/good
-
-
-
-/*	.................   Cheap dye crafting   ................... */
-/datum/orderless_slapcraft/cheapdye
-	recipe_name = "Cheap dyes"
-	starting_item = /obj/item/ash
-	related_skill = /datum/skill/misc/sewing
-	skill_xp_gained = 2
-	requirements = list(
-		list(
-			/obj/item/reagent_containers/food/snacks/produce/jacksberry/poison,
-			/obj/item/reagent_containers/food/snacks/produce/jacksberry,
-			/obj/item/reagent_containers/food/snacks/produce/swampweed) = 2
-	)
-	output_item = /obj/item/dye_pack/cheap


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->
Fixes the crafting recipe for cheap dyes. I did this by removing it from the pie order-less crafting, and making it a standard craft. Now instead of choosing between swampweed, jacksberries, or poinsoned jacksberries, you can only make it with 2 non-poisonous jacksberries and ash now. Attack the ash with the jacksberries.

Since I did it this way, you don't get the little bit of sewing XP for this anymore, and making the dye is based off crafting, and has the default crafting difficulty of 1 (Weak).
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Removes a "Generic Recipe" showing in the game, and allows players to craft cheap dyes to dye things cheaply.
## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
