### PR TITLE
Fix dirty varedit in rosewood

### DIFF
--- a/_maps/map_files/rosewood/rosewood.dmm
+++ b/_maps/map_files/rosewood/rosewood.dmm
@@ -20369,8 +20369,6 @@
 /area/rogue/indoors/town/cell)
 "ljD" = (
 /obj/structure/mineral_door/wood/deadbolt{
-	icon_state = "wooddir";
-	locked = 0;
 	name = "guest servant room"
 	},
 /turf/open/floor/ruinedwood,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
remove icon_state / locked varedit from a door in rosewood

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
Ingame:
![image](https://github.com/user-attachments/assets/b23ede0c-0b9d-407a-bef0-cd6801b394b9)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
