### PR TITLE
Fixes server crashes related to the certain mobs deaths

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -362,7 +362,8 @@
 	var/mob/living/actual_target = passed_target
 	if(!actual_target)
 		actual_target = target
-	return actual_target?.attack_animal(src)
+	if(!QDELETED(actual_target))
+		return actual_target.attack_animal(src)
 
 /mob/living/simple_animal/hostile/proc/Aggro()
 	vision_range = aggro_vision_range

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/summons/elemental/behemoth.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/summons/elemental/behemoth.dm
@@ -70,7 +70,8 @@
 	if(!target)
 		return
 	addtimer(CALLBACK(src,PROC_REF(yeet),target), 1 SECONDS)
-	return target.attack_animal(src)
+	if(!QDELETED(target))
+		return target.attack_animal(src)
 
 /obj/effect/temp_visual/marker
 	icon = 'icons/effects/effects.dmi'

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/summons/elemental/warden.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/summons/elemental/warden.dm
@@ -74,7 +74,8 @@
 	if(!target)
 		return
 	yeet(target)
-	return target.attack_animal(src)
+	if(!QDELETED(target))
+		return target.attack_animal(src)
 
 /mob/living/simple_animal/hostile/retaliate/elemental/warden/proc/yeet(target)
 	var/atom/throw_target = get_edge_target_turf(src, get_dir(src, target)) //ill be real I got no idea why this worked.

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/summons/fae/glimmerwing.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/summons/fae/glimmerwing.dm
@@ -77,4 +77,5 @@
 		targetted.visible_message(span_danger("[src] dusts [target] with some kind of powder!"))
 		targetted.adjustToxLoss(15)
 		src.drug_cd = world.time
-	return target.attack_animal(src)
+	if(!QDELETED(target))
+		return target.attack_animal(src)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/summons/infernal/hellhound.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/summons/infernal/hellhound.dm
@@ -79,4 +79,5 @@
 		targetted.IgniteMob()
 		targetted.visible_message(span_danger("[src] sets [target] on fire!"))
 		src.flame_cd = world.time
-	return target.attack_animal(src)
+	if(!QDELETED(target))
+		return target.attack_animal(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

The problematic mobs whos death were causing crashes were the ones with `del_on_death = TRUE` variable, like familiars.

Only doing if(!target) check was not enough, as sometimes the mob was in process of qdeling and managed to pass into the attack_animal proc.

Rosewood had higher chance to crash as it had elemental wardens already prespawned.

Fixes #1553

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Less crashes.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
