### PR TITLE
Triumph Unbuy refunds 100%

### DIFF
--- a/code/controllers/subsystem/triumph/triumphs.dm
+++ b/code/controllers/subsystem/triumph/triumphs.dm
@@ -76,7 +76,7 @@ SUBSYSTEM_DEF(triumphs)
 	TRIUMPH BUY DATUM THINGS
 */
 
-	var/current_refund_percentage = 0.50 // Current refund percentage is 50%
+	var/current_refund_percentage = 1.00 // Current refund percentage is 100%
 	//this is basically the total list of triumph buy datums on init
 	var/list/triumph_buy_datums = list()
 
@@ -152,7 +152,7 @@ SUBSYSTEM_DEF(triumphs)
 			to_chat(C, span_redtext("You don't have enough triumphs to unbuy that."))
 			return FALSE
 		triumph_adjust(-pull_it_out.triumph_cost, C.ckey)
-	// Give the person who originally bought it a 50% refund
+	// Give the person who originally bought it a 100% refund
 	var/ckey_prev_owna = pull_it_out.ckey_of_buyer
 	var/refund_amount = round(pull_it_out.triumph_cost * current_refund_percentage)
 	triumph_adjust(refund_amount, ckey_prev_owna)

--- a/code/controllers/subsystem/triumph/triumphs.dm
+++ b/code/controllers/subsystem/triumph/triumphs.dm
@@ -145,14 +145,6 @@ SUBSYSTEM_DEF(triumphs)
 	Also used for refunding due to conflicts
  */
 /datum/controller/subsystem/triumphs/proc/attempt_to_unbuy_triumph_condition(client/C, datum/triumph_buy/pull_it_out, reason = "\improper UNBUY")
-	if(pull_it_out.ckey_of_buyer != C.ckey)
-		// We're being unbought by someone other than the original buyer?
-		// That costs extra, you know... (for some reason? I don't know, Macha wrote it that way)
-		if(get_triumphs(C.ckey) < pull_it_out.triumph_cost) // We're too broke!
-			to_chat(C, span_redtext("You don't have enough triumphs to unbuy that."))
-			return FALSE
-		triumph_adjust(-pull_it_out.triumph_cost, C.ckey)
-	// Give the person who originally bought it a 100% refund
 	var/ckey_prev_owna = pull_it_out.ckey_of_buyer
 	var/refund_amount = round(pull_it_out.triumph_cost * current_refund_percentage)
 	triumph_adjust(refund_amount, ckey_prev_owna)


### PR DESCRIPTION
## About The Pull Request

Triumph Unbuy now refunds 100% of triumphs spent instead of 50%.

## Why It's Good For The Game

Losing 10-15 rounds of triumphs, or more depending on how much you can sleep in a round, sucks. This can be done either by losing the role you were trying to roll for or just having to refund it last second due to having to suddenly leave. Neither scenario is a good thing. Aberra agreed and I finally got around to doing this.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
