### PR TITLE
(FIX) Give Physicker a belt

### DIFF
--- a/code/modules/jobs/job_types/adventurer/types/pilgrim/physicker.dm
+++ b/code/modules/jobs/job_types/adventurer/types/pilgrim/physicker.dm
@@ -25,6 +25,7 @@
 	gloves = /obj/item/clothing/gloves/leather/phys
 	armor = /obj/item/clothing/shirt/robe/phys
 	neck = /obj/item/clothing/neck/phys
+	belt = /obj/item/storage/belt/leather/rope
 	beltl = /obj/item/storage/keyring/physicker
 
 	H.mind?.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

The Physicker doesn't have a belt, yet they spawn with a keyring. They can't spawn with the keyring as they lack a belt to spawn it on. What the fuck?

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
