### PR TITLE
Removes orphanage assistant and cheesemaker from roundstart

### DIFF
--- a/code/modules/jobs/job_types/adventurer/adventurer.dm
+++ b/code/modules/jobs/job_types/adventurer/adventurer.dm
@@ -37,7 +37,7 @@ GLOBAL_VAR_INIT(adventurer_hugbox_duration_still, 3 MINUTES)
 		hugboxify_for_class_selection(spawned)
 
 /datum/outfit/job/adventurer // Reminder message
-	var/merc_ad = "<br><br><font color='#855b14'><span class='bold'>If I wanted to make mammons by selling my services, or completing quests, the Mercenary guild would be a good place to start.</span></font><br><br>"
+	var/merc_ad = "<br><font color='#855b14'><span class='bold'>If I wanted to make mammons by selling my services, or completing quests, the Mercenary guild would be a good place to start.</span></font><br>"
 
 /datum/outfit/job/adventurer/post_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/jobs/job_types/adventurer/types/pilgrim/cheesemaker.dm
+++ b/code/modules/jobs/job_types/adventurer/types/pilgrim/cheesemaker.dm
@@ -1,13 +1,20 @@
 /datum/advclass/pilgrim/cheesemaker
 	name = "Cheesemaker"
-	tutorial = "Craftsmen who have mastered the art of curdling milks \
-				into delicious and long lasting wheels of cheese."
+	tutorial = "Some say Dendor brings bountiful harvests - this much is true, but rot brings forth life. \
+	From life brings decay, and from decay brings life. Like your parents before you, you let milk rot into cheese. \
+	This is your duty, this is your call."
 	allowed_sexes = list(MALE, FEMALE)
 
 	outfit = /datum/outfit/job/adventurer/cheesemaker
 
 	category_tags = list(CTAG_PILGRIM)
 	apprentice_name = "Cheesemaker Apprentice"
+
+/datum/advclass/pilgrim/cheesemaker/post_equip(mob/living/carbon/human/H)
+	. = ..()
+	var/animal_path = pick(/mob/living/simple_animal/hostile/retaliate/goat, /mob/living/simple_animal/hostile/retaliate/cow)
+	var/mob/living/simple_animal/animal = new animal_path(get_turf(H))
+	animal.tamed(H)
 
 /datum/outfit/job/adventurer/cheesemaker/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -17,7 +24,7 @@
 	H.mind?.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
 	H.mind?.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
 	H.mind?.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
-	H.mind?.adjust_skillrank(/datum/skill/labor/taming, 1, TRUE)
+	H.mind?.adjust_skillrank(/datum/skill/labor/taming, 3, TRUE)
 	H.mind?.adjust_skillrank(/datum/skill/craft/cooking, 4, TRUE)
 	H.mind?.adjust_skillrank(/datum/skill/labor/farming, 2, TRUE)
 	belt = /obj/item/storage/belt/leather

--- a/code/modules/jobs/job_types/apprentices/servant.dm
+++ b/code/modules/jobs/job_types/apprentices/servant.dm
@@ -52,7 +52,7 @@
 /datum/job/tapster
 	title = "Tapster"
 	f_title = "Alemaid"
-	tutorial = "The Innkeeper needed waiters and here am I, serving the food, drinks and ensuring the rooms are clean."
+	tutorial = "The Innkeeper needed waiters and extra hands. So here am I, serving the food and drinks while ensuring the tavern rooms are kept clean."
 	flag = SERVANT
 	department_flag = APPRENTICES
 	job_flags = (JOB_ANNOUNCE_ARRIVAL | JOB_SHOW_IN_CREDITS | JOB_EQUIP_RANK | JOB_NEW_PLAYER_JOINABLE)
@@ -97,7 +97,6 @@
 		H.change_stat(STATKEY_SPD, 1)
 		H.change_stat(STATKEY_END, 1)
 
-
 /datum/job/matron_assistant
 	title = "Orphanage Assistant"
 	tutorial = "I once was an orphan, the matron took me in and now I am forever in her debt. \
@@ -107,8 +106,8 @@
 	job_flags = (JOB_ANNOUNCE_ARRIVAL | JOB_SHOW_IN_CREDITS | JOB_EQUIP_RANK | JOB_NEW_PLAYER_JOINABLE)
 	display_order = JDO_SERVANT
 	faction = FACTION_STATION
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	min_pq = -20
 	bypass_lastclass = TRUE
 
@@ -148,8 +147,8 @@
 
 /datum/job/gaffer_assistant
 	title = "Ring Servant"
-	tutorial = "I never had what it took to be a mercenary, but I offered my service to the guild regardless. \
-	my vow is to serve whomever has the ring of burden, but I know to avoid its curse my self"
+	tutorial = "I never had what it took to be a mercenary, but I offered my service to the Guild regardless. \
+	My vow is to serve whomever holds the ring of Burden while avoiding its curse from befalling me."
 	flag = SERVANT
 	department_flag = APPRENTICES
 	job_flags = (JOB_ANNOUNCE_ARRIVAL | JOB_SHOW_IN_CREDITS | JOB_EQUIP_RANK | JOB_NEW_PLAYER_JOINABLE)

--- a/code/modules/jobs/job_types/peasants/cheesemaker.dm
+++ b/code/modules/jobs/job_types/peasants/cheesemaker.dm
@@ -8,8 +8,8 @@
 	job_flags = (JOB_ANNOUNCE_ARRIVAL | JOB_SHOW_IN_CREDITS | JOB_EQUIP_RANK | JOB_NEW_PLAYER_JOINABLE)
 	display_order = JDO_CHEESEMAKER
 	faction = FACTION_STATION
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_PLAYER_ALL

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -61,7 +61,6 @@ GLOBAL_LIST_INIT(peasant_positions, list(
 	/datum/job/jester::title,
 	/datum/job/hunter::title,
 	/datum/job/fisher::title,
-	/datum/job/cheesemaker::title,
 	/datum/job/bard::title,
 	/datum/job/prisoner::title,
 	/datum/job/vagrant::title,

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -73,6 +73,8 @@ GLOBAL_LIST_INIT(apprentices_positions, list(
 	/datum/job/bapprentice::title,
 	/datum/job/wapprentice::title,
 	/datum/job/servant::title,
+	/datum/job/tapster::title,
+	/datum/job/gaffer_assistant::title,
 	/datum/job/orphan::title,
 	))
 GLOBAL_PROTECT(apprentices_positions)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
- Removes orphanage assistant and cheesemaker as actual jobs
- Cheesemaker pilgrim has buffed taming skill and spawns with a tamed goat or cow

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
Death to job bloat. Cheesemakers get a source of milk to make cheese with.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
