### PR TITLE
Tweak handcart qol

### DIFF
--- a/code/game/objects/structures/handcart.dm
+++ b/code/game/objects/structures/handcart.dm
@@ -161,10 +161,6 @@
 /obj/structure/handcart/proc/put_in_wood(turf/user_turf)
 	return filtered_put(user_turf, list(/obj/item/grown/log/tree))
 
-//Small gems.
-/obj/structure/handcart/proc/put_in_gems(turf/user_turf)
-	return filtered_put(user_turf, list(/obj/item/gem))
-
 /obj/structure/handcart/proc/put_in(atom/movable/O, mob/user)
 	if(!insertion_allowed(O))
 		return

--- a/code/game/objects/structures/handcart.dm
+++ b/code/game/objects/structures/handcart.dm
@@ -105,11 +105,62 @@
 	if(isturf(T))
 		user.changeNext_move(CLICK_CD_MELEE)
 		var/fou
-		for(var/obj/item/I in T)
-			put_in(I)
+
+		//First, we do ores.
+		if(put_in_ores(T))
 			fou = TRUE
+		//Then, we try wood
+		else if(put_in_wood(T))
+			fou = TRUE
+		// Then, everything else.
+		else
+			for(var/obj/item/I in T)
+				put_in(I)
+				fou = TRUE
 		if(fou)
 			playsound(loc, 'sound/foley/cartadd.ogg', 100, FALSE, -1)
+
+
+/**
+ * @brief This allows you to sieve through objects on a given turf and insert
+ * them into the cart if they match the given type.
+ *
+ * @param user_turf: The turf of the mob that clicked on this cart.
+ * @param type: Must be a type path, or else this will do nothing.
+ *
+ * @return bool: Whether this proc has inserted at least one item.
+ */
+/obj/structure/handcart/proc/filtered_put(turf/user_turf, type)
+	//Check if the type parameter is any good.
+	if(!ispath(type))
+		return
+
+	//Turf check should be handled by caller.
+
+	var/have_inserted = FALSE
+
+	//Nothing especially fancy here. We just check for the type to match
+	// before letting the object be "put in".
+	for(var/obj/item/I in user_turf)
+		if(istype(I, type))
+			put_in(I)
+			have_inserted = TRUE
+	if(have_inserted)
+		playsound(loc, 'sound/foley/cartadd.ogg', 100, FALSE, -1)
+
+	return have_inserted
+
+//Handles any object that's an ore
+/obj/structure/handcart/proc/put_in_ores(turf/user_turf)
+	return filtered_put(user_turf, /obj/item/ore)
+
+//Handles logs (big, small), sticks. Big logs may run afoul of the cart's weight limits.
+/obj/structure/handcart/proc/put_in_wood(turf/user_turf)
+	return filtered_put(user_turf, /obj/item/grown/log/tree)
+
+//Small gems.
+/obj/structure/handcart/proc/put_in_gems(turf/user_turf)
+	return filtered_put(user_turf, /obj/item/gem)
 
 /obj/structure/handcart/proc/put_in(atom/movable/O, mob/user)
 	if(!insertion_allowed(O))

--- a/code/game/objects/structures/handcart.dm
+++ b/code/game/objects/structures/handcart.dm
@@ -115,8 +115,9 @@
 		// Then, everything else.
 		else
 			for(var/obj/item/I in T)
-				put_in(I)
-				fou = TRUE
+				//Only play the sound if success.
+				if(put_in(I))
+					fou = TRUE
 		if(fou)
 			playsound(loc, 'sound/foley/cartadd.ogg', 100, FALSE, -1)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

This adds some small QoL changes for handcarts, which I think make the process of mining a little more fun. 
Handcarts will now attempt to filter for a few commonly gathered types of objects for their `attack_hand` proc. This is mostly meant to address a common problem of having to load the dross rock alongside the valuable ores you unearth when mining, needlessly cluttering the handcart with trash rocks.

If you click the cart with nothing in your hand, the cart will first seek out any ores or gems on the turf beneath the user. It will gather them and only them, if they exist.

Next, it moves on to wood -- specifically, logs. It does the same filtering thing there.

Then, it continues the default logic of grabbing everything it can on the turf.

I can easily add some more common use cases if I've missed a big one, but the primary issue was mixing ores with trash rocks. 

## Why It's Good For The Game

This makes the mining experience less tedious by removing a common pain point that I've encountered. 

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
