### PR TITLE
Buffs Necra Templar against deadites

### DIFF
--- a/code/controllers/subsystem/devotion.dm
+++ b/code/controllers/subsystem/devotion.dm
@@ -156,7 +156,11 @@
 
 	var/datum/patron/A = H.patron
 	if(istype(A, /datum/patron/divine/necra))
-		var/list/spelllist = list(/obj/effect/proc_holder/spell/targeted/churn, A.t3)
+		var/list/spelllist = list(
+			/obj/effect/proc_holder/spell/targeted/churn = A.t3,
+			/obj/effect/proc_holder/spell/invoked/lesser_heal = A.t0
+		)
+		//You need abrogation to get lesser_heal
 		for(var/spell_type in spelllist)
 			if(!spell_type || H.mind.has_spell(spell_type))
 				continue

--- a/code/controllers/subsystem/devotion.dm
+++ b/code/controllers/subsystem/devotion.dm
@@ -155,11 +155,19 @@
 		return
 
 	var/datum/patron/A = H.patron
-	var/list/spelllist = list(/obj/effect/proc_holder/spell/targeted/abrogation, A.t0)
-	for(var/spell_type in spelllist)
-		if(!spell_type || H.mind.has_spell(spell_type))
-			continue
-		H.mind.AddSpell(new spell_type)
+	if(istype(A, /datum/patron/divine/necra))
+		var/list/spelllist = list(/obj/effect/proc_holder/spell/targeted/churn, A.t3)
+		for(var/spell_type in spelllist)
+			if(!spell_type || H.mind.has_spell(spell_type))
+				continue
+			H.mind.AddSpell(new spell_type)
+	else
+		var/list/spelllist = list(/obj/effect/proc_holder/spell/targeted/abrogation, A.t0)
+		for(var/spell_type in spelllist)
+			if(!spell_type || H.mind.has_spell(spell_type))
+				continue
+			H.mind.AddSpell(new spell_type)
+
 	level = CLERIC_T0
 	max_devotion = 230
 	max_progression = 230


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

Necra templars  get Churn undead and not abrogation.

## Why It's Good For The Game

i can't stress enough, the goddess that hate the undead and is the actual goddess of death has the weakest templar possible since their first two abilities are 100% support, this change is in hope that people actually fear and play Necra Templars, Necra is the BANE of any undead creature and her templars should reflect that.

Keep in mind that all other templar got atleast a single skill being offensive/debuff/buff. (besides Pestra the goddess of medicine)

Templars still got less skill in miracles than acolytes, so their regen and gathering is slower, so a Necra Acolyte overrall will still be able to cast it faster.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
