### PR TITLE
Knockening

### DIFF
--- a/code/game/objects/structures/hidden_doors.dm
+++ b/code/game/objects/structures/hidden_doors.dm
@@ -72,6 +72,15 @@ GLOBAL_LIST_EMPTY(thieves_guild_doors)
 /obj/structure/mineral_door/secret/door_rattle()
 	return
 
+/obj/structure/mineral_door/secret/attack_hand(mob/user)
+	. = ..()
+	if(.)
+		return
+	user.changeNext_move(CLICK_CD_MELEE)
+	to_chat(user, span_notice("I start feeling around [src]"))
+	if(!do_after(user, 1.5 SECONDS, src))
+		return
+
 //can't kick it open, but you can kick it closed
 /obj/structure/mineral_door/secret/onkick(mob/user)
 	if(locked)

--- a/code/game/objects/structures/mannequin.dm
+++ b/code/game/objects/structures/mannequin.dm
@@ -103,7 +103,7 @@
 	update_icon()
 
 /obj/structure/mannequin/attack_hand(mob/living/user)
-	if(user.cmode || user.a_intent == INTENT_HARM || user.a_intent == INTENT_DISARM)
+	if(user.a_intent.name == "punch")
 		if(!tipped_over)
 			TipOver()
 			return

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -249,12 +249,17 @@
 			if(L.m_intent == MOVE_INTENT_SNEAK)
 				to_chat(user, span_warning("This door is locked."))
 				return
-		if(world.time >= last_bump+20)
+		if(world.time >= last_bump+20 && can_knock)
 			last_bump = world.time
-			if(can_knock)
+			if(user.a_intent.name == "punch")
 				playsound(src, 'sound/foley/doors/knocking.ogg', 100)
 				user.visible_message(span_warning("[user] knocks on [src]."), \
 					span_notice("I knock on [src]."))
+				return
+			door_rattle()
+			user.visible_message(span_warning("[user] tries the handle, but the door does not move."), \
+					span_notice("I try the handle, but the door does not move."))
+			return
 		return
 	return TryToSwitchState(user)
 

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -241,7 +241,7 @@
 	if(locked)
 		if( user.used_intent.type == /datum/intent/unarmed/claw )
 			user.changeNext_move(CLICK_CD_MELEE)
-			to_chat(user, "<span class='warning'>The deadite claws at the door!!</span>")
+			to_chat(user, "<span class='warning'>Something claws at the door!!</span>")
 			take_damage(40, "brute", "slash", 1)
 			return
 		if(isliving(user))

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -241,7 +241,7 @@
 	if(locked)
 		if( user.used_intent.type == /datum/intent/unarmed/claw )
 			user.changeNext_move(CLICK_CD_MELEE)
-			to_chat(user, "<span class='warning'>Something claws at the door!!</span>")
+			to_chat(user, "<span class='warning'>[src] is damaged by the claws!!</span>")
 			take_damage(40, "brute", "slash", 1)
 			return
 		if(isliving(user))

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -244,7 +244,7 @@
 	if(brokenstate)
 		return
 	if( user.used_intent.type == /datum/intent/unarmed/claw )
-		to_chat(user, "<span class='warning'>The deadite smashes the window!!</span>")
+		to_chat(user, "<span class='warning'>[user] smashes the window!!</span>")
 		obj_break()
 		return
 	user.changeNext_move(CLICK_CD_MELEE)

--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -39,7 +39,7 @@
 			return
 
 /turf/closed/proc/feel_turf(mob/living/user)
-	to_chat(user, span_notice("I start feeling around the [src]"))
+	to_chat(user, span_notice("I start feeling around [src]"))
 	if(!do_after(user, 1.5 SECONDS, src))
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
Instead of immediately knocking on a locked door when it is locked and you clicked on it, you now have to be on harm/punch intent. Otherwise it defaults to trying the handle and the rattle animation/sounds, exactly like walking into the door.
Furthermore I changed some wording when attacking windows and doors with claw intent, since mobs other than deadites use it, changed some checks for tipping over mannequins and made secret doors blend in even better with the surrounding walls.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
It seemed weird that by default your character immediately knocks on a locked door
it's weird that you'd get a "The deadite smashes the window/claws at the door!" in chat if the mob happened to be a goblin, for example, or that you'd see the assailant from the other side of a locked door.
Secret doors now have less metagaming potential, acting almost indistinguishable from from walls at first glance. Also removed a redundant 'the' that would be displayed twice.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
