### PR TITLE
Aasimar hunger debuff removed and added to half-orcs

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/other/aasimar.dm
+++ b/code/modules/mob/living/carbon/human/species_types/other/aasimar.dm
@@ -6,7 +6,6 @@
 
 //	( + Pain Resist )
 //	( + Bleed Resist )
-//	( - Hunger )
 
 /mob/living/carbon/human/species/aasimar
 	race = /datum/species/aasimar
@@ -27,7 +26,6 @@
 	but their insides are just as mortal as any other."
 
 	skin_tone_wording = "Crafted With"
-	nutrition_mod = 2 // 200% higher hunger rate. Hungry, hungry aasimar
 	pain_mod = 0.9 // 10% less pain from wounds
 	bleed_mod = 0.8 // 20% less bleed rate from injuries
 

--- a/code/modules/mob/living/carbon/human/species_types/other/halforc.dm
+++ b/code/modules/mob/living/carbon/human/species_types/other/halforc.dm
@@ -50,8 +50,8 @@
 	OFFSET_FACE_F = list(0,0), OFFSET_BELT_F = list(0,1), OFFSET_BACK_F = list(0,1), \
 	OFFSET_NECK_F = list(0,1), OFFSET_MOUTH_F = list(0,1), OFFSET_PANTS_F = list(0,0), \
 	OFFSET_SHIRT_F = list(0,1), OFFSET_ARMOR_F = list(0,1), OFFSET_UNDIES_F = list(0,1))
-	specstats = list(STATKEY_STR = 2, STATKEY_PER = -2, STATKEY_INT = -2, STATKEY_CON = 2, STATKEY_END = 1, STATKEY_SPD = 0, STATKEY_LCK = -1)
-	specstats_f = list(STATKEY_STR = 2, STATKEY_PER = -2, STATKEY_INT = -1, STATKEY_CON = 1, STATKEY_END = 1, STATKEY_SPD = 0, STATKEY_LCK = -1)
+	specstats = list(STATKEY_STR = 2, STATKEY_PER = -2, STATKEY_INT = -2, STATKEY_CON = 2, STATKEY_END = 1, STATKEY_SPD = 0, STATKEY_LCK = 0)
+	specstats_f = list(STATKEY_STR = 2, STATKEY_PER = -2, STATKEY_INT = -1, STATKEY_CON = 1, STATKEY_END = 1, STATKEY_SPD = 0, STATKEY_LCK = 0)
 	enflamed_icon = "widefire"
 	exotic_bloodtype = /datum/blood_type/human/horc
 

--- a/code/modules/mob/living/carbon/human/species_types/other/halforc.dm
+++ b/code/modules/mob/living/carbon/human/species_types/other/halforc.dm
@@ -22,6 +22,7 @@
 	THIS IS AN <I>EXTREMELY</I> DISCRIMINATED SPECIES. EXPECT A MORE DIFFICULT EXPERIENCE. <B>NOBLES EVEN MORE SO.</B> PLAY AT YOUR OWN RISK."
 
 	skin_tone_wording = "Clan"
+	nutrition_mod = 2 // 200% higher hunger rate. Hungry, hungry horcs
 
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,STUBBLE,OLDGREY)
 	inherent_traits = list(TRAIT_NOMOBSWAP, TRAIT_NOSTINK)


### PR DESCRIPTION
## About The Pull Request

Removes the 2 times nutrition depletion modifier on aasimar 
Adds a 2 times nutrition depletion modifier to half orcs
Half-orcs get their fortune back

## Why It's Good For The Game

Aasimar constantly have to eat, which means more time is spent walking to/from kitchens and gobbling food instead of roleplaying. This debuff isn't mentioned at all in the lore, and is entirely a balance mechanic from stonekeep where aasimar are objectively the best fighters. However, this debuff doesn't fit in Vanderlin, where aasimar have transferred archetypes from hungry high-maintenance brutes to intelligent sluggish generalists. Also this debuff is extremely unpopular, and discourages people from playing aasimar in the first place. Ook said to give the hunger to half-orcs.

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.