### PR TITLE
Satchel on hip

### DIFF
--- a/code/modules/clothing/belt/misc.dm
+++ b/code/modules/clothing/belt/misc.dm
@@ -209,7 +209,7 @@
 	item_state = "satchel"
 	icon = 'icons/roguetown/clothing/storage.dmi'
 	w_class = WEIGHT_CLASS_BULKY
-	slot_flags = ITEM_SLOT_BACK
+	slot_flags = ITEM_SLOT_BACK|ITEM_SLOT_HIP
 	resistance_flags = NONE
 	max_integrity = 300
 	equip_sound = 'sound/blank.ogg'


### PR DESCRIPTION

## About The Pull Request

Allows satchels to be worn on the hip

## Why It's Good For The Game

This allows somebody to have two large weapons on their back, and still have adequate storage space.

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.