### PR TITLE
Pious-Court

### DIFF
--- a/code/modules/jobs/job_types/nobility/captain.dm
+++ b/code/modules/jobs/job_types/nobility/captain.dm
@@ -18,6 +18,7 @@
 
 	outfit = /datum/outfit/job/captain
 	spells = list(/obj/effect/proc_holder/spell/self/convertrole/guard)
+	allowed_patrons = ALL_TEMPLE_PATRONS
 	give_bank_account = 120
 	cmode_music = 'sound/music/cmode/antag/CombatSausageMaker.ogg'
 	noble_income = 11

--- a/code/modules/jobs/job_types/nobility/lord.dm
+++ b/code/modules/jobs/job_types/nobility/lord.dm
@@ -30,6 +30,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	)
 	outfit = /datum/outfit/job/lord
 	bypass_lastclass = TRUE
+	allowed_patrons = ALL_TEMPLE_PATRONS
 	give_bank_account = 500
 	selection_color = "#7851A9"
 


### PR DESCRIPTION
Monarch and Captain cannot be heretics in Vanderlin without triumph buys... this PR makes the Monarch and Captain locked to the temple accepted patrons list.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! --> As stated, makes Monarch and Captain, two of the highest importance roles in Vanderlin, expectedly pious. Will work well with heretic triumph buy whenever added.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. --> This makes the Monarch and Captain (the most trusted knight of the Monarch) pious per lore accuracy of Vanderlin being a religious state. A heretic of these roles can be a triumph buy, to preserve the health of the setting and prevent constant CvC rounds.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
