### PR TITLE
[Bug fix] Spangenhelm worn sprite 2

### DIFF
--- a/code/modules/clothing/head/helmets/heavy.dm
+++ b/code/modules/clothing/head/helmets/heavy.dm
@@ -105,6 +105,7 @@
 	name = "spangenhelm"
 	desc = "A steel helmet with built in eye and nose protection, commonly used by warriors of the north."
 	icon_state = "Spangenhelm_item"
+	item_state = "Spangenhelm_worn"
 	icon = 'icons/roguetown/clothing/special/spangenhelm_item.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/spangenhelm_worn.dmi'
 	body_parts_covered = HEAD|NOSE|EYES


### PR DESCRIPTION

## About The Pull Request

The sprite for the spangenhelm is STILL broken, this fixes it, finally.

## Why It's Good For The Game

helmets ought to have sprites

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
