### PR TITLE
kills the terrible dirt fix "bearerdied" var from the ring of burden with a fix that corrects the issue that it prevented

### DIFF
--- a/code/modules/clothing/ring/misc.dm
+++ b/code/modules/clothing/ring/misc.dm
@@ -251,7 +251,6 @@
 	name = "ring of burden"
 	icon_state = "ring_protection" //N/A change this to a real sprite after its made
 	sellprice = 0
-	var/bearerdied = FALSE
 
 /obj/item/clothing/ring/gold/burden/Initialize()
 	. = ..()
@@ -313,7 +312,6 @@
 		return
 	visible_message(span_warning("[src] begins to twitch and shake violently, before crumbling into ash"))
 	new /obj/item/ash(loc)
-	bearerdied = TRUE
 	qdel(src)
 
 /obj/item/clothing/ring/gold/burden/equipped(mob/user, slot)
@@ -332,8 +330,6 @@
 	to_chat(user, span_danger("The moment the [src] is in your grasp, it fuses with the skin of your palm, you can't let it go without choosing your destiny first."))
 
 /obj/item/clothing/ring/gold/burden/Destroy()
-	if(bearerdied == TRUE)
-		SEND_GLOBAL_SIGNAL(COMSIG_GAFFER_RING_DESTROYED, src)
-		bearerdied = FALSE
-		. = ..()
+	SEND_GLOBAL_SIGNAL(COMSIG_GAFFER_RING_DESTROYED, src)
+	. = ..()
 

--- a/code/modules/jobs/job_types/serfs/gaffer.dm
+++ b/code/modules/jobs/job_types/serfs/gaffer.dm
@@ -28,7 +28,7 @@
 
 	spells = list(/obj/effect/proc_holder/spell/self/convertrole/mercenary)
 
-/datum/outfit/job/gaffer/pre_equip(mob/living/carbon/human/H)
+/datum/outfit/job/gaffer/pre_equip(mob/living/carbon/human/H, visualsOnly)
 	..()
 
 
@@ -41,7 +41,10 @@
 	shirt = /obj/item/clothing/shirt/tunic/black
 	wrists = /obj/item/clothing/wrists/bracers/leather/advanced
 	armor = /obj/item/clothing/armor/leather/hide
-	ring = /obj/item/clothing/ring/gold/burden
+	if(!visualsOnly)
+		ring = /obj/item/clothing/ring/gold/burden
+	else
+		ring = /obj/item/clothing/ring/gold
 	pants = /obj/item/clothing/pants/trou/leather/advanced
 	shoes = /obj/item/clothing/shoes/nobleboot
 	cloak = /obj/item/clothing/cloak/raincloak/furcloak/black


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

- Removes "bearerdied" var from the ring of burden, which was in place to quickly fix an issue with gaffer spawning resulting in the ring of burden destroy proc being called, sending the signal and causing a dupe ring

- Adds visualsOnly to gaffer pre-equip so the real ring of burden isn't used in the preview, which will be destroyed after creation and send the signal to begin with

## Why It's Good For The Game

it kills the bearerdied var, which only creates issue. like this one https://github.com/Vanderlin-Tales-Of-Wine/Vanderlin/issues/1333

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
