### PR TITLE
Royal knight flails!

### DIFF
--- a/code/modules/jobs/job_types/garrison/royalguard.dm
+++ b/code/modules/jobs/job_types/garrison/royalguard.dm
@@ -93,7 +93,7 @@
 	switch(weapon_choice)
 		if("Flail)
 			r_hand = /obj/item/weapon/flail/sflail
-			H.mind?.adjust_skillrank(/datum/skill/combat/whipsandflails, 4, TRUE)
+			H.mind?.adjust_skillrank(/datum/skill/combat/whipsflails, 4, TRUE)
 		if("Halberd")
 			r_hand = /obj/item/weapon/polearm/halberd
 			H.mind?.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)

--- a/code/modules/jobs/job_types/garrison/royalguard.dm
+++ b/code/modules/jobs/job_types/garrison/royalguard.dm
@@ -92,5 +92,7 @@
 	. = ..()
 	spawned.select_equippable(player_client,
 		list("Flail" = /obj/item/weapon/flail/sflail,
-		"Halberd" = /obj/item/weapon/polearm/halberd,)
-		title = "KNIGHT" )
+		"Halberd" = /obj/item/weapon/polearm/halberd,
+		message = "Take up arms!",
+		title = "KNIGHT" 
+		)

--- a/code/modules/jobs/job_types/garrison/royalguard.dm
+++ b/code/modules/jobs/job_types/garrison/royalguard.dm
@@ -93,4 +93,4 @@
 	spawned.select_equippable(player_client,
 		list("Flail" = /obj/item/weapon/flail/sflail,
 		"Halberd" = /obj/item/weapon/polearm/halberd,)
-		title = "KNIGHT")
+		title = "KNIGHT" )

--- a/code/modules/jobs/job_types/garrison/royalguard.dm
+++ b/code/modules/jobs/job_types/garrison/royalguard.dm
@@ -93,6 +93,5 @@
 		H.mind?.adjust_skillrank(/datum/skill/combat/whipsflails, 4, TRUE)
 		"Halberd" = /obj/item/weapon/polearm/halberd,
 		H.mind?.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)
-		message = "Take up arms!",
 		title = "KNIGHT"
 		)

--- a/code/modules/jobs/job_types/garrison/royalguard.dm
+++ b/code/modules/jobs/job_types/garrison/royalguard.dm
@@ -95,5 +95,5 @@
 		"Halberd" = /obj/item/weapon/polearm/halberd,
 		message = "Take up arms!",
 		title = "KNIGHT" )
-)	)	)	)	)
+)
 

--- a/code/modules/jobs/job_types/garrison/royalguard.dm
+++ b/code/modules/jobs/job_types/garrison/royalguard.dm
@@ -88,6 +88,7 @@
 	if(H.dna?.species)
 		if(H.dna.species.id == "human")
 			H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
+
 /datum/job/royalguard/after_spawn(mob/living/carbon/spawned, client/player_client)
 	. = ..()
 	spawned.select_equippable(player_client,

--- a/code/modules/jobs/job_types/garrison/royalguard.dm
+++ b/code/modules/jobs/job_types/garrison/royalguard.dm
@@ -57,7 +57,6 @@
 	beltr = /obj/item/weapon/sword/arming
 	backr = /obj/item/storage/backpack/satchel
 	backl = /obj/item/weapon/shield/tower/metal
-	r_hand = /obj/item/weapon/polearm/halberd
 	gloves = /obj/item/clothing/gloves/chain
 	head = /obj/item/clothing/head/helmet/visored/knight
 
@@ -67,7 +66,6 @@
 		H.mind?.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
-		H.mind?.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/axesmaces, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/shields, 4, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
@@ -88,3 +86,14 @@
 	if(H.dna?.species)
 		if(H.dna.species.id == "human")
 			H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
+	H.adjust_blindness(-3)
+	var/weapons = list("Flail","Halberd")
+	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+	H.set_blindness(0)
+	switch(weapon_choice)
+		if("Flail)
+			r_hand = /obj/item/weapon/flail/sflail
+			H.mind?.adjust_skillrank(/datum/skill/combat/whipsandflails, 4, TRUE)
+		if("Halberd")
+			r_hand = /obj/item/weapon/polearm/halberd
+			H.mind?.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)

--- a/code/modules/jobs/job_types/garrison/royalguard.dm
+++ b/code/modules/jobs/job_types/garrison/royalguard.dm
@@ -75,6 +75,8 @@
 		H.mind?.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/riding, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/labor/mathematics, 3, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/whipsflails, 4, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)
 		H.change_stat(STATKEY_STR, 2)
 		H.change_stat(STATKEY_PER, 2)
 		H.change_stat(STATKEY_END, 2)
@@ -89,9 +91,7 @@
 /datum/job/royalguard/after_spawn(mob/living/carbon/spawned, client/player_client)
 	. = ..()
 	spawned.select_equippable(player_client,
-		list("Flail" = /obj/item/weapon/flail/sflail,
-		H.mind?.adjust_skillrank(/datum/skill/combat/whipsflails, 4, TRUE)
-		"Halberd" = /obj/item/weapon/polearm/halberd,
-		H.mind?.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)
+		list("Flail" = /obj/item/weapon/flail/sflail,)
+		"Halberd" = /obj/item/weapon/polearm/halberd,)
 		title = "KNIGHT"
 		)

--- a/code/modules/jobs/job_types/garrison/royalguard.dm
+++ b/code/modules/jobs/job_types/garrison/royalguard.dm
@@ -86,14 +86,13 @@
 	if(H.dna?.species)
 		if(H.dna.species.id == "human")
 			H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
-	H.adjust_blindness(-3)
-	var/weapons = list("Flail","Halberd")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Flail")
-			r_hand = /obj/item/weapon/flail/sflail
-			H.mind?.adjust_skillrank(/datum/skill/combat/whipsflails, 4, TRUE)
-		if("Halberd")
-			r_hand = /obj/item/weapon/polearm/halberd
-			H.mind?.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)
+/datum/job/royalguard/after_spawn(mob/living/carbon/spawned, client/player_client)
+	. = ..()
+	spawned.select_equippable(player_client,
+		list("Flail" = /obj/item/weapon/flail/sflail,
+		H.mind?.adjust_skillrank(/datum/skill/combat/whipsflails, 4, TRUE)
+		"Halberd" = /obj/item/weapon/polearm/halberd,
+		H.mind?.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)
+		message = "Take up arms!",
+		title = "KNIGHT"
+		)

--- a/code/modules/jobs/job_types/garrison/royalguard.dm
+++ b/code/modules/jobs/job_types/garrison/royalguard.dm
@@ -94,5 +94,4 @@
 		list("Flail" = /obj/item/weapon/flail/sflail,
 		"Halberd" = /obj/item/weapon/polearm/halberd,
 		message = "Take up arms!",
-		title = "KNIGHT" 
-		)
+		title = "KNIGHT" )

--- a/code/modules/jobs/job_types/garrison/royalguard.dm
+++ b/code/modules/jobs/job_types/garrison/royalguard.dm
@@ -40,6 +40,8 @@
 		honorary = "Dame"
 	spawned.real_name = "[honorary] [prev_real_name]"
 	spawned.name = "[honorary] [prev_name]"
+	var/static/list/selectable = list("Flail" = /obj/item/weapon/flail/sflail, "Halberd" = /obj/item/weapon/polearm/halberd)
+	spawned.select_equippable(player_client, selectable, message = "Take up arms!", title = "KNIGHT")
 
 /datum/outfit/job/royalguard
 	job_bitflag = BITFLAG_GARRISON
@@ -88,13 +90,3 @@
 	if(H.dna?.species)
 		if(H.dna.species.id == "human")
 			H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
-
-/datum/job/royalguard/after_spawn(mob/living/carbon/spawned, client/player_client)
-	. = ..()
-	spawned.select_equippable(player_client,
-		list("Flail" = /obj/item/weapon/flail/sflail,
-		"Halberd" = /obj/item/weapon/polearm/halberd,
-		message = "Take up arms!",
-		title = "KNIGHT" )
-)
-

--- a/code/modules/jobs/job_types/garrison/royalguard.dm
+++ b/code/modules/jobs/job_types/garrison/royalguard.dm
@@ -95,5 +95,5 @@
 		"Halberd" = /obj/item/weapon/polearm/halberd,
 		message = "Take up arms!",
 		title = "KNIGHT" )
-
+)	)	)	)	)
 

--- a/code/modules/jobs/job_types/garrison/royalguard.dm
+++ b/code/modules/jobs/job_types/garrison/royalguard.dm
@@ -93,5 +93,4 @@
 	spawned.select_equippable(player_client,
 		list("Flail" = /obj/item/weapon/flail/sflail,)
 		"Halberd" = /obj/item/weapon/polearm/halberd,)
-		title = "KNIGHT"
-		)
+		title = "KNIGHT")

--- a/code/modules/jobs/job_types/garrison/royalguard.dm
+++ b/code/modules/jobs/job_types/garrison/royalguard.dm
@@ -91,6 +91,6 @@
 /datum/job/royalguard/after_spawn(mob/living/carbon/spawned, client/player_client)
 	. = ..()
 	spawned.select_equippable(player_client,
-		list("Flail" = /obj/item/weapon/flail/sflail,)
+		list("Flail" = /obj/item/weapon/flail/sflail,
 		"Halberd" = /obj/item/weapon/polearm/halberd,)
 		title = "KNIGHT")

--- a/code/modules/jobs/job_types/garrison/royalguard.dm
+++ b/code/modules/jobs/job_types/garrison/royalguard.dm
@@ -91,7 +91,7 @@
 	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 	H.set_blindness(0)
 	switch(weapon_choice)
-		if("Flail)
+		if("Flail")
 			r_hand = /obj/item/weapon/flail/sflail
 			H.mind?.adjust_skillrank(/datum/skill/combat/whipsflails, 4, TRUE)
 		if("Halberd")

--- a/code/modules/jobs/job_types/garrison/royalguard.dm
+++ b/code/modules/jobs/job_types/garrison/royalguard.dm
@@ -95,3 +95,5 @@
 		"Halberd" = /obj/item/weapon/polearm/halberd,
 		message = "Take up arms!",
 		title = "KNIGHT" )
+
+


### PR DESCRIPTION
## About The Pull Request

Gives the option roundstart to choose a flail instead of the halberd! Royal knight now gets no polearms skill or flails skill, but if they choose the flail, they get 4 whips/flails, if they choose the halberd, they get 4 polearms

## Why It's Good For The Game

Flails are so rare! I want to see more flails. Currently, the only garrison class that starts with a flail is the captain, who gets a flail in his closet on only some specific maps, and a skill of 2. Also, flails are cool. Plus, everyone who has ever played Royal Knight hates lugging around the halberd, so a tighter option letting people have hands free is great.
![conqueror](https://github.com/user-attachments/assets/452af967-4b87-4679-bd72-06d0a528331f)

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
