### PR TITLE
Acolyte cooks

### DIFF
--- a/code/modules/jobs/job_types/church/monk.dm
+++ b/code/modules/jobs/job_types/church/monk.dm
@@ -122,7 +122,7 @@
 		H.mind?.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/magic/holy, 3, TRUE)
-		H.mind?.adjust_skillrank(/datum/skill/craft/cooking, 3, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/craft/cooking, 2, TRUE)
 		if(H.age == AGE_OLD)
 			H.mind?.adjust_skillrank(/datum/skill/magic/holy, 1, TRUE)
 		H.change_stat(STATKEY_INT, 1)

--- a/code/modules/jobs/job_types/church/monk.dm
+++ b/code/modules/jobs/job_types/church/monk.dm
@@ -122,6 +122,7 @@
 		H.mind?.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/magic/holy, 3, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/craft/cooking, 3, TRUE)
 		if(H.age == AGE_OLD)
 			H.mind?.adjust_skillrank(/datum/skill/magic/holy, 1, TRUE)
 		H.change_stat(STATKEY_INT, 1)


### PR DESCRIPTION

## About The Pull Request

Acolytes now get 3 cooking skill, skilled.

## Why It's Good For The Game

Acolytes make food in the game, and in the lore it says one of their daily chores is making food, so it's immersion breaking to see them have zero cooking skill.

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

