### PR TITLE
Removes Last Class restriction from a few roles.

### DIFF
--- a/code/modules/jobs/job_types/church/templar.dm
+++ b/code/modules/jobs/job_types/church/templar.dm
@@ -11,6 +11,7 @@
 	total_positions = 2
 	spawn_positions = 2
 	min_pq = 8
+	bypass_lastclass = TRUE
 
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_PLAYER_NONDISCRIMINATED

--- a/code/modules/jobs/job_types/peasants/hunter.dm
+++ b/code/modules/jobs/job_types/peasants/hunter.dm
@@ -12,6 +12,7 @@
 	total_positions = 4
 	spawn_positions = 4
 	min_pq = 0
+	bypass_lastclass = TRUE
 
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_PLAYER_ALL

--- a/code/modules/jobs/job_types/peasants/miner.dm
+++ b/code/modules/jobs/job_types/peasants/miner.dm
@@ -9,6 +9,7 @@
 	faction = FACTION_STATION
 	total_positions = 12
 	spawn_positions = 12
+	bypass_lastclass = TRUE
 
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_PLAYER_ALL

--- a/code/modules/jobs/job_types/serfs/carpenter.dm
+++ b/code/modules/jobs/job_types/serfs/carpenter.dm
@@ -9,6 +9,7 @@
 	faction = FACTION_STATION
 	total_positions = 6
 	spawn_positions = 4
+	bypass_lastclass = TRUE
 
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_PLAYER_ALL


### PR DESCRIPTION
## About The Pull Request
Removes Last Class restriction from;
- Templar
- Carpenter
- Hunter
- Miner
Allowing players to roll these multiple times in a row without using triumphs.
## Why It's Good For The Game

In regards for Templar, Royal Knight isn't restricted so why is Templar? Templar often doesn't have its slots filled leaving the church weak compared to the Crown that often has RK's.

The others are peasant classes that make no sense to restrict in the slightest.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
