### PR TITLE
Switch kick and stomp damage, kicks no longer use punch damage proc

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -107,8 +107,10 @@
 
 /mob/living/carbon/human/get_punch_dmg()
 	var/damage = 12
-
 	var/used_str = STASTR
+
+	if(mind?.has_antag_datum(/datum/antagonist/werewolf))
+		return 30
 
 	if(domhand)
 		used_str = get_str_arms(used_hand)
@@ -123,11 +125,25 @@
 	if(istype(BP))
 		damage *= BP.punch_modifier
 
-	if(mind)
-		if(mind.has_antag_datum(/datum/antagonist/werewolf))
-			return 30
-
 	return damage
+
+/mob/living/carbon/human/get_kick_damage(multiplier = 1)
+	var/damage = 12
+	var/used_str = STASTR
+
+	if(mind?.has_antag_datum(/datum/antagonist/werewolf))
+		return 30 * multiplier
+
+	if(used_str >= 11)
+		damage = max(damage + (damage * ((used_str - 10) * 0.3)), 1)
+
+	if(used_str <= 9)
+		damage = max(damage - (damage * ((10 - used_str) * 0.1)), 1)
+
+	if(shoes)
+		damage *= (1 + (shoes.armor_class * 0.2))
+
+	return damage * multiplier
 
 /// Fully randomizes everything in the character.
 // Reflect changes in [datum/preferences/proc/randomise_appearance_prefs]

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -127,7 +127,7 @@
 
 	return damage
 
-/mob/living/carbon/human/get_kick_damage(multiplier = 1)
+/mob/living/carbon/human/proc/get_kick_damage(multiplier = 1)
 	var/damage = 12
 	var/used_str = STASTR
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1510,9 +1510,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 				target.mind.attackedme[user.real_name] = world.time
 			var/selzone = accuracy_check(user.zone_selected, user, target, /datum/skill/combat/unarmed, user.used_intent)
 			var/obj/item/bodypart/affecting = target.get_bodypart(check_zone(selzone))
-			var/damage = (user.get_punch_dmg() * 1.4)
-			if(user.shoes)
-				damage *= (1 + (user.shoes.armor_class * 0.2))
+			var/damage = user.get_kick_damage(2.5)
 			var/armor_block = target.run_armor_check(selzone, "blunt", blade_dulling = BCLASS_BLUNT)
 			var/balance = 10
 			target.next_attack_msg.Cut()
@@ -1616,9 +1614,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		if(!affecting)
 			affecting = target.get_bodypart(BODY_ZONE_CHEST)
 		var/armor_block = target.run_armor_check(selzone, "blunt", blade_dulling = BCLASS_BLUNT)
-		var/damage = (user.get_punch_dmg() * 2.5)
-		if(user.shoes)
-			damage *= (1 + (user.shoes.armor_class * 0.2))
+		var/damage = user.get_kick_damage(1.4)
 		if(!target.apply_damage(damage, user.dna.species.attack_type, affecting, armor_block))
 			target.next_attack_msg += " <span class='warning'>Armor stops the damage.</span>"
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
Kicks now have a decicated proc for getting their damage so they aren't effected by used hand. Base damage and scaling is the same as punching like before.

Switched stomp and kick damage:
Kicks now do punch damage * 1.4
Stomps now do punch damage * 2.5

Stomps require you do be standing ON your target yet are worse than kicks, this makes no sense.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
