### PR TITLE
Brigand gear buff

### DIFF
--- a/code/modules/jobs/job_types/adventurer/types/antag/brigand.dm
+++ b/code/modules/jobs/job_types/adventurer/types/antag/brigand.dm
@@ -10,6 +10,7 @@
 	..()
 	H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/axesmaces, 4, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/shields, 4, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)

--- a/code/modules/jobs/job_types/adventurer/types/antag/brigand.dm
+++ b/code/modules/jobs/job_types/adventurer/types/antag/brigand.dm
@@ -1,6 +1,6 @@
 /datum/advclass/brigand //Strength class, starts with axe or flails and medium armor training
 	name = "Brigand"
-	tutorial = "Cast from society, you use your powerful physical might and endurance to take from those who are weaker from you."
+	tutorial = "Cast from society, you use your powerful physical might and endurance to take from those who are weaker from you. USE DEFEND INTENT IF YOU CHOOSE FLAIL/SHIELD"
 	allowed_sexes = list(MALE, FEMALE)
 	outfit = /datum/outfit/job/bandit/brigand
 	category_tags = list(CTAG_BANDIT)

--- a/code/modules/jobs/job_types/adventurer/types/antag/brigand.dm
+++ b/code/modules/jobs/job_types/adventurer/types/antag/brigand.dm
@@ -25,13 +25,13 @@
 	H.mind.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
 	belt = /obj/item/storage/belt/leather
-	pants = /obj/item/clothing/pants/trou/leather
-	shirt = /obj/item/clothing/shirt/shortshirt/random
+	pants = /obj/item/clothing/pants/trou/leather/advanced
+	shirt = /obj/item/clothing/armor/chainmail
 	shoes = /obj/item/clothing/shoes/boots
 	backr = /obj/item/storage/backpack/satchel
 	backpack_contents = list(/obj/item/needle/thorn = 1, /obj/item/natural/cloth = 1)
 	mask = /obj/item/clothing/face/facemask/steel
-	neck = /obj/item/clothing/neck/coif
+	neck = /obj/item/clothing/neck/chaincoif/iron
 	head = /obj/item/clothing/head/helmet/leather/volfhelm
 	armor = /obj/item/clothing/armor/leather/hide
 	H.change_stat(STATKEY_STR, 3)

--- a/code/modules/jobs/job_types/adventurer/types/antag/brigand.dm
+++ b/code/modules/jobs/job_types/adventurer/types/antag/brigand.dm
@@ -33,7 +33,7 @@
 	mask = /obj/item/clothing/face/facemask/steel
 	neck = /obj/item/clothing/neck/chaincoif/iron
 	head = /obj/item/clothing/head/helmet/leather/volfhelm
-	armor = /obj/item/clothing/armor/leather/hide
+	armor = /obj/item/clothing/armor/cuirass/iron
 	H.change_stat(STATKEY_STR, 3)
 	H.change_stat(STATKEY_END, 2)
 	H.change_stat(STATKEY_CON, 2)


### PR DESCRIPTION
## About The Pull Request

Replaces the completely bumass normal shirt with a haubergeon. Replaces the completely bumass cloth coif with an iron chain one. Replaces the completely bumass leather pants with slightly better leather pants. 
Replaces the completely bumass hide armor with an iron breastplate
Replaces the completely bumass ZERO shield skill with 4 shield skill

## Why It's Good For The Game

Brigand is the default bandit, it should not suck this bad, this guy is supposed to be a medium armor bruiser, why the fuck does he get hide. With the new bandit PR that made them a guaranteed threat, their severe gear shittery has become glaring.

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

