### PR TITLE
Makes brimmed hats craftable and be called "brimmed hat" instead of hat

### DIFF
--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -39,6 +39,7 @@
 	flags_inv = HIDEEARS
 
 /obj/item/clothing/head/brimmed
+	name = "brimmed hat"
 	desc = "A simple brimmed hat that provides some relief from the sun."
 	icon_state = "brimmed"
 

--- a/code/modules/crafting/quality_of_crafting/leatherworking.dm
+++ b/code/modules/crafting/quality_of_crafting/leatherworking.dm
@@ -341,7 +341,7 @@
 		/obj/item/natural/hide/cured = 1,
 	)
 	output_amount = 2
-	output = list(/obj/item/clothing/head/brimmed
+	output = /obj/item/clothing/head/brimmed
 	craftdiff = 1
 
 /datum/repeatable_crafting_recipe/leather/volfmantle

--- a/code/modules/crafting/quality_of_crafting/leatherworking.dm
+++ b/code/modules/crafting/quality_of_crafting/leatherworking.dm
@@ -340,7 +340,8 @@
 	requirements = list(
 		/obj/item/natural/hide/cured = 1,
 	)
-	output = list(/obj/item/clothing/head/brimmed = 2)
+	output_amount = 2
+	output = list(/obj/item/clothing/head/brimmed
 	craftdiff = 1
 
 /datum/repeatable_crafting_recipe/leather/volfmantle


### PR DESCRIPTION
## About The Pull Request

As it says on the tin, makes the brimmed hat recipe actually produce hats, and instead of being called "hat" are now called brimmed hat.

## Why It's Good For The Game

Being able to waste leather on creating nothing is bad.

fixes  #1761 

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
