### PR TITLE
Mercenary balance adjustments

### DIFF
--- a/code/modules/jobs/job_types/garrison/garrisonguard.dm
+++ b/code/modules/jobs/job_types/garrison/garrisonguard.dm
@@ -71,14 +71,14 @@
 		H.mind?.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE) // Backup
 		H.mind?.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
-		H.mind?.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE) // Guards should be going for less than lethal in reality. Unarmed would be a primary thing.
 		H.change_stat(STATKEY_STR, 1)
 		H.change_stat(STATKEY_END, 2)
 		H.change_stat(STATKEY_CON, 1)
 		ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 		H.mind?.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
-		H.mind?.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE) // Wrestling is cardio intensive, and guards wrestle with the populace a lot.
 		H.mind?.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
@@ -115,7 +115,7 @@
 		H.change_stat(STATKEY_SPD, 2)
 		ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 		H.mind?.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
-		H.mind?.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/misc/climbing, 4, TRUE) // Getting up onto vantage points is common for archers.
 		H.mind?.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
@@ -155,7 +155,7 @@
 	H.mind?.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
 	H.mind?.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 	H.mind?.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
-	H.mind?.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+	H.mind?.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE) // Polearms use a lot of stamina. They'd be enduring.
 	H.mind?.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
 	H.mind?.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 	H.change_stat(STATKEY_STR, 2)

--- a/code/modules/jobs/job_types/other/merc_classes/anthrax.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/anthrax.dm
@@ -65,7 +65,7 @@
 			H.mind?.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
 			H.mind?.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
 			H.mind?.adjust_skillrank(/datum/skill/misc/lockpicking, 3, TRUE)
-			H.mind?.adjust_skillrank(/datum/skill/combat/bows, 3, TRUE)
+			H.mind?.adjust_skillrank(/datum/skill/combat/bows, 4, TRUE)
 			H.mind?.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
 			H.mind?.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 			H.mind?.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)
@@ -76,7 +76,7 @@
 
 			H.change_stat(STATKEY_SPD, 2) //Speedier than a Steppesman, but not as tough or damaging.
 			H.change_stat(STATKEY_END, 1)
-			H.change_stat(STATKEY_PER, 3)
+			H.change_stat(STATKEY_PER, 2)
 
 			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 

--- a/code/modules/jobs/job_types/other/merc_classes/anthrax.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/anthrax.dm
@@ -76,6 +76,7 @@
 
 			H.change_stat(STATKEY_SPD, 2) //Speedier than a Steppesman, but not as tough or damaging.
 			H.change_stat(STATKEY_END, 1)
+			H.change_stat(STATKEY_PER, 3)
 
 			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 

--- a/code/modules/jobs/job_types/other/merc_classes/blackoak.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/blackoak.dm
@@ -36,6 +36,8 @@
 
 		H.merctype = 4
 
-		H.change_stat(STATKEY_END, 2)
+		H.change_stat(STATKEY_END, 3)
 		H.change_stat(STATKEY_STR, 1)
+		H.change_stat(STATKEY_SPD, 1)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/other/merc_classes/boltslinger.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/boltslinger.dm
@@ -29,7 +29,7 @@
 		H.mind?.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/shields, pick(0,0,1), TRUE)
-		H.mind?.adjust_skillrank(/datum/skill/combat/crossbows, 3, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/crossbows, 4, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/craft/tanning, 1, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
@@ -44,7 +44,7 @@
 
 		H.merctype = 6
 
-		H.change_stat(STATKEY_PER, 3)
+		H.change_stat(STATKEY_PER, 2)
 		H.change_stat(STATKEY_END, 1)
 		H.change_stat(STATKEY_STR, 1)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/other/merc_classes/corsair.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/corsair.dm
@@ -40,5 +40,4 @@
 	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 	H.change_stat(STATKEY_END, 2)
 	H.change_stat(STATKEY_PER, -2) // We don't want them using ranged weapons, period.
-	H.change_stat(STATKEY_SPD, 2) // Hit-And-Run.
-	H.change_stat(STATKEY_STR, -1) // Returning expert wrestling at suggestion of Head Admin Gale. Giving a strength malus to balance this.
+	H.change_stat(STATKEY_SPD, 3) // Hit-And-Run.

--- a/code/modules/jobs/job_types/other/merc_classes/corsair.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/corsair.dm
@@ -2,9 +2,7 @@
 	name = "Corsair"
 	tutorial = "Banished from polite society, you once found kin with privateers, working adjacent to a royal navy. After the Red Flag battered itself in the wind one last time, your purse was still not satisfied... And yet he complained that his belly was not full."
 	allowed_sexes = list(MALE, FEMALE)
-	allowed_races = list(
-		"Tiefling"
-	)
+	allowed_races = list("Tiefling")
 	outfit = /datum/outfit/job/adventurer/corsair
 	category_tags = list(CTAG_MERCENARY)
 	cmode_music = 'sound/music/cmode/adventurer/CombatOutlander.ogg'

--- a/code/modules/jobs/job_types/other/merc_classes/corsair.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/corsair.dm
@@ -28,7 +28,7 @@
 
 		H.mind?.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
-		H.mind?.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE) // Swords / Nonlethal.
+		H.mind?.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE) // Swords / Nonlethal.
 		H.mind?.adjust_skillrank(/datum/skill/labor/fishing, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/swimming, 4, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/climbing, 5, TRUE) // For jumping off roofs. Don't lower.

--- a/code/modules/jobs/job_types/other/merc_classes/corsair.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/corsair.dm
@@ -28,7 +28,7 @@
 
 		H.mind?.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
-		H.mind?.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE) // Swords / Nonlethal.
+		H.mind?.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE) // Swords / Nonlethal.
 		H.mind?.adjust_skillrank(/datum/skill/labor/fishing, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/swimming, 4, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/climbing, 5, TRUE) // For jumping off roofs. Don't lower.
@@ -40,6 +40,7 @@
 
 	shirt = pick(/obj/item/clothing/shirt/undershirt/sailor, /obj/item/clothing/shirt/undershirt/sailor/red)
 	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
-	H.change_stat(STATKEY_END, 3)
+	H.change_stat(STATKEY_END, 2)
 	H.change_stat(STATKEY_PER, -2) // We don't want them using ranged weapons, period.
 	H.change_stat(STATKEY_SPD, 2) // Hit-And-Run.
+	H.change_stat(STATKEY_STR, -1) // Returning expert wrestling at suggestion of Head Admin Gale. Giving a strength malus to balance this.

--- a/code/modules/jobs/job_types/other/merc_classes/corsair.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/corsair.dm
@@ -34,7 +34,7 @@
 		H.mind?.adjust_skillrank(/datum/skill/misc/climbing, 5, TRUE) // For jumping off roofs. Don't lower.
 		H.mind?.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE) // Most other classes have better Sneaking.
 		H.mind?.adjust_skillrank(/datum/skill/misc/lockpicking, 3, TRUE)
-		H.mind?.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE) // Very athletic from climbing masts and being on boats all the time.
 		H.mind?.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/craft/cooking, 3, TRUE)
 

--- a/code/modules/jobs/job_types/other/merc_classes/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/grenzelhoft.dm
@@ -18,7 +18,7 @@
 		H.mind?.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)	//Big sword user so - really helps them.
 		H.mind?.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
-		H.mind?.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/whipsflails, pick(1,1,2), TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/axesmaces, pick(2,3), TRUE) // Equal chance between skilled and average, can use a cudgel to beat less dangerous targets into submission
 		H.mind?.adjust_skillrank(/datum/skill/combat/shields, pick(0,0,1), TRUE)
@@ -49,6 +49,5 @@
 	H.merctype = 2
 
 	H.change_stat(STATKEY_STR, 2) // They need this to roll at least min STR for the Zwei.
-	H.change_stat(STATKEY_END, 1)
 	H.change_stat(STATKEY_CON, 2)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/other/merc_classes/steppesman.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/steppesman.dm
@@ -47,7 +47,7 @@
 		H.mind?.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
-	H.change_stat(STATKEY_PER, 1)
+	H.change_stat(STATKEY_PER, 2)
 	H.change_stat(STATKEY_CON, 1)
 	H.change_stat(STATKEY_SPD, 1)
 	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/other/merc_classes/steppesman.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/steppesman.dm
@@ -31,7 +31,7 @@
 	backr = /obj/item/storage/backpack/satchel
 	backpack_contents = list(/obj/item/weapon/knife/hunting = 1)
 	if(H.mind)
-		H.mind?.adjust_skillrank(/datum/skill/combat/bows, 3, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/bows, 4, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
@@ -47,7 +47,7 @@
 		H.mind?.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
-	H.change_stat(STATKEY_PER, 2)
+	H.change_stat(STATKEY_PER, 1)
 	H.change_stat(STATKEY_CON, 1)
 	H.change_stat(STATKEY_SPD, 1)
 	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/other/merc_classes/steppesman.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/steppesman.dm
@@ -37,7 +37,7 @@
 		H.mind?.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
-		H.mind?.adjust_skillrank(/datum/skill/misc/riding, 3, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/misc/riding, 4, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/craft/tanning, 2, TRUE)

--- a/code/modules/jobs/job_types/other/merc_classes/underdweller.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/underdweller.dm
@@ -43,20 +43,20 @@
 		H.mind?.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
 		H.change_stat(STATKEY_LCK, 1)
-		H.change_stat(STATKEY_END, 3)
+		H.change_stat(STATKEY_END, 2)
 		H.change_stat(STATKEY_STR, 1)
 		H.change_stat(STATKEY_INT, 1)
 
 	if(H.dna.species.id == "dwarf")
 		H.cmode_music = 'sound/music/cmode/adventurer/CombatOutlander2.ogg'
-		H.mind?.adjust_skillrank(/datum/skill/combat/axesmaces, 3, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/axesmaces, 4, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/craft/bombs, 4, TRUE) // Dwarves get to make bombs.
 		head = /obj/item/clothing/head/helmet/leather/minershelm
 		beltl = /obj/item/weapon/pick/paxe // Dorfs get a pick as their primary weapon and axes/maces to use it
 		backr = /obj/item/weapon/shield/wood
 	else // No miner's helm for Delves or kobolds as they haven nitevision now.
-		H.mind?.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
 
 		beltl = /obj/item/weapon/sword/sabre // Dark elves get a sabre as their primary weapon and swords skill, who woulda thought
 		head = /obj/item/clothing/head/helmet/leather//similar to the miner helm, except not as cool of course

--- a/code/modules/jobs/job_types/other/merc_classes/underdweller.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/underdweller.dm
@@ -30,7 +30,7 @@
 	backpack_contents = list(/obj/item/storage/belt/pouch/coins/poor=1)
 	if(H.mind)
 		H.mind?.adjust_skillrank(/datum/skill/labor/mining, 3, TRUE)
-		H.mind?.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
@@ -38,22 +38,24 @@
 		H.mind?.adjust_skillrank(/datum/skill/misc/lockpicking, 2, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
-		H.mind?.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/misc/climbing, 4, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
 		H.change_stat(STATKEY_LCK, 1)
-		H.change_stat(STATKEY_END, 1)
+		H.change_stat(STATKEY_END, 3)
 		H.change_stat(STATKEY_STR, 1)
+		H.change_stat(STATKEY_INT, 1)
 
-	if(H.dna.species.id == "dwarf" || H.dna.species.id == "kobold")
+	if(H.dna.species.id == "dwarf")
 		H.cmode_music = 'sound/music/cmode/adventurer/CombatOutlander2.ogg'
 		H.mind?.adjust_skillrank(/datum/skill/combat/axesmaces, 3, TRUE)
 		H.mind?.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/craft/bombs, 4, TRUE) // Dwarves get to make bombs.
 		head = /obj/item/clothing/head/helmet/leather/minershelm
 		beltl = /obj/item/weapon/pick/paxe // Dorfs get a pick as their primary weapon and axes/maces to use it
 		backr = /obj/item/weapon/shield/wood
-	else // No miner's helm for Delves as they haven nitevision now.
+	else // No miner's helm for Delves or kobolds as they haven nitevision now.
 		H.mind?.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 
 		beltl = /obj/item/weapon/sword/sabre // Dark elves get a sabre as their primary weapon and swords skill, who woulda thought


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! --> This brings all mercenaries and town watch into the skilled/low expert tier for combat, allowing MAA to be the step up before knights as far as defensive line in the town.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. --> This prevents power creep on mercenaries end and gives dwarf underdweller bombcrafting skill for soul purposes, removes expert wrestling from a few mercenaries, and allows black oak elven mercenary to actually dodge, considering it a shieldless light armor character.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
