### PR TITLE
Steward Fixes

### DIFF
--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -4085,13 +4085,8 @@
 /area/rogue/outdoors/town)
 "ctI" = (
 /obj/structure/closet/crate/chest/neu_iron,
-/obj/item/key/manor,
 /obj/item/key/walls,
 /obj/item/key/blacksmith,
-/obj/item/key/steward{
-	pixel_x = 5;
-	pixel_y = 15
-	},
 /obj/item/key/church{
 	pixel_x = -4;
 	pixel_y = 7
@@ -4124,6 +4119,20 @@
 	pixel_y = 3
 	},
 /obj/item/key/tailor,
+/obj/item/key/apothecary,
+/obj/item/key/archive,
+/obj/item/key/atarms,
+/obj/item/key/bathhouse,
+/obj/item/key/butcher,
+/obj/item/key/clinic,
+/obj/item/key/courtphys,
+/obj/item/key/forrestgarrison,
+/obj/item/key/gaffer,
+/obj/item/key/guest,
+/obj/item/key/matron,
+/obj/item/key/miner,
+/obj/item/key/soilson,
+/obj/item/key/tower,
 /turf/open/floor/carpet/green,
 /area/rogue/indoors/town/steward)
 "cuc" = (
@@ -23555,6 +23564,12 @@
 	pixel_y = 4;
 	pixel_z = null
 	},
+/obj/item/key/custom,
+/obj/item/key/custom,
+/obj/item/storage/belt/pouch,
+/obj/item/storage/belt/pouch,
+/obj/item/storage/belt/pouch,
+/obj/item/storage/sack,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/steward)
 "pfV" = (
@@ -28495,6 +28510,12 @@
 /obj/item/key/apartments/apartment3,
 /obj/item/key/apartments/apartment2,
 /obj/item/key/apartments/apartment1,
+/obj/item/key/apartments/slums1,
+/obj/item/key/apartments/slums2,
+/obj/item/key/apartments/slums3,
+/obj/item/key/apartments/slums4,
+/obj/item/key/apartments/slums5,
+/obj/item/key/apartments/slums6,
 /turf/open/floor/wood,
 /area/rogue/indoors/town/steward)
 "swU" = (
@@ -30796,6 +30817,12 @@
 	pixel_y = 32
 	},
 /obj/machinery/light/fueled/wallfire/candle/r,
+/obj/item/key/captain,
+/obj/item/key/mage,
+/obj/item/key/manor,
+/obj/item/key/merchant,
+/obj/item/key/vault,
+/obj/item/key/veteran,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/steward)
 "tSr" = (


### PR DESCRIPTION
## About The Pull Request
Grants the Steward a key to every townie job, including that of the Veteran and Captain.
Removes one of the two Steward keys laying around in their office and grants them a spare Vault key.

## Why It's Good For The Game

The Steward was made to be the keeper of the keys and financial controller of the town, yet cannot give access to half of the business on the map, nor can they assist the King in promoting new guards, Captains, Veterans, Forest Guards/Wardens. Nor can they even grant access to the Soilsons (arguably one of the more important roles in the game)

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.