### PR TITLE
Squire and page by randumb reupload with vsc and author permission

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -184,6 +184,7 @@
 #define SQUIRE		(1<<1)
 #define SERVANT		(1<<2)
 #define PRINCE		(1<<3)
+#define PAGE		(1<<4)
 
 #define YOUNGFOLK           (1<<6)
 

--- a/code/modules/jobs/job_types/apprentices/page.dm
+++ b/code/modules/jobs/job_types/apprentices/page.dm
@@ -1,0 +1,139 @@
+/datum/job/page
+title = "Page"
+tutorial = "You've shown promise, both physically and mentally, and now you've been taken in by the knights of the realm to both serve and learn.\
+Though you may be a knight one day, it's mostly doing what you're told so far..."
+flag = PAGE
+department_flag = APPRENTICES
+job_flags = (JOB_ANNOUNCE_ARRIVAL | JOB_SHOW_IN_CREDITS | JOB_EQUIP_RANK | JOB_NEW_PLAYER_JOINABLE)
+faction = FACTION_STATION
+total_positions = 2
+spawn_positions = 2
+
+allowed_races = RACES_PLAYER_NONDISCRIMINATED
+allowed_sexes = list(MALE, FEMALE)
+allowed_ages = list(AGE_CHILD)
+
+outfit = /datum/outfit/job/page
+display_order = JDO_page
+give_bank_account = TRUE
+min_pq = 0
+bypass_lastclass = TRUE
+selection_color = "#304529"
+advclass_cat_rolls = list(CTAG_page = 20)
+can_have_apprentices = FALSE
+
+
+/datum/outfit/job/page
+	shirt = /obj/item/clothing/shirt/undershirt/guard
+	pants = /obj/item/clothing/pants/trou/leather
+	shoes = /obj/item/clothing/shoes/boots
+	belt = /obj/item/storage/belt/leather
+	beltl = /obj/item/storage/keyring/manorguard
+	armor = /obj/item/clothing/armor/gambeson/light
+
+/datum/job/page/after_spawn(mob/living/carbon/spawned, client/player_client)
+	. = ..()
+
+/datum/advclass/page/lancer
+	name = "Pikeman Page"
+	tutorial = "You were chosen as a page, a knight's servant, and chose the pike as your weapon of choice. Perhaps your future holds you as a man-at-arms, or a knight in shining armor, if you survive to adulthood, that is."
+	outfit = /datum/outfit/job/page/lancer
+
+	category_tags = list(CTAG_page)
+
+/datum/outfit/job/page/lancer/pre_equip(mob/living/carbon/human/H)
+	r_hand = /obj/item/weapon/polearm/spear
+	gloves = /obj/item/clothing/gloves/leather
+	wrists = /obj/item/clothing/wrists/bracers/leather
+	backr = /obj/item/storage/backpack/satchel
+	cloak = /obj/item/clothing/cloak/stabard/guard
+	backpack_contents = list(/obj/item/storage/belt/pouch/coins/poor = 1, /obj/item/clothing/neck/chaincoif = 1, /obj/item/weapon/hammer/iron = 1,)
+	if(H.mind)
+		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/craft/weaponsmithing, 1, TRUE)  // For repairing your good Royal Guards equipment
+		H.mind.adjust_skillrank(/datum/skill/craft/armorsmithing, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/riding, 1, TRUE)
+		H.change_stat(STATKEY_STR, 1)
+		H.change_stat(STATKEY_PER, 1)
+		H.change_stat(STATKEY_CON, 1)
+		H.change_stat(STATKEY_INT, 1)
+		H.change_stat(STATKEY_SPD, 1)
+	if(H.gender == MALE && H.dna?.species)
+		H.dna.species.soundpack_m = new /datum/voicepack/male/page()
+
+/datum/advclass/page/footman
+	name = "Footman Page"
+	tutorial = "You were chosen as a page, a knight's servant, and chose the sword as your weapon of choice. Perhaps your future holds you as a man-at-arms, or a knight in shining armor, if you survive to adulthood, that is."
+	outfit = /datum/outfit/job/page/footman
+
+	category_tags = list(CTAG_page)
+
+/datum/outfit/job/page/footman/pre_equip(mob/living/carbon/human/H)
+	gloves = /obj/item/clothing/gloves/leather
+	wrists = /obj/item/clothing/wrists/bracers/leather
+	backr = /obj/item/storage/backpack/satchel
+	beltr = /obj/item/weapon/sword
+	cloak = /obj/item/clothing/cloak/tabard/knight/guard
+	backpack_contents = list(/obj/item/storage/belt/pouch/coins/poor = 1, /obj/item/clothing/neck/chaincoif = 1, /obj/item/weapon/hammer/iron = 1,)
+	if(H.mind)
+		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/craft/weaponsmithing, 1, TRUE)  // For repairing your good Royal Guards equipment
+		H.mind.adjust_skillrank(/datum/skill/craft/armorsmithing, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/riding, 1, TRUE)
+		H.change_stat(STATKEY_STR, 1)
+		H.change_stat(STATKEY_PER, 1)
+		H.change_stat(STATKEY_CON, 1)
+		H.change_stat(STATKEY_INT, 1)
+		H.change_stat(STATKEY_SPD, 1)
+	if(H.gender == MALE && H.dna?.species)
+		H.dna.species.soundpack_m = new /datum/voicepack/male/page()
+
+/datum/advclass/page/skirmisher
+	name = "Bowman Page"
+	tutorial = "You were chosen as a page, a knight's servant, and chose the bow as your weapon of choice. Perhaps your future holds you as a man-at-arms, or a knight in shining armor, if you survive to adulthood, that is."
+	outfit = /datum/outfit/job/page/skirmisher
+
+	category_tags = list(CTAG_page)
+
+/datum/outfit/job/page/skirmisher/pre_equip(mob/living/carbon/human/H)
+	beltr = /obj/item/ammo_holder/quiver/arrows
+	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
+	gloves = /obj/item/clothing/gloves/leather
+	wrists = /obj/item/clothing/wrists/bracers/leather
+	backr = /obj/item/storage/backpack/satchel
+	cloak = /obj/item/clothing/cloak/stabard/surcoat/guard
+	backpack_contents = list(/obj/item/weapon/knife/dagger/steel = 1, /obj/item/storage/belt/pouch/coins/poor = 1, /obj/item/clothing/neck/chaincoif = 1, /obj/item/weapon/hammer/iron = 1,)
+	if(H.mind)
+		H.mind.adjust_skillrank(/datum/skill/combat/bows, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/riding, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/craft/weaponsmithing, 1, TRUE)  // For repairing your good Royal Guards equipment
+		H.mind.adjust_skillrank(/datum/skill/craft/armorsmithing, 1, TRUE)
+		H.change_stat(STATKEY_STR, 1)
+		H.change_stat(STATKEY_PER, 1)
+		H.change_stat(STATKEY_CON, 1)
+		H.change_stat(STATKEY_INT, 1)
+		H.change_stat(STATKEY_SPD, 1)
+	if(H.gender == MALE && H.dna?.species)
+		H.dna.species.soundpack_m = new /datum/voicepack/male/squire()

--- a/code/modules/jobs/job_types/apprentices/page.dm
+++ b/code/modules/jobs/job_types/apprentices/page.dm
@@ -1,27 +1,26 @@
 /datum/job/page
-title = "Page"
-tutorial = "You've shown promise, both physically and mentally, and now you've been taken in by the knights of the realm to both serve and learn.\
-Though you may be a knight one day, it's mostly doing what you're told so far..."
-flag = PAGE
-department_flag = APPRENTICES
-job_flags = (JOB_ANNOUNCE_ARRIVAL | JOB_SHOW_IN_CREDITS | JOB_EQUIP_RANK | JOB_NEW_PLAYER_JOINABLE)
-faction = FACTION_STATION
-total_positions = 2
-spawn_positions = 2
+	title = "Page"
+	tutorial = "You've shown promise, both physically and mentally, and now you've been taken in by the knights of the realm to both serve and learn.\
+	Though you may be a knight one day, it's mostly doing what you're told so far..."
+	flag = PAGE
+	department_flag = APPRENTICES
+	job_flags = (JOB_ANNOUNCE_ARRIVAL | JOB_SHOW_IN_CREDITS | JOB_EQUIP_RANK | JOB_NEW_PLAYER_JOINABLE)
+	faction = FACTION_STATION
+	total_positions = 2
+	spawn_positions = 2
 
-allowed_races = RACES_PLAYER_NONDISCRIMINATED
-allowed_sexes = list(MALE, FEMALE)
-allowed_ages = list(AGE_CHILD)
+	allowed_races = RACES_PLAYER_NONDISCRIMINATED
+	allowed_sexes = list(MALE, FEMALE)
+	allowed_ages = list(AGE_CHILD)
 
-outfit = /datum/outfit/job/page
-display_order = JDO_page
-give_bank_account = TRUE
-min_pq = 0
-bypass_lastclass = TRUE
-selection_color = "#304529"
-advclass_cat_rolls = list(CTAG_page = 20)
-can_have_apprentices = FALSE
-
+	outfit = /datum/outfit/job/page
+	display_order = JDO_page
+	give_bank_account = TRUE
+	min_pq = 0
+	bypass_lastclass = TRUE
+	selection_color = "#304529"
+	advclass_cat_rolls = list(CTAG_page = 20)
+	can_have_apprentices = FALSE
 
 /datum/outfit/job/page
 	shirt = /obj/item/clothing/shirt/undershirt/guard

--- a/code/modules/jobs/job_types/apprentices/squire.dm
+++ b/code/modules/jobs/job_types/apprentices/squire.dm
@@ -18,7 +18,6 @@
 	min_pq = 0
 	bypass_lastclass = TRUE
 	selection_color = "#304529"
-	advclass_cat_rolls = list(CTAG_SQUIRE = 20)
 	can_have_apprentices = FALSE
 
 

--- a/code/modules/jobs/job_types/apprentices/squire.dm
+++ b/code/modules/jobs/job_types/apprentices/squire.dm
@@ -1,16 +1,12 @@
 /datum/job/squire
 	title = "Squire"
-	tutorial = "You've always had greater aspirations than the simple life of a peasant. \n\
-	You and your friends practiced the basics, swordfighting with sticks and loosing arrows into hay bale targets. \n\
-	The Captain took notice of your potential, and recruited you as a personal ward. \
-	\n\n\
-	Learn from the garrison and train hard... maybe one dae you will be honored with knighthood."
+	tutorial = "All those years as a page... You've finally finished your courses on the main three, pikes, swords, and bows. You're still mostly lugging crap around, including a variety of weapons your master will never use, BUT! You're moments away from knighthood! All it would take is the unfortunate retiring or demise of your master..."
 	flag = SQUIRE
 	department_flag = APPRENTICES
 	job_flags = (JOB_ANNOUNCE_ARRIVAL | JOB_SHOW_IN_CREDITS | JOB_EQUIP_RANK | JOB_NEW_PLAYER_JOINABLE)
 	faction = FACTION_STATION
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 1
+	spawn_positions = 1
 
 	allowed_races = RACES_PLAYER_NONDISCRIMINATED
 	allowed_sexes = list(MALE, FEMALE)
@@ -22,53 +18,48 @@
 	min_pq = 0
 	bypass_lastclass = TRUE
 	selection_color = "#304529"
+	advclass_cat_rolls = list(CTAG_SQUIRE = 20)
 	can_have_apprentices = FALSE
 
 
-/datum/outfit/job/squire
+/datum/outfit/job/squire/pre_equip(mob/living/carbon/human/H)
 	shirt = /obj/item/clothing/shirt/undershirt/guard
 	pants = /obj/item/clothing/pants/chainlegs/iron
 	shoes = /obj/item/clothing/shoes/boots
 	belt = /obj/item/storage/belt/leather
-	beltl = /obj/item/storage/keyring/manorguard
-
-/datum/job/squire/after_spawn(mob/living/carbon/spawned, client/player_client)
-	. = ..()
-
-/datum/advclass/squire/lancer
-	name = "Pikeman Squire"
-	tutorial = "History with riding, and a bit of practice with a spear have landed you in a promising mounted position."
-	outfit = /datum/outfit/job/squire/lancer
-
-	category_tags = list(CTAG_SQUIRE)
-
-/datum/outfit/job/squire/lancer/pre_equip(mob/living/carbon/human/H)
 	r_hand = /obj/item/weapon/polearm/spear
+	backl = /obj/item/storage/backpack/backpack
+	backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
+	beltl = /obj/item/weapon/sword
+	beltr = /obj/item/ammo_holder/quiver/arrows
 	armor = /obj/item/clothing/armor/chainmail
 	gloves = /obj/item/clothing/gloves/leather
 	wrists = /obj/item/clothing/wrists/bracers/leather
-	backr = /obj/item/storage/backpack/satchel
-	cloak = /obj/item/clothing/cloak/stabard/guard
-	backpack_contents = list(/obj/item/storage/belt/pouch/coins/poor = 1, /obj/item/clothing/neck/chaincoif = 1, /obj/item/weapon/hammer/iron = 1,)
+	backpack_contents = list(/obj/item/storage/keyring/manorguard = 1, /obj/item/clothing/neck/chaincoif = 1, /obj/item/weapon/hammer/iron = 1, /obj/item/clothing/head/helmet/nasal = 1, /obj/item/storage/belt/pouch/coins/poor = 1)
 	if(H.mind)
-		H.mind.adjust_skillrank(/datum/skill/combat/axesmaces, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/craft/weaponsmithing, 1, TRUE)  // For repairing your good Royal Guards equipment
+		H.mind?.adjust_skillrank(/datum/skill/combat/bows, 2, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/axesmaces, 1, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
+		H.mind?.adjust_skillrank(/datum/skill/labor/mathematics, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/craft/weaponsmithing, 1, TRUE)  // for repairs
 		H.mind.adjust_skillrank(/datum/skill/craft/armorsmithing, 1, TRUE)
 		H.change_stat(STATKEY_STR, 1)
 		H.change_stat(STATKEY_PER, 1)
+		H.change_stat(STATKEY_END, 1)
 		H.change_stat(STATKEY_CON, 1)
-		H.change_stat(STATKEY_INT, 1)
-		H.change_stat(STATKEY_SPD, 1)
+	H.verbs |= /mob/proc/haltyell
+	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_KNOWBANDITS, TRAIT_GENERIC)
 	if(H.gender == MALE && H.dna?.species)
-		H.dna.species.soundpack_m = new /datum/voicepack/male/squire()
-	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+	H.dna.species.soundpack_m = new /datum/voicepack/male/squire()

--- a/code/modules/jobs/job_types/apprentices/squire.dm
+++ b/code/modules/jobs/job_types/apprentices/squire.dm
@@ -14,7 +14,7 @@
 
 	allowed_races = RACES_PLAYER_NONDISCRIMINATED
 	allowed_sexes = list(MALE, FEMALE)
-	allowed_ages = list(AGE_CHILD)
+	allowed_ages = list(AGE_ADULT)
 
 	outfit = /datum/outfit/job/squire
 	display_order = JDO_SQUIRE
@@ -22,7 +22,6 @@
 	min_pq = 0
 	bypass_lastclass = TRUE
 	selection_color = "#304529"
-	advclass_cat_rolls = list(CTAG_SQUIRE = 20)
 	can_have_apprentices = FALSE
 
 
@@ -73,78 +72,3 @@
 	if(H.gender == MALE && H.dna?.species)
 		H.dna.species.soundpack_m = new /datum/voicepack/male/squire()
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
-
-/datum/advclass/squire/footman
-	name = "Footman Squire"
-	tutorial = "Years of hitting dummies with a sword and chasing your friends around have finally paid off."
-	outfit = /datum/outfit/job/squire/footman
-
-	category_tags = list(CTAG_SQUIRE)
-
-/datum/outfit/job/squire/footman/pre_equip(mob/living/carbon/human/H)
-	armor = /obj/item/clothing/armor/chainmail
-	gloves = /obj/item/clothing/gloves/leather
-	wrists = /obj/item/clothing/wrists/bracers/leather
-	backr = /obj/item/storage/backpack/satchel
-	beltr = /obj/item/weapon/sword
-	cloak = /obj/item/clothing/cloak/tabard/knight/guard
-	backpack_contents = list(/obj/item/storage/belt/pouch/coins/poor = 1, /obj/item/clothing/neck/chaincoif = 1, /obj/item/weapon/hammer/iron = 1,)
-	if(H.mind)
-		H.mind.adjust_skillrank(/datum/skill/combat/axesmaces, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/craft/weaponsmithing, 1, TRUE)  // For repairing your good Royal Guards equipment
-		H.mind.adjust_skillrank(/datum/skill/craft/armorsmithing, 1, TRUE)
-		H.change_stat(STATKEY_STR, 1)
-		H.change_stat(STATKEY_PER, 1)
-		H.change_stat(STATKEY_CON, 1)
-		H.change_stat(STATKEY_INT, 1)
-		H.change_stat(STATKEY_SPD, 1)
-	if(H.gender == MALE && H.dna?.species)
-		H.dna.species.soundpack_m = new /datum/voicepack/male/squire()
-	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
-
-/datum/advclass/squire/skirmisher
-	name = "Bowman Squire"
-	tutorial = "Coming from a background of hunters, your practice with a bow has proven useful for the keep."
-	outfit = /datum/outfit/job/squire/skirmisher
-
-	category_tags = list(CTAG_SQUIRE)
-
-/datum/outfit/job/squire/skirmisher/pre_equip(mob/living/carbon/human/H)
-	beltr = /obj/item/ammo_holder/quiver/arrows
-	armor = /obj/item/clothing/armor/chainmail
-	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
-	gloves = /obj/item/clothing/gloves/leather
-	wrists = /obj/item/clothing/wrists/bracers/leather
-	backr = /obj/item/storage/backpack/satchel
-	cloak = /obj/item/clothing/cloak/stabard/surcoat/guard
-	backpack_contents = list(/obj/item/weapon/knife/dagger/steel = 1, /obj/item/storage/belt/pouch/coins/poor = 1, /obj/item/clothing/neck/chaincoif = 1, /obj/item/weapon/hammer/iron = 1,)
-	if(H.mind)
-		H.mind.adjust_skillrank(/datum/skill/combat/bows, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/riding, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/craft/weaponsmithing, 1, TRUE)  // For repairing your good Royal Guards equipment
-		H.mind.adjust_skillrank(/datum/skill/craft/armorsmithing, 1, TRUE)
-		H.change_stat(STATKEY_PER, 1)
-		H.change_stat(STATKEY_CON, 1)
-		H.change_stat(STATKEY_INT, 1)
-		H.change_stat(STATKEY_SPD, 2)
-	if(H.gender == MALE && H.dna?.species)
-		H.dna.species.soundpack_m = new /datum/voicepack/male/squire()
-	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)

--- a/vanderlin.dme
+++ b/vanderlin.dme
@@ -1796,6 +1796,7 @@
 #include "code\modules\jobs\job_types\adventurer\types\pilgrim\rare\zybantine.dm"
 #include "code\modules\jobs\job_types\adventurer\types\special\crusader.dm"
 #include "code\modules\jobs\job_types\apprentices\bapprentice.dm"
+#include "code\modules\jobs\job_types\apprentices\page.dm"
 #include "code\modules\jobs\job_types\apprentices\prince.dm"
 #include "code\modules\jobs\job_types\apprentices\servant.dm"
 #include "code\modules\jobs\job_types\apprentices\shophand.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! --> Squire has been SPLIT in two!

Page: youngling, goober, no armor training and crappy weapon skills. Full time complimenter and servant of their master, usually just grabbing crap for em, or riding a pig, repairing equipment, or acting like a kid.
Squire: adult, knight-in-training, moments away from being a knight. Carries the heavy weight and weapons while the page slacks off.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Randumb was ordered to make this. People keep playing their youngling characters as badass warriors. Youngling classes are meant to be for learning gameplay mechanics, and this reinforces that. As compensation, the new squire is an upgrade from ye olde squire, now including various things like puberty, and acne. They're also able to replace the knight if they need replacing. We worked together to fix some errors and the only remaining issue is Page is not showing up on job select.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
