### PR TITLE
Mage Attunement Fix

### DIFF
--- a/_maps/map_files/shared/CentCom.dmm
+++ b/_maps/map_files/shared/CentCom.dmm
@@ -8493,7 +8493,7 @@ Ed
 xt
 so
 so
-fT
+Kn
 FR
 Te
 xt

--- a/_maps/map_files/shared/CentCom.dmm
+++ b/_maps/map_files/shared/CentCom.dmm
@@ -2082,7 +2082,13 @@
 /area/rogue/indoors)
 "nh" = (
 /obj/structure/rack,
-/obj/item/clothing/neck/coif,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/pants/chainlegs/iron,
+/obj/item/clothing/pants/trou/leather,
+/obj/item/clothing/pants/trou/leather,
+/obj/item/clothing/pants/trou/leather/advanced,
+/obj/item/clothing/wrists/bracers/leather,
 /turf/open/floor/ruinedwood/darker,
 /area/rogue/indoors/bandit_lair)
 "ni" = (
@@ -3154,8 +3160,19 @@
 /obj/item/clothing/head/roguehood/eora,
 /turf/open/floor/wood,
 /area/rogue)
+"xq" = (
+/obj/machinery/light/fueled/cauldron,
+/turf/open/floor/dirt/road,
+/area/rogue/outdoors/woods_safe)
 "xt" = (
 /turf/open/floor/dirt/road,
+/area/rogue/outdoors/woods_safe)
+"xC" = (
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 1;
+	locked = 1
+	},
+/turf/open/floor/grass,
 /area/rogue/outdoors/woods_safe)
 "xI" = (
 /obj/structure/closet/crate/coffin/vampire,
@@ -3235,11 +3252,13 @@
 "yo" = (
 /obj/structure/rack,
 /obj/item/weapon/mace/cudgel,
+/obj/item/weapon/whip,
 /turf/open/floor/ruinedwood/darker,
 /area/rogue/indoors/bandit_lair)
 "yq" = (
 /obj/structure/rack,
 /obj/item/weapon/knife/dagger,
+/obj/item/weapon/sword/scimitar/falchion,
 /turf/open/floor/ruinedwood/darker,
 /area/rogue/indoors/bandit_lair)
 "yv" = (
@@ -3293,6 +3312,8 @@
 /obj/structure/closet/crate/crafted_closet,
 /obj/item/clothing/face/shepherd/rag,
 /obj/item/clothing/face/shepherd/rag,
+/obj/item/clothing/face/facemask/copper,
+/obj/item/clothing/face/facemask/copper,
 /turf/open/floor/ruinedwood/darker,
 /area/rogue/indoors/bandit_lair)
 "yR" = (
@@ -4079,6 +4100,14 @@
 /obj/structure/rack,
 /obj/item/clothing/head/helmet/leather/headscarf,
 /obj/item/clothing/head/helmet/leather/headscarf,
+/obj/item/clothing/head/helmet/leather,
+/obj/item/clothing/head/helmet/leather,
+/obj/item/clothing/head/helmet/leather/advanced,
+/obj/item/clothing/head/helmet/leather/advanced,
+/obj/item/clothing/head/helmet/nasal,
+/obj/item/clothing/head/helmet/skullcap,
+/obj/item/clothing/head/helmet/kettle,
+/obj/item/clothing/neck/coif,
 /turf/open/floor/ruinedwood/darker,
 /area/rogue/indoors/bandit_lair)
 "Hu" = (
@@ -4553,6 +4582,10 @@
 "Mc" = (
 /obj/structure/rack,
 /obj/item/clothing/head/helmet/leather/volfhelm,
+/obj/item/clothing/armor/leather/splint,
+/obj/item/clothing/armor/leather/splint,
+/obj/item/clothing/armor/cuirass/copperchest,
+/obj/item/clothing/armor/cuirass/iron,
 /turf/open/floor/ruinedwood/darker,
 /area/rogue/indoors/bandit_lair)
 "Mg" = (
@@ -5739,6 +5772,8 @@
 "Xk" = (
 /obj/structure/closet/crate/chest/old_crate,
 /obj/item/ore/coal,
+/obj/item/ore/iron,
+/obj/item/ore/iron,
 /obj/item/ore/iron,
 /obj/item/ore/iron,
 /turf/open/floor/dirt/road,
@@ -7938,7 +7973,7 @@ xt
 so
 so
 FR
-xt
+Sn
 xt
 xt
 xt
@@ -8068,7 +8103,7 @@ xt
 xt
 xt
 xt
-xt
+Sn
 xt
 xt
 xt
@@ -8198,7 +8233,7 @@ so
 Kn
 Kn
 so
-so
+xC
 so
 so
 so
@@ -8328,7 +8363,7 @@ xt
 xt
 xt
 xt
-xt
+Sn
 xt
 xt
 xt
@@ -8458,7 +8493,7 @@ Ed
 xt
 so
 so
-Kn
+fT
 FR
 Te
 xt
@@ -8563,7 +8598,7 @@ xt
 Qy
 Qy
 xt
-xt
+xq
 xt
 Lg
 xt

--- a/code/datums/mana/attunement.dm
+++ b/code/datums/mana/attunement.dm
@@ -45,6 +45,8 @@ GLOBAL_LIST_INIT(default_attunements, create_default_attunement_list())
 
 	alignments = list(
 		/datum/patron/divine/astrata = 1,
+		/datum/patron/inhumen/zizo = 0.15,
+		/datum/patron/inhumen/noc = 0.3,
 		/datum/patron/divine/malum = 1.2,
 	)
 
@@ -54,6 +56,7 @@ GLOBAL_LIST_INIT(default_attunements, create_default_attunement_list())
 
 	alignments = list(
 		/datum/patron/divine/noc = 1,
+		/datum/patron/inhumen/zizo = 0.4,
 	)
 
 /datum/attunement/electric
@@ -62,6 +65,7 @@ GLOBAL_LIST_INIT(default_attunements, create_default_attunement_list())
 
 	alignments = list(
 		/datum/patron/divine/noc = 0.35,
+		/datum/patron/inhumen/zizo = 0.15,
 		/datum/patron/divine/abyssor = 0.5,
 	)
 
@@ -73,7 +77,7 @@ GLOBAL_LIST_INIT(default_attunements, create_default_attunement_list())
 		/datum/patron/divine/abyssor = 2,
 		/datum/patron/divine/pestra = 0.5,
 		/datum/patron/divine/dendor = 0.5,
-		/datum/patron/inhumen/zizo = 1.2,
+		/datum/patron/inhumen/zizo = 1,
 		/datum/patron/inhumen/graggar = 2,
 	)
 

--- a/code/modules/antagonists/villain/bandit.dm
+++ b/code/modules/antagonists/villain/bandit.dm
@@ -22,7 +22,6 @@
 		return "<span class='boldnotice'>Another free man. My ally.</span>"
 
 /datum/antagonist/bandit/on_gain()
-	owner.special_role = "Bandit"
 	owner.purge_combat_knowledge()
 	move_to_spawnpoint()
 	owner.current.roll_mob_stats()

--- a/code/modules/jobs/job_types/adventurer/types/antag/brigand.dm
+++ b/code/modules/jobs/job_types/adventurer/types/antag/brigand.dm
@@ -1,6 +1,6 @@
 /datum/advclass/brigand //Strength class, starts with axe or flails and medium armor training
 	name = "Brigand"
-	tutorial = "Cast from society, you use your powerful physical might and endurance to take from those who are weaker from you."
+	tutorial = "Cast from society for your violent tendencies, at a young age your temper and natural talent for murder had you branded and hunted by the catchpoles, it was only here among the Brigands of Matthios that your talents could finally be put to good use."
 	allowed_sexes = list(MALE, FEMALE)
 	outfit = /datum/outfit/job/bandit/brigand
 	category_tags = list(CTAG_BANDIT)
@@ -34,9 +34,10 @@
 	neck = /obj/item/clothing/neck/coif
 	head = /obj/item/clothing/head/helmet/leather/volfhelm
 	armor = /obj/item/clothing/armor/leather/hide
+	H.mind.special_role = "Bandit"
 	H.change_stat(STATKEY_STR, 3)
-	H.change_stat(STATKEY_END, 2)
-	H.change_stat(STATKEY_CON, 2)
+	H.change_stat(STATKEY_END, 3)
+	H.change_stat(STATKEY_CON, 3)
 	H.change_stat(STATKEY_INT, -3)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 	H.adjust_blindness(-3)

--- a/code/modules/jobs/job_types/adventurer/types/antag/hedgeknight.dm
+++ b/code/modules/jobs/job_types/adventurer/types/antag/hedgeknight.dm
@@ -1,6 +1,6 @@
 /datum/advclass/hedgeknight //heavy knight class - just like black knight adventurer class. starts with heavy armor training and plate, but less weapon skills than brigand, sellsword and knave
 	name = "Hedge Knight"
-	tutorial = "A noble fallen from grace, your tarnished armor sits upon your shoulders as a heavy reminder of the life you've lost. Take back what is rightfully yours."
+	tutorial = "A noble fallen from grace, your tarnished armor sits upon your shoulders as a heavy reminder of the life you've lost. Amongst all your friends, you are the most despised within the Kingdom. Your crimes innumerable, but necessary for your dreams to become reality."
 	allowed_sexes = list(MALE, FEMALE)
 	outfit = /datum/outfit/job/bandit/hedgeknight
 	category_tags = list(CTAG_BANDIT)
@@ -20,7 +20,8 @@
 	beltr = /obj/item/weapon/sword/long
 	backr = /obj/item/storage/backpack/satchel/black
 	backl = /obj/item/weapon/shield/tower/metal
-	backpack_contents = list(/obj/item/weapon/knife/dagger = 1)
+	backpack_contents = list(/obj/item/weapon/knife/dagger/steel = 1)
+	H.mind.special_role = "Bandit"
 	H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)
@@ -36,8 +37,8 @@
 	H.mind.adjust_skillrank(/datum/skill/labor/butchering, 1, TRUE)
 	H.mind?.adjust_skillrank(/datum/skill/labor/mathematics, 3, TRUE)
 	H.change_stat(STATKEY_STR, 2)
-	H.change_stat(STATKEY_END, 1)
-	H.change_stat(STATKEY_CON, 2)
+	H.change_stat(STATKEY_END, 2)
+	H.change_stat(STATKEY_CON, 3)
 	H.change_stat(STATKEY_INT, 1)
 	H.change_stat(STATKEY_SPD, 1)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/adventurer/types/antag/roguemage.dm
+++ b/code/modules/jobs/job_types/adventurer/types/antag/roguemage.dm
@@ -1,6 +1,6 @@
 /datum/advclass/roguemage //mage class - like the adventurer mage, but more evil.
 	name = "Rogue Mage"
-	tutorial = "Those fools at the academy laughed at you and cast you from the ivory tower of higher learning and magickal practice. No matter - you will ascend to great power one day, but first you need wealth - vast amounts of it. Show those fools in the town what REAL magic looks like."
+	tutorial = "Cast aside by your masters for unholy experimentation, you lived for a time in hiding in the forest where you eventually met the unsavory followers of Matthios who took you in as family, one of their own. Amongst your brigand friends you now have opportunity to attain the wealth and power necessary for your to rise above those who once looked down on you."
 	allowed_sexes = list(MALE, FEMALE)
 	outfit = /datum/outfit/job/bandit/roguemage
 	category_tags = list(CTAG_BANDIT)
@@ -23,6 +23,7 @@
 
 	r_hand = /obj/item/weapon/polearm/woodstaff
 	if(H.mind)
+		H.mind.special_role = "Bandit"
 		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 1, TRUE)
@@ -50,5 +51,6 @@
 		H.change_stat(STATKEY_INT, 3)
 		H.change_stat(STATKEY_CON, 1)
 		H.change_stat(STATKEY_END, -1)
-		H.mind.adjust_spellpoints(1)
+		H.mind.adjust_spellpoints(6)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/acidsplash5e)

--- a/code/modules/jobs/job_types/adventurer/types/antag/sawbones.dm
+++ b/code/modules/jobs/job_types/adventurer/types/antag/sawbones.dm
@@ -1,6 +1,6 @@
 /datum/advclass/sawbones // doctor class. like the pilgrim, but more evil
 	name = "Sawbones"
-	tutorial = "It was an accident! Your patient wasn't using his second kidney, anyway. After an unfortunate 'misunderstanding' with the town and your medical practice, you know practice medicine on the run with your new associates. Business has never been better!"
+	tutorial = "An unholy practictioner of medicine and when necessary -- murder. You joined hands with Brigands to ensure that your coin purse and your rumbling belly are always satisfied."
 	allowed_sexes = list(MALE, FEMALE)
 	outfit = /datum/outfit/job/bandit/sawbones
 	category_tags = list(CTAG_BANDIT)
@@ -19,7 +19,7 @@
 	backr = /obj/item/storage/backpack/satchel
 	backl = /obj/item/storage/backpack/satchel/surgbag
 	backpack_contents = list(/obj/item/natural/worms/leech = 1, /obj/item/natural/cloth = 2,)
-	H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/knives, 4, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/craft/carpentry, 2, TRUE)
@@ -27,11 +27,13 @@
 	H.mind.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE) //needed for getting into hideout
-	H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/medicine, 5, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/sewing, 3, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/craft/alchemy, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/craft/alchemy, 3, TRUE)
 	H.change_stat(STATKEY_INT, 3)
+	H.change_stat(STATKEY_SPD, 1)
+	H.change_stat(STATKEY_END, 1)
 	H.change_stat(STATKEY_LCK, 1)
 	if(H.age == AGE_OLD)
 		H.change_stat(STATKEY_SPD, -1)
@@ -39,3 +41,4 @@
 		H.change_stat(STATKEY_PER, 1)
 	H?.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
 	ADD_TRAIT(H, TRAIT_FORAGER, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_LEGENDARY_ALCHEMIST, TRAIT_GENERIC)


### PR DESCRIPTION
Currently Zizo Mages are currently unable to do most magical spells, considering they are evil and are more likely to need offensive spells, being able to do magic that isn't just Hydrosophy would be ideal. As most of the schools they are proficient with by default aren't really useful at all or are utility spells.

I've also edited Noc to be more proficient then Zizo at pyromancy. Generally Noc Mages are still substantially better then Zizo mages, but at least it's not a complete joke. The whole point of following inhumen gods as a mage should be that you want power at any cost, so they shouldn't be just bad at magic in general.

I understand if there might be a desire in future for them to focus on different magicks, but due to the facts that a lot of their attunements do effectively nothing to help them is an issue. They also just generally have less attunement and are worse then Noc mages by far, even if their attunements were actually for spells they used.