### PR TITLE
Mage Attunement Changes

### DIFF
--- a/code/datums/mana/attunement.dm
+++ b/code/datums/mana/attunement.dm
@@ -158,7 +158,7 @@ GLOBAL_LIST_INIT(default_attunements, create_default_attunement_list())
 	desc = ""
 
 	alignments = list(
-		/datum/patron/divine/noc = 1.5,
+		/datum/patron/divine/noc = 2,
 		/datum/patron/inhumen/zizo = 1.2,
 	)
 

--- a/code/datums/mana/attunement.dm
+++ b/code/datums/mana/attunement.dm
@@ -45,6 +45,8 @@ GLOBAL_LIST_INIT(default_attunements, create_default_attunement_list())
 
 	alignments = list(
 		/datum/patron/divine/astrata = 1,
+		/datum/patron/inhumen/zizo = 0.15,
+		/datum/patron/divine/noc = 0.3,
 		/datum/patron/divine/malum = 1.2,
 	)
 
@@ -54,6 +56,7 @@ GLOBAL_LIST_INIT(default_attunements, create_default_attunement_list())
 
 	alignments = list(
 		/datum/patron/divine/noc = 1,
+		/datum/patron/inhumen/zizo = 0.4,
 	)
 
 /datum/attunement/electric
@@ -62,6 +65,7 @@ GLOBAL_LIST_INIT(default_attunements, create_default_attunement_list())
 
 	alignments = list(
 		/datum/patron/divine/noc = 0.35,
+		/datum/patron/inhumen/zizo = 0.15,
 		/datum/patron/divine/abyssor = 0.5,
 	)
 
@@ -73,7 +77,7 @@ GLOBAL_LIST_INIT(default_attunements, create_default_attunement_list())
 		/datum/patron/divine/abyssor = 2,
 		/datum/patron/divine/pestra = 0.5,
 		/datum/patron/divine/dendor = 0.5,
-		/datum/patron/inhumen/zizo = 1.2,
+		/datum/patron/inhumen/zizo = 1,
 		/datum/patron/inhumen/graggar = 2,
 	)
 

--- a/code/datums/mana/attunement.dm
+++ b/code/datums/mana/attunement.dm
@@ -45,8 +45,8 @@ GLOBAL_LIST_INIT(default_attunements, create_default_attunement_list())
 
 	alignments = list(
 		/datum/patron/divine/astrata = 1,
-		/datum/patron/inhumen/zizo = 0.15,
-		/datum/patron/divine/noc = 0.3,
+		/datum/patron/inhumen/zizo = 0.25,
+		/datum/patron/divine/noc = 0.15,
 		/datum/patron/divine/malum = 1.2,
 	)
 
@@ -64,7 +64,7 @@ GLOBAL_LIST_INIT(default_attunements, create_default_attunement_list())
 	desc = "An element typically associated with weather, sometimes with divinity, and often technology."
 
 	alignments = list(
-		/datum/patron/divine/noc = 0.35,
+		/datum/patron/divine/noc = 0.25,
 		/datum/patron/inhumen/zizo = 0.15,
 		/datum/patron/divine/abyssor = 0.5,
 	)
@@ -158,7 +158,7 @@ GLOBAL_LIST_INIT(default_attunements, create_default_attunement_list())
 	desc = ""
 
 	alignments = list(
-		/datum/patron/divine/noc = 2,
+		/datum/patron/divine/noc = 1.5,
 		/datum/patron/inhumen/zizo = 1.2,
 	)
 


### PR DESCRIPTION
## About The Pull Request
Currently Zizo Mages are unable to do most magical spells, considering they are evil and are more likely to need offensive spells, being able to do magic that isn't just Hydrosophy would be ideal. As most of the schools they are proficient with by default aren't really useful at all or are utility spells.

I've also edited Noc to be more proficient then Zizo at pyromancy. Generally Noc Mages are still substantially better then Zizo mages, but at least it's not a complete joke. The whole point of following inhumen gods as a mage should be that you want power at any cost, so they shouldn't be just bad at magic in general.

I understand if there might be a desire in future for them to focus on different magicks, but due to the facts that a lot of their attunements do effectively nothing to help them is an issue. They also just generally have less attunement and are worse then Noc mages by far, even if their attunements were actually for spells they used.

## Why It's Good For The Game
See Above.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your cxode/feature/fix locally. -->
