### PR TITLE
Elecrocution recovery status effect

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -113,7 +113,7 @@
 	icon_state = "paralyze"
 
 /datum/status_effect/shock_recovery
-	id = "stressvgood"
+	id = "shock_recovery"
 	alert_type = /atom/movable/screen/alert/status_effect/paralyzed/recovery
 
 /datum/status_effect/stress/shock_recovery

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -112,6 +112,16 @@
 	desc = ""
 	icon_state = "paralyze"
 
+/datum/status_effect/shock_recovery
+	id = "stressvgood"
+	alert_type = /atom/movable/screen/alert/status_effect/paralyzed/recovery
+
+/datum/status_effect/stress/shock_recovery
+
+/atom/movable/screen/alert/status_effect/paralyzed/recovery
+	name = "Shock Recovery"
+	desc = "I have recently been shocked. \n"
+
 //UNCONSCIOUS
 /datum/status_effect/incapacitating/unconscious
 	id = "unconscious"

--- a/code/game/objects/items/weapons/melee/special.dm
+++ b/code/game/objects/items/weapons/melee/special.dm
@@ -98,15 +98,15 @@
 				user.Beam(target, icon_state = "lightning[rand(1, 12)]", time = 0.5 SECONDS) // LIGHTNING
 				playsound(user, 'sound/magic/lightningshock.ogg', 70, TRUE)
 				H.electrocute_act(5, src)
-				log_message("[HU] has shocked [H] with the master's rod!", LOG_ATTACK)
+				HU.log_message("has shocked [H] with the [src]!", LOG_ATTACK)
 				to_chat(H, "<span class='danger'>I'm electrocuted by the scepter!</span>")
 				return
 
 			if(istype(user.used_intent, /datum/intent/lord_silence))
-				HU.visible_message("<span class='warning'>[HU] silences [H] with \the [src].</span>")
+				HU.visible_message(span_warning("[HU] silences [H] with \the [src]."))
 				H.set_silence(20 SECONDS)
-				log_message("[HU] has silenced [H] with the master's rod!", LOG_ATTACK)
-				to_chat(H, "<span class='danger'>I'm silenced by the scepter!</span>")
+				HU.log_message("[HU] has silenced [H] with the master's rod!", LOG_ATTACK)
+				to_chat(H, span_danger("I'm silenced by the scepter!"))
 				return
 
 /obj/item/weapon/mace/stunmace

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -330,8 +330,8 @@
 	//Stun
 	var/should_stun = (!(flags & SHOCK_TESLA) || siemens_coeff > 0.5) && !(flags & SHOCK_NOSTUN)
 	if(!HAS_TRAIT(src, TRAIT_NOPAIN))
-		if(should_stun && !HAS_TRAIT(src, TRAIT_NOPAINSTUN))
-			Paralyze(30)
+		if(should_stun && !HAS_TRAIT(src, TRAIT_NOPAINSTUN) && !has_status_effect(/datum/status_effect/shock_recovery))
+			Paralyze(3 SECONDS)
 		//Jitter and other fluff.
 		jitteriness += 1000
 		do_jitter_animation(jitteriness)
@@ -343,8 +343,16 @@
 ///Called slightly after electrocute act to reduce jittering and apply a secondary stun.
 /mob/living/carbon/proc/secondary_shock(should_stun)
 	jitteriness = max(jitteriness - 990, 10)
-	if(should_stun && !HAS_TRAIT(src, TRAIT_NOPAINSTUN))
-		Paralyze(60)
+	if(should_stun && !HAS_TRAIT(src, TRAIT_NOPAINSTUN) && !has_status_effect(/datum/status_effect/shock_recovery))
+		Paralyze(6 SECONDS)
+		apply_shock_paralyze_immunity(12 SECONDS)
+
+/mob/living/carbon/proc/apply_shock_paralyze_immunity(time)
+	apply_status_effect(/datum/status_effect/shock_recovery)
+	addtimer(CALLBACK(src, PROC_REF(remove_shock_paralyze_immunity), src), time)
+
+/mob/living/carbon/proc/remove_shock_paralyze_immunity
+	remove_status_effect(/datum/status_effect/shock_recovery)
 
 /mob/living/carbon/proc/help_shake_act(mob/living/carbon/M)
 	if(on_fire)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -351,7 +351,7 @@
 	apply_status_effect(/datum/status_effect/shock_recovery)
 	addtimer(CALLBACK(src, PROC_REF(remove_shock_paralyze_immunity), src), time)
 
-/mob/living/carbon/proc/remove_shock_paralyze_immunity
+/mob/living/carbon/proc/remove_shock_paralyze_immunity()
 	remove_status_effect(/datum/status_effect/shock_recovery)
 
 /mob/living/carbon/proc/help_shake_act(mob/living/carbon/M)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
applies a 12 second status effect that prevents you from getting immobilize stunned when getting shocked when you get shocked
(shocks immobilize you for 9 seconds)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
this is to prevent permanent stuns, which are not fun.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
