### PR TITLE
Only turfs fully blocked can not see the sky

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -137,7 +137,7 @@
 	..()
 
 /turf/proc/can_see_sky()
-	if(outdoor_effect?.state == SKY_VISIBLE)
+	if(outdoor_effect?.state != SKY_BLOCKED)
 		return TRUE
 	return FALSE
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -137,7 +137,9 @@
 	..()
 
 /turf/proc/can_see_sky()
-	if(outdoor_effect?.state != SKY_BLOCKED)
+	if(!outdoor_effect)
+		return FALSE
+	if(outdoor_effect.state != SKY_BLOCKED)
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
Only turfs without an outdoor effect or turfs completely blocked by a light blocking turf/object return false for can_see_sky

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
Current behaviour is unintuitive and raises a lot of questions for people growing crops

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
