### PR TITLE
Heart crit requires rib fracture first or specific bclass

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -198,6 +198,7 @@
 #define BCLASS_CUT			"slash"
 #define BCLASS_CHOP			"chopping"
 #define BCLASS_STAB			"stab"
+#define BCLASS_PIERCE		"pierce"
 #define BCLASS_SHOT			"shot"
 #define BCLASS_PICK			"stab"
 #define BCLASS_TWIST		"twist"

--- a/code/_globalvars/lists/wounds.dm
+++ b/code/_globalvars/lists/wounds.dm
@@ -14,6 +14,7 @@ GLOBAL_LIST_INIT(artery_bclasses, list(
 	BCLASS_PICK,
 	BCLASS_BITE,
 	BCLASS_SHOT,
+	BCLASS_PIERCE,
 ))
 
 GLOBAL_LIST_INIT(artery_strong_bclasses, list(
@@ -25,6 +26,7 @@ GLOBAL_LIST_INIT(artery_strong_bclasses, list(
 GLOBAL_LIST_INIT(artery_heart_bclasses, list(
 	BCLASS_PICK,
 	BCLASS_SHOT,
+	BCLASS_PIERCE,
 ))
 
 GLOBAL_LIST_INIT(dislocation_bclasses, list(
@@ -44,6 +46,7 @@ GLOBAL_LIST_INIT(stab_bclasses, list(
 	BCLASS_STAB,
 	BCLASS_SHOT,
 	BCLASS_PICK,
+	BCLASS_PIERCE,
 ))
 
 GLOBAL_LIST_INIT(charring_bclasses, list(

--- a/code/_globalvars/lists/wounds.dm
+++ b/code/_globalvars/lists/wounds.dm
@@ -22,6 +22,11 @@ GLOBAL_LIST_INIT(artery_strong_bclasses, list(
 	BCLASS_SHOT,
 ))
 
+GLOBAL_LIST_INIT(artery_heart_bclasses, list(
+	BCLASS_PICK,
+	BCLASS_SHOT,
+))
+
 GLOBAL_LIST_INIT(dislocation_bclasses, list(
 	BCLASS_TWIST,
 ))

--- a/code/datums/wounds/arteries.dm
+++ b/code/datums/wounds/arteries.dm
@@ -58,6 +58,8 @@
 /datum/wound/artery/neck/on_mob_gain(mob/living/affected)
 	. = ..()
 	ADD_TRAIT(affected, TRAIT_GARGLE_SPEECH, "[type]")
+	if(HAS_TRAIT(affected, TRAIT_CRITICAL_WEAKNESS))
+		affected.death()
 
 /datum/wound/artery/neck/on_mob_loss(mob/living/affected)
 	. = ..()

--- a/code/game/objects/items/weapons/ranged/ammo.dm
+++ b/code/game/objects/items/weapons/ranged/ammo.dm
@@ -47,7 +47,7 @@
 	hitsound = 'sound/combat/hits/hi_arrow2.ogg'
 	embedchance = 100
 	armor_penetration = BOLT_PENETRATION
-	woundclass = BCLASS_STAB
+	woundclass = BCLASS_PIERCE
 	flag =  "piercing"
 	speed = 0.3
 	accuracy = 85 //Crossbows have higher accuracy
@@ -174,7 +174,7 @@
 	hitsound = 'sound/combat/hits/hi_arrow2.ogg'
 	embedchance = 100
 	armor_penetration = ARROW_PENETRATION
-	woundclass = BCLASS_STAB
+	woundclass = BCLASS_PIERCE
 	flag =  "piercing"
 	speed = 0.4
 	var/piercing = FALSE

--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -301,7 +301,7 @@
 			if(prob(used))
 				if((zone_precise == BODY_ZONE_PRECISE_STOMACH) && !resistance)
 					attempted_wounds += /datum/wound/slash/disembowel
-				if(owner.has_wound(/datum/wound/fracture/chest) || bclass in GLOB.artery_heart_bclasses)
+				if(owner.has_wound(/datum/wound/fracture/chest) || (bclass in GLOB.artery_heart_bclasses))
 					attempted_wounds += /datum/wound/artery/chest
 				else
 					attempted_wounds += /datum/wound/artery

--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -301,7 +301,10 @@
 			if(prob(used))
 				if((zone_precise == BODY_ZONE_PRECISE_STOMACH) && !resistance)
 					attempted_wounds += /datum/wound/slash/disembowel
-				attempted_wounds += /datum/wound/artery/chest
+				if(owner.has_wound(/datum/wound/fracture/chest) || bclass in GLOB.artery_heart_bclasses)
+					attempted_wounds += /datum/wound/artery/chest
+				else
+					attempted_wounds += /datum/wound/artery
 		if("scarring")
 			if(user && istype(user.rmb_intent, /datum/rmb_intent/strong))
 				dam += 10


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
Chest applies a normal artery wound unless the ribs are fractured or a bow/gun/pickaxe (for soul come on pickaxes are awful) is used. 

Make the neck artery fatal to CRITICAL_WEAKNESS since its as lethal as a heart crit.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
You cannot miss the chest, having an extra step (fracture) to basically immediately kill someone is probably a good thing and gives maces more of a use/requires more input then just stab chest.

Ranged weapons could do with a bit of love, if a bullet is going THROUGH your chest it should be able to hit your heart regardless.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
