### PR TITLE
Removes the tiling that saves people in the acid pits

### DIFF
--- a/_maps/map_files/daftmarsh/daftmarsh.dmm
+++ b/_maps/map_files/daftmarsh/daftmarsh.dmm
@@ -85802,7 +85802,7 @@ ite
 ite
 xyn
 cEF
-bAM
+cEF
 cEF
 kck
 vDk

--- a/_maps/map_files/rosewood/rosewood.dmm
+++ b/_maps/map_files/rosewood/rosewood.dmm
@@ -61273,8 +61273,8 @@ gFQ
 wLJ
 pBA
 eLB
-aZj
-aZj
+eMY
+eMY
 eMY
 xuC
 hhK
@@ -61475,9 +61475,9 @@ dgR
 dgR
 pBA
 riN
-aZj
-aZj
-aZj
+eMY
+eMY
+eMY
 uqd
 hhK
 hhK

--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -59557,7 +59557,7 @@ lml
 lml
 vdE
 ogO
-bET
+ogO
 ogO
 jZU
 nYn


### PR DESCRIPTION
initial

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->
Removes tiles under the acid pit that prevent people from being acided

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

On paper it's a good addition, however from what I've been seeing in practice; people just meta the the tiles that aren't acid to prevent death and shout from above. I think the gate should be more punishing and people should really think twice about who they trust with the gate. Reward infiltration with a higher reward, since the gate is a _really_ hard place to infiltrate and kill others that are vigilant.


## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
