### PR TITLE
Immigration/exit config based on map

### DIFF
--- a/_maps/daftmarsh.json
+++ b/_maps/daftmarsh.json
@@ -2,6 +2,7 @@
     "map_name": "Daftmarsh",
     "map_path": "map_files/daftmarsh",
     "map_file": "daftmarsh.dmm",
+	"immigrant_origin": "Vanderlin",
 	"traits": [
 		{"Up": true, "Turf Weather Effects": true},
 		{"Up": true, "Down": true, "Turf Weather Effects": true},

--- a/_maps/roguetest.json
+++ b/_maps/roguetest.json
@@ -2,6 +2,7 @@
     "map_name": "Roguetest",
     "map_path": "map_files/debug",
     "map_file": "roguetest.dmm",
+	"immigrant_origin": "Psydonia",
 	"traits": [{"Up": true, "Leylines": true}, {"Down": true, "Leylines": true}],
 	"minetype": null,
 	"space_empty_levels": 0,

--- a/_maps/rosewood.json
+++ b/_maps/rosewood.json
@@ -2,6 +2,7 @@
     "map_name": "Rosewood",
     "map_path": "map_files/rosewood",
     "map_file": "rosewood.dmm",
+	"immigrant_origin": "Kingsfield",
 	"traits": [
 		{"Up": true, "Turf Weather Effects": true, "Cellar": true},
 		{"Up": true, "Down": true, "Turf Weather Effects": true, "Leylines": true},

--- a/_maps/vanderlin.json
+++ b/_maps/vanderlin.json
@@ -2,6 +2,7 @@
 	"map_name": "Vanderlin",
 	"map_path": "map_files/vanderlin",
 	"map_file": "vanderlin.dmm",
+	"immigrant_origin": "Kingsfield",
 	"traits": [
 		{"Up": true, "Turf Weather Effects": true, "Cellar": true},
 		{"Up": true, "Down": true, "Turf Weather Effects": true, "Leylines": true},

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -70,7 +70,6 @@
 	map_name = json["map_name"]
 	CHECK_EXISTS("map_path")
 	map_path = json["map_path"]
-	CHECK_EXISTS("immigrant_origin")
 	immigrant_origin = json["immigrant_origin"]
 
 	map_file = json["map_file"]

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -70,6 +70,8 @@
 	map_name = json["map_name"]
 	CHECK_EXISTS("map_path")
 	map_path = json["map_path"]
+	CHECK_EXISTS("immigrant_origin")
+	immigrant_origin = json["immigrant_origin"]
 
 	map_file = json["map_file"]
 	if (istext(map_file))

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -17,6 +17,7 @@
 	var/map_name = "Vanderlin"
 	var/map_path = "map_files/vanderlin"
 	var/map_file = "vanderlin.dmm"
+	var/immigrant_origin = "Kingsfield"
 
 	var/traits = null
 	var/space_ruin_levels = 7

--- a/code/game/objects/structures/train.dm
+++ b/code/game/objects/structures/train.dm
@@ -29,20 +29,20 @@
 		return
 	var/mob/living/carbon/human/departing_mob = dropping
 	if(departing_mob != user && departing_mob.client)
-		to_chat(user, span_warning("This one retains their free will. It's their choice if they want to leave for Kingsfield or not."))
+		to_chat(user, span_warning("This one retains their free will. It's their choice if they want to leave for [SSmapping.config.immigrant_origin] or not."))
 		return //prevents people from forceghosting others
 	if(departing_mob.stat == DEAD)
-		say("The dead cannot leave for Kingsfield, ensure they get a proper burial in [SSmapping.config.map_name].")
+		say("The dead cannot leave for [SSmapping.config.immigrant_origin], ensure they get a proper burial in [SSmapping.config.map_name].")
 		return
 	if(is_type_in_list(departing_mob.mind?.assigned_role, uncryoable))
 		var/title = departing_mob.gender == FEMALE ? "lady" : "lord"
 		say("Surely you jest, my [title], you have a kingdom to rule over!")
 		return //prevents noble roles from cryoing as per request of Aberra
-	if(alert("Are you sure you want to [departing_mob == user ? "leave for Kingsfield (you" : "send this person to Kingfield (they"] will be removed from the current round, the job slot freed)?", "Departing", "Confirm", "Cancel") != "Confirm")
+	if(alert("Are you sure you want to [departing_mob == user ? "leave for [SSmapping.config.immigrant_origin] (you" : "send this person to [SSmapping.config.immigrant_origin] (they"] will be removed from the current round, the job slot freed)?", "Departing", "Confirm", "Cancel") != "Confirm")
 		return //doublechecks that people actually want to leave the round
 	if(user.incapacitated(ignore_grab = TRUE) || QDELETED(departing_mob) || (departing_mob != user && departing_mob.client) || get_dist(src, dropping) > 2 || get_dist(src, user) > 2)
 		return //Things have changed since the alert happened.
-	say("[user] [departing_mob == user ? "is departing for Kingsfield" : "is sending [departing_mob] to Kingsfield!"]")
+	say("[user] [departing_mob == user ? "is departing for [SSmapping.config.immigrant_origin]" : "is sending [departing_mob] to [SSmapping.config.immigrant_origin]!"]")
 	in_use = TRUE //Just sends a simple message to chat that some-one is leaving
 	if(!do_after(user, 5 SECONDS, src))
 		in_use = FALSE

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -222,7 +222,7 @@
 
 	if(spawned.islatejoin && (job_flags & JOB_ANNOUNCE_ARRIVAL)) //to be moved somewhere more appropriate
 		var/used_title = get_informed_title(spawned)
-		scom_announce("[spawned.real_name] the [used_title] arrives from Kingsfield.")
+		scom_announce("[spawned.real_name] the [used_title] arrives from [SSmapping.config.immigrant_origin].")
 
 	if(give_bank_account)
 		if(give_bank_account > 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
Allows for a more dynamic arrival and departure, paving the way for future maps where it would not make sense to go to or from Kingsfield. The only tangible changes in this PR are with Daftmarsh (departing to Vanderlin) and Roguetest (departing to Psydonia.)

![RoguetestOrigin2](https://github.com/user-attachments/assets/6ae9f3c7-ffef-4dd8-9ce1-62d2c1bfa5a1)
![RoguetestOrigin](https://github.com/user-attachments/assets/a72caf10-0ccf-4588-9487-375973a96058)
![DaftmarshTest](https://github.com/user-attachments/assets/86064e35-b283-47c5-8034-a01b527abd79)
![RosewoodTest](https://github.com/user-attachments/assets/9d94ed38-469f-432f-9b11-7c82e9d44441)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
Flavour.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
