### PR TITLE
Fixes species restriction in Rosewood.

### DIFF
--- a/_maps/map_files/rosewood/map_adjustment_rosewood.dm
+++ b/_maps/map_files/rosewood/map_adjustment_rosewood.dm
@@ -15,8 +15,8 @@
 
 /datum/map_adjustment/rosewood/job_change()
 	. = ..()
-	for(var/datum/job/elf in knifeEars)
-		var/datum/job/J = SSjob.GetJobType(elf)
+	for(var/jobType in knifeEars)
+		var/datum/job/J = SSjob.GetJobType(jobType)
 		J?.allowed_races = list(
 			"Elf",
 			"Half-Elf"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
Rosewood was intended to be elf and half-elf for leadership roles. Previously it was broken, now it's not.

As a humen, roles on Vanderlin:
![VanderlinSpeciesRight](https://github.com/user-attachments/assets/d3833668-f26f-46c7-9838-4c58992e9826)

As a humen, roles on Rosewood:
![RosewoodSpeciesRight](https://github.com/user-attachments/assets/a94f4155-4850-4dc2-b3b2-2673abd86cb8)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
Bug fixing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
