### PR TITLE
Half-drow distinction.

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -401,7 +401,7 @@
 
 //skin tones defines
 
-//HALF ORK SKIN TONES
+//HALF ORC SKIN TONES
 #define SKIN_COLOR_BLOOD_AXE "A84C4F" //Clay red
 #define SKIN_COLOR_GROONN "50715C" //Mint
 #define SKIN_COLOR_BLACK_HAMMER "1B2B21" //Dark green
@@ -445,6 +445,26 @@
 #define SKIN_COLOR_SAND_ELF "5d4c41" //Black 1
 #define SKIN_COLOR_CRIMSON_ELF "4e3729" //Black 2
 
+//HALF ELF SKIN TONES
+#define SKIN_COLOR_TIMBER_GRONN "ffe0d1" //Pale
+#define SKIN_COLOR_SOLAR_HUE "fcccb3" //White
+#define SKIN_COLOR_WALNUT_STINE "edc6b3" //White
+#define SKIN_COLOR_AMBER_STAINED "e2b9a3" //White
+#define SKIN_COLOR_REDWOOD_ROOTED "c9a893" //Mediterranean 1
+#define SKIN_COLOR_DRIFTED_WOOD "ba9882" //Mediterranean 2
+#define SKIN_COLOR_VINE_WRAPPED "ac8369" //Latin 2
+#define SKIN_COLOR_JOSHUA_ALIGNED "9c6f52" //Middle-east
+#define SKIN_COLOR_ARID_BIRTHED "5a4a41" //Black
+#define SKIN_COLOR_SAGE_BLOOMED "4e3729" //Black 2
+
+//HALF DROW SKIN TONES
+#define SKIN_COLOR_ZIZO_CURSED "fff0e9" //Pale as SHIT
+#define SKIN_COLOUR_PARASITE_TAINTED "a191a1" //Light purple
+#define SKIN_COLOR_MUSHROOM_MINDED "897489" //Mid purple
+#define SKIN_COLOR_CAVE_ATTUNED "5f5f70" // Dark purple
+#define SKIN_COLOR_FUNGUS_STAINED "897489" //Pink
+#define SKIN_COLOR_DEPTH_DEPARTED "5f5f70" //Grey-blue
+
 //HUMEN SKIN TONES
 #define SKIN_COLOR_ICECAP "fff0e9" //Pale as SHIT!!
 #define SKIN_COLOR_ARCTIC "ffe0d1" //White 1
@@ -458,6 +478,7 @@
 #define SKIN_COLOR_DESERT "9c6f52" //Middle-east
 #define SKIN_COLOR_CRIMSONLANDS "4e3729" //Black
 
+//LEGACY HUMEN SKIN TONES (DOES NOT FIT VANDERLIN LORE)
 #define SKIN_COLOR_GRENZELHOFT "fff0e9"
 #define SKIN_COLOR_HAMMERHOLD "ffe0d1"
 #define SKIN_COLOR_AVAR "fcccb3"
@@ -486,18 +507,6 @@
 #define SKIN_COLOR_LARIMAR "a9ded1" //Cyan
 #define SKIN_COLOR_AMAZONITE "b6f1f2" //also Cyan
 #define SKIN_COLOR_ZINC "daeaeb" //Light aqua
-
-//HALF ELF SKIN TONES
-#define SKIN_COLOR_ZIZO_CURSED "fff0e9" //Pale as SHIT
-#define SKIN_COLOR_TIMBER_GRONN "ffe0d1" //Pale
-#define SKIN_COLOR_SOLAR_HUE "fcccb3" //White
-#define SKIN_COLOR_WALNUT_STINE "edc6b3" //White
-#define SKIN_COLOR_AMBER_STAINED "e2b9a3" //White
-#define SKIN_COLOR_JOSHUA_ALIGNED "9c6f52" //Middle-east
-#define SKIN_COLOR_ARID_BIRTHED "5a4a41" //Black
-#define SKIN_COLOUR_PARASITE_TAINTED "a191a1" //Light purple
-#define SKIN_COLOR_MUSHROOM_MINDED "897489" //Mid purple
-#define SKIN_COLOR_CAVE_ATTUNED "5f5f70" // Dark purple
 
 //TIEFLING SKIN TONES
 #define SKIN_COLOR_CRIMSON_LAND "cd2042" //Bright red

--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -2,29 +2,29 @@
 #define ALL_RACES_LIST					list("human", "demihuman", "harpy","rakshari", "dwarf", "elf", "tiefling", "aasimar", "halforc", "orc", "zizombie", "kobold")
 
 /// All playable races from character selection menu.
-#define RACES_PLAYER_ALL				list("Humen", "Hollow-Kin", "Harpies", "Rakshari", "Half-Elf", "Dark Elf", "Elf", "Dwarf", "Tiefling", "Half-Orc", "Aasimar", "Kobold")
+#define RACES_PLAYER_ALL				list("Humen", "Hollow-Kin", "Harpies", "Rakshari", "Half-Elf", "Half-Drow", "Dark Elf", "Elf", "Dwarf", "Tiefling", "Half-Orc", "Aasimar", "Kobold")
 
 /// Races not considered discriminated against in Vanderlin. Used for nobility, guards, etc.
 #define RACES_PLAYER_NONDISCRIMINATED	list("Humen", "Half-Elf", "Elf", "Dwarf", "Aasimar")
 /// Races who are nonheretical to the church. Excluded races typically have an inhumen god associated, like Zizo. Used for church/faith roles.
 #define RACES_PLAYER_NONHERETICAL		list("Humen", "Half-Elf", "Elf", "Dwarf", "Aasimar")
 /// Races who are non-exotic to Vanderlin. These are races from foreign lands with no local pull or uncommon races. Used in miscellaneous cases, when they would not be that role.
-#define RACES_PLAYER_NONEXOTIC			list("Humen", "Hollow-Kin", "Harpies", "Half-Elf", "Dark Elf", "Elf", "Dwarf", "Tiefling", "Half-Orc", "Aasimar")
+#define RACES_PLAYER_NONEXOTIC			list("Humen", "Hollow-Kin", "Harpies", "Half-Elf", "Half-Drow", "Dark Elf", "Elf", "Dwarf", "Tiefling", "Half-Orc", "Aasimar")
 ///Races that lack lux
-#define RACES_PLAYER_LUXLESS			list("Kobold", "Hollow-Kin", "Harpies", "Rakshari", "Dark Elf", "Tiefling", "Half-Orc", "Dark Elf")
+#define RACES_PLAYER_LUXLESS			list("Kobold", "Hollow-Kin", "Rakshari")
 
 /// Races who are affiliated with Grenzelhoft or Psydon specifically.
 #define RACES_PLAYER_GRENZ				list("Humen", "Dwarf", "Aasimar")
 /// Elves and Half-Elves
 #define RACES_PLAYER_ELF				list("Half-Elf", "Elf")
-/// Elves, Half-Elves, Dark Elves
-#define RACES_PLAYER_ELF_D				list("Half-Elf", "Dark Elf", "Elf")
+/// Elves, Half-Elves, Half-Drow, Dark Elves
+#define RACES_PLAYER_ELF_D				list("Half-Drow", "Half-Elf", "Dark Elf", "Elf")
 
 /// Patreon only races.
 #define RACES_PLAYER_PATREON			list("Kobold", "Hollow-Kin")
 
 /// Guard Races - No Orcs
-#define RACES_PLAYER_GUARD						list("Humen", "Rakshari", "Half-Elf", "Elf", "Dwarf", "Tiefling", "Aasimar", "Harpies", "Dark Elf")
+#define RACES_PLAYER_GUARD				list("Humen", "Rakshari", "Half-Elf", "Elf", "Dwarf", "Tiefling", "Aasimar", "Harpies")
 
 
 #define ALL_TEMPLE_PATRONS 		list(/datum/patron/divine/astrata, /datum/patron/divine/noc, /datum/patron/divine/dendor, /datum/patron/divine/abyssor, /datum/patron/divine/necra, /datum/patron/divine/ravox, /datum/patron/divine/xylix, /datum/patron/divine/pestra, /datum/patron/divine/malum, /datum/patron/divine/eora)

--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -24,7 +24,7 @@
 #define RACES_PLAYER_PATREON			list("Kobold", "Hollow-Kin")
 
 /// Guard Races - No Orcs
-#define RACES_PLAYER_GUARD				list("Humen", "Rakshari", "Half-Elf", "Elf", "Dwarf", "Tiefling", "Aasimar", "Harpies")
+#define RACES_PLAYER_GUARD				list("Humen", "Rakshari", "Half-Elf", "Half-Drow", "Elf", "Dwarf", "Tiefling", "Aasimar", "Harpies")
 
 
 #define ALL_TEMPLE_PATRONS 		list(/datum/patron/divine/astrata, /datum/patron/divine/noc, /datum/patron/divine/dendor, /datum/patron/divine/abyssor, /datum/patron/divine/necra, /datum/patron/divine/ravox, /datum/patron/divine/xylix, /datum/patron/divine/pestra, /datum/patron/divine/malum, /datum/patron/divine/eora)

--- a/code/modules/mob/living/carbon/human/species_types/other/halfdrow.dm
+++ b/code/modules/mob/living/carbon/human/species_types/other/halfdrow.dm
@@ -90,8 +90,8 @@
 		"Parasite-Taineted" = SKIN_COLOUR_PARASITE_TAINTED, // - (Light purple)
 		"Mushroom-Minded" = SKIN_COLOR_MUSHROOM_MINDED, // - (Mid purple)
 		"Cave-Attuned" = SKIN_COLOR_CAVE_ATTUNED, // - (Deep purple)
-		"Fungus-Stained" = SKIN_COLOR_FUNGUS_STAINED, //Pink
-		"Depth-Departed" = SKIN_COLOR_DEPTH_DEPARTED, //Grey-blue
+		"Fungus-Stained" = SKIN_COLOR_FUNGUS_STAINED, // - (Pink)
+		"Depth-Departed" = SKIN_COLOR_DEPTH_DEPARTED, // - (Grey-blue)
 	))
 
 /datum/species/human/halfdrow/get_hairc_list()

--- a/code/modules/mob/living/carbon/human/species_types/other/halfdrow.dm
+++ b/code/modules/mob/living/carbon/human/species_types/other/halfdrow.dm
@@ -1,32 +1,26 @@
 	/*==============*
 	*				*
-	*	Half-Elf	*
+	*	Half-Drow	*
 	*				*
 	*===============*/
 
-/mob/living/carbon/human/species/human/halfelf
-	race = /datum/species/human/halfelf
+/mob/living/carbon/human/species/human/halfdrow
+	race = /datum/species/human/halfdrow
 
-/datum/species/human/halfelf
-	name = "Half-Elf"
+/datum/species/human/halfdrow
+	name = "Half-Drow"
 	id = "human"
-	desc = "The child of Elf and Humen. \
+	desc = "The child of a Dark Elf and Humen. \
 	\n\n\
-	Half-Elves are generally frowned upon by more conservative peoples, \
-	although as species tensions lower, more and more half-elves are being born. \
-	To the point that some scholars worry that someday, \
-	it may be impossible to distinguish the two species. \
+	The distinction between Half-Elves and 'Half-Drow' has been a subject of debate for centuries. \
+	While similar in physicality and longevity to their non-drow cousins, their origins cause them to face discrimination akin to their elven side. \
 	\n\n\
-	Half-Elves are extraordinarily diverse, as they combine both Humen and Elvish culture. \
-	It is widely considered that Half-Elf culture is simply a melting pot of \
-	various others condensing into one vibrant entity. \
-	\n\n\
-	Their longevity spanning too long for a human and short for an elf lead them to congregate together. \
-	Due to their heritage, Half-Elves tend to gain species traits \
-	depending on how strong their fathers, or mothers, genes were. \
-	Half-Elves also typically try to find identity."
+	Groups of half-elves and half-drow have been known to congregate together and consider themselves one species. \
+	According to some radical academic scholars, they might be one species indeed- yet the people of Psydonia certainly do not believe the same at large. \
+	\n\
+	THIS IS A DISCRIMINATED SPECIES. EXPECT A MORE DIFFICULT EXPERIENCE. <B>NOBLES EVEN MORE SO.</B> PLAY AT YOUR OWN RISK."
 
-	skin_tone_wording = "Half-Elven Identity"
+	skin_tone_wording = "Half-Drow Identity"
 
 	default_color = "FFFFFF"
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,STUBBLE,OLDGREY)
@@ -87,24 +81,20 @@
 		/datum/body_marking/tonage,
 	)
 
-/datum/species/human/halfelf/check_roundstart_eligible()
+/datum/species/human/halfdrow/check_roundstart_eligible()
 	return TRUE
 
-/datum/species/human/halfelf/get_skin_list()
+/datum/species/human/halfdrow/get_skin_list()
 	return sortList(list(
-		"Timber-Gronn" = SKIN_COLOR_TIMBER_GRONN, // - (White 1)
-		"Solar-Hue" = SKIN_COLOR_SOLAR_HUE, // - (White 2)
-		"Walnut-Stine" = SKIN_COLOR_WALNUT_STINE, // - (White 3)
-		"Amber-Stained" = SKIN_COLOR_AMBER_STAINED, // - (White 4)
-		"Joshua-Aligned" = SKIN_COLOR_JOSHUA_ALIGNED, // - (Middle-Eastern)
-		"Arid-Birthed" = SKIN_COLOR_ARID_BIRTHED, // - (Black)
-		"Redwood-Rooted" = SKIN_COLOR_REDWOOD_ROOTED, // - (Mediterranean 1)
-		"Drifted-Wood" = SKIN_COLOR_DRIFTED_WOOD, // - (Mediterranean 2)
-		"Vine-Wrapped" = SKIN_COLOR_VINE_WRAPPED, // - (Latin 2)
-		"Sage-Bloomed" = SKIN_COLOR_SAGE_BLOOMED, // - (Black 2)
+		"Zizo-Cursed" = SKIN_COLOR_ZIZO_CURSED, // - (Pale)
+		"Parasite-Taineted" = SKIN_COLOUR_PARASITE_TAINTED, // - (Light purple)
+		"Mushroom-Minded" = SKIN_COLOR_MUSHROOM_MINDED, // - (Mid purple)
+		"Cave-Attuned" = SKIN_COLOR_CAVE_ATTUNED, // - (Deep purple)
+		"Fungus-Stained" = SKIN_COLOR_FUNGUS_STAINED, //Pink
+		"Depth-Departed" = SKIN_COLOR_DEPTH_DEPARTED, //Grey-blue
 	))
 
-/datum/species/human/halfelf/get_hairc_list()
+/datum/species/human/halfdrow/get_hairc_list()
 	return sortList(list(
 	"black - oil" = "181a1d",
 	"black - cave" = "201616",
@@ -127,22 +117,26 @@
 	"blond - drywheat" = "d5ba7b",
 	"blond - strawberry" = "c69b71",
 
-	"green - leaf" = "2f3c2e",
-	"green - moss" = "3b3c2a"
+	"white - ice" = "f4f4f4",
+	"white - cavedew" = "dee9ed",
+	"white - spiderweb" = "f4f4f4"
+
 	))
 
-/datum/species/human/halfelf/get_possible_names(gender = MALE)
+/datum/species/human/halfdrow/get_possible_names(gender = MALE)
 	var/static/list/male_names = world.file2list('strings/rt/names/elf/elfwm.txt')
 	var/static/list/female_names = world.file2list('strings/rt/names/elf/elfwf.txt')
 	return (gender == FEMALE) ? female_names : male_names
 
-/datum/species/human/halfelf/get_possible_surnames(gender = MALE)
+/datum/species/human/halfdrow/get_possible_surnames(gender = MALE)
 	return null
 
-/datum/species/human/halfelf/after_creation(mob/living/carbon/human/C)
+/datum/species/human/halfdrow/after_creation(mob/living/carbon/human/C)
 	..()
+	if(C.skin_tone == SKIN_COLOR_ZIZO_CURSED)
+		exotic_bloodtype = /datum/blood_type/human/cursed_elf
 	C.grant_language(/datum/language/elvish)
 	to_chat(C, "<span class='info'>I can speak Elvish with ,e before my speech.</span>")
 
-/datum/species/human/halfelf/get_native_language()
+/datum/species/human/halfdrow/get_native_language()
 	return pick("Elfish", "Imperial")

--- a/vanderlin.dme
+++ b/vanderlin.dme
@@ -2058,6 +2058,7 @@
 #include "code\modules\mob\living\carbon\human\species_types\human\humen.dm"
 #include "code\modules\mob\living\carbon\human\species_types\kobold\_kobold.dm"
 #include "code\modules\mob\living\carbon\human\species_types\other\aasimar.dm"
+#include "code\modules\mob\living\carbon\human\species_types\other\halfdrow.dm"
 #include "code\modules\mob\living\carbon\human\species_types\other\halfelf.dm"
 #include "code\modules\mob\living\carbon\human\species_types\other\halforc.dm"
 #include "code\modules\mob\living\carbon\human\species_types\other\tiefling.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
Splits half-elves and half-drow into two species for the purposes of lore-accurate discrimination.
Players have been playing half-elves with dark elven skin tones as a workaround to play dark elves, or in some cases 'snow elves' in positions of power. This is not against the rules, but it is against the spirit of the lore. This rectifies that.

Half-elves and half-drow have received new skin tones from their parent species for added diversity. 
Half-elf:
"Redwood-Rooted" - Mediterranean 1 - Wood elf parallel.
"Drifted-Wood" - Mediterranean 2 - Sea elf parallel.
"Vine-Wrapped" - Latin 2 - Jungle elf parallel.
"Sage-Bloomed" - Black 2 - Crimsonlands elf paralell.

Half-drow:
"Fungus-Stained" - Pinkish
"Depth-Departed" - Grey-blue

Lastly, this PR fixes species defines and brings everything up to standard with current lore. Incorrectly defined 'Luxless' groups have been rectified. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
Maintaining game atmosphere.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
