### PR TITLE
Featured Statistics DLC: Half Drows, Smiths and Gluttons

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -77,6 +77,7 @@ GLOBAL_LIST_INIT(turfs_without_ground, typecacheof(list(
 #define isaasimar(A) (is_species(A, /datum/species/aasimar))
 #define ishollowkin(A) (is_species(A, /datum/species/demihuman))
 #define isharpy(A) (is_species(A, /datum/species/harpy))
+#define ishalfdrow(A) (is_species(A, /datum/species/human/halfdrow))
 
 //more carbon mobs
 #define ismonkey(A) (istype(A, /mob/living/carbon/monkey))

--- a/code/__HELPERS/qdel.dm
+++ b/code/__HELPERS/qdel.dm
@@ -1,5 +1,4 @@
 #define QDEL_IN(item, time) addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(qdel), item), time, TIMER_STOPPABLE)
-#define QDEL_IN_CLIENT_TIME(item, time) addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(qdel), item), time, TIMER_STOPPABLE | TIMER_CLIENT_TIME)
 #define QDEL_NULL(item) qdel(item); item = null
 #define QDEL_LIST(L) if(L) { for(var/I in L) qdel(I); L.Cut(); }
 #define QDEL_LIST_IN(L, time) addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(______qdel_list_wrapper), L), time, TIMER_STOPPABLE)

--- a/code/__HELPERS/round_statistics.dm
+++ b/code/__HELPERS/round_statistics.dm
@@ -351,18 +351,18 @@ GLOBAL_LIST_INIT(featured_stats, list(
 	),
 	FEATURED_STATS_CRAFTERS = list(
 		"name" = "TOP 10 Crafters",
-		"color" = "#a8a24e",
+		"color" = "#a59f4e",
 		"entries" = list()
 	),
 	FEATURED_STATS_CRAFTED_ITEMS = list(
 		"name" = "TOP 10 Crafted Items",
-		"color" = "#a5953a",
+		"color" = "#cfb834",
 		"entries" = list(),
 		"object_stat" = TRUE
 	),
 	FEATURED_STATS_SMITHS = list(
 		"name" = "TOP 10 Smiths",
-		"color" = "#c58545",
+		"color" = "#cc945c",
 		"entries" = list()
 	),
 	FEATURED_STATS_FORGED_ITEMS = list(

--- a/code/__HELPERS/round_statistics.dm
+++ b/code/__HELPERS/round_statistics.dm
@@ -4,6 +4,7 @@
 #define STATS_ALIVE_DARK_ELVES "alive_dark_elves"
 #define STATS_ALIVE_SNOW_ELVES "alive_snow_elves"
 #define STATS_ALIVE_HALF_ELVES "alive_half_elves"
+#define STATS_ALIVE_HALF_DROWS "alive_half_drows"
 #define STATS_ALIVE_HALF_ORCS "alive_half_orcs"
 #define STATS_ALIVE_KOBOLDS "alive_kobolds"
 #define STATS_ALIVE_RAKSHARI "alive_rakshari"
@@ -219,6 +220,7 @@ GLOBAL_LIST_INIT(vanderlin_round_stats, list(
 	STATS_ALIVE_DARK_ELVES = 0,
 	STATS_ALIVE_SNOW_ELVES = 0,
 	STATS_ALIVE_HALF_ELVES = 0,
+	STATS_ALIVE_HALF_DROWS = 0,
 	STATS_ALIVE_HALF_ORCS = 0,
 	STATS_ALIVE_KOBOLDS = 0,
 	STATS_ALIVE_RAKSHARI = 0,
@@ -271,7 +273,7 @@ GLOBAL_LIST_EMPTY(patron_follower_counts)
 #define FEATURED_STATS_ALCOHOLICS "alcohol_drinkers"
 #define FEATURED_STATS_SPEAKERS "speakers"
 #define FEATURED_STATS_FISHERS "fishers"
-#define FEATURED_STATS_GOURMETS "gourmets"
+#define FEATURED_STATS_EATERS "eaters"
 #define FEATURED_STATS_SCREAMERS "screamers"
 #define FEATURED_STATS_MINERS "miners"
 #define FEATURED_STATS_CRIMINALS "criminals"
@@ -279,10 +281,17 @@ GLOBAL_LIST_EMPTY(patron_follower_counts)
 #define FEATURED_STATS_CRAFTERS "crafters"
 #define FEATURED_STATS_FARMERS "farmers"
 #define FEATURED_STATS_STORYTELLERS "storytellers"
+#define FEATURED_STATS_SMITHS "smiths"
+#define FEATURED_STATS_BLEEDERS "bleeders"
 
 // Featured objects stats
 #define FEATURED_STATS_CRAFTED_ITEMS "crafted_items"
+#define FEATURED_STATS_FORGED_ITEMS "forged_items"
 #define FEATURED_STATS_DRINKS "drinks"
+#define FEATURED_STATS_FOOD "food"
+#define FEATURED_STATS_SPELLS "spells"
+#define FEATURED_STATS_CROPS "crops"
+#define FEATURED_STATS_FLAWS "flaws"
 
 GLOBAL_LIST_INIT(featured_stats, list(
 	FEATURED_STATS_TREE_FELLERS = list(
@@ -315,21 +324,25 @@ GLOBAL_LIST_INIT(featured_stats, list(
 		"color" = "#3bac5d",
 		"entries" = list()
 	),
+	FEATURED_STATS_BLEEDERS = list(
+		"name" = "TOP 10 Bleeders",
+		"color" = "#d34747",
+		"entries" = list()
+	),
 	FEATURED_STATS_STORYTELLERS = list(
 		"name" = "TOP 10 Reigning Gods",
 		"color" = "#eeca2c",
 		"entries" = list()
 	),
-	FEATURED_STATS_GOURMETS = list(
-		"name" = "TOP 10 Gourmets",
-		"color" = "#6765cf",
+	FEATURED_STATS_EATERS = list(
+		"name" = "TOP 10 Eaters",
+		"color" = "#654dbe",
 		"entries" = list()
 	),
-	FEATURED_STATS_CRAFTED_ITEMS = list(
-		"name" = "TOP 10 Crafted Items",
-		"color" = "#a5953a",
-		"entries" = list(),
-		"object_stat" = TRUE
+	FEATURED_STATS_FOOD = list(
+		"name" = "TOP 10 Food",
+		"color" = "#73b647",
+		"entries" = list()
 	),
 	FEATURED_STATS_FISHERS = list(
 		"name" = "TOP 10 Fishers",
@@ -341,14 +354,42 @@ GLOBAL_LIST_INIT(featured_stats, list(
 		"color" = "#a8a24e",
 		"entries" = list()
 	),
+	FEATURED_STATS_CRAFTED_ITEMS = list(
+		"name" = "TOP 10 Crafted Items",
+		"color" = "#a5953a",
+		"entries" = list(),
+		"object_stat" = TRUE
+	),
+	FEATURED_STATS_SMITHS = list(
+		"name" = "TOP 10 Smiths",
+		"color" = "#bd742bcc",
+		"entries" = list()
+	),
+	FEATURED_STATS_FORGED_ITEMS = list(
+		"name" = "TOP 10 Forged Items",
+		"color" = "#c48c25",
+		"entries" = list(),
+		"object_stat" = TRUE
+	),
 	FEATURED_STATS_FARMERS = list(
 		"name" = "TOP 10 Farmers",
 		"color" = "#50eb77",
 		"entries" = list()
 	),
+	FEATURED_STATS_CROPS = list(
+		"name" = "TOP 10 Crops",
+		"color" = "#a3db59",
+		"entries" = list(),
+		"object_stat" = TRUE
+	),
+	FEATURED_STATS_ALCOHOLICS = list(
+		"name" = "TOP 10 Alcoholics",
+		"color" = "#945d96",
+		"entries" = list()
+	),
 	FEATURED_STATS_DRINKS = list(
 		"name" = "TOP 10 Beverages",
-		"color" = "#5487c0",
+		"color" = "#6a8dc2",
 		"entries" = list(),
 		"object_stat" = TRUE
 	),
@@ -362,15 +403,22 @@ GLOBAL_LIST_INIT(featured_stats, list(
 		"color" = "#6e4a25",
 		"entries" = list()
 	),
-	FEATURED_STATS_ALCOHOLICS = list(
-		"name" = "TOP 10 Alcoholics",
-		"color" = "#945d96",
-		"entries" = list()
-	),
 	FEATURED_STATS_MAGES = list(
 		"name" = "TOP 10 Mages",
 		"color" = "#9eaceb",
 		"entries" = list()
+	),
+	FEATURED_STATS_SPELLS = list(
+		"name" = "TOP 10 Spells",
+		"color" = "#6375c5",
+		"entries" = list(),
+		"object_stat" = TRUE
+	),
+	FEATURED_STATS_FLAWS = list(
+		"name" = "TOP 10 Flaws",
+		"color" = "#c7c569",
+		"entries" = list(),
+		"object_stat" = TRUE
 	),
 ))
 

--- a/code/__HELPERS/round_statistics.dm
+++ b/code/__HELPERS/round_statistics.dm
@@ -362,12 +362,12 @@ GLOBAL_LIST_INIT(featured_stats, list(
 	),
 	FEATURED_STATS_SMITHS = list(
 		"name" = "TOP 10 Smiths",
-		"color" = "#bd742bcc",
+		"color" = "#c58545",
 		"entries" = list()
 	),
 	FEATURED_STATS_FORGED_ITEMS = list(
 		"name" = "TOP 10 Forged Items",
-		"color" = "#c48c25",
+		"color" = "#c08924",
 		"entries" = list(),
 		"object_stat" = TRUE
 	),

--- a/code/controllers/subsystem/storyteller.dm
+++ b/code/controllers/subsystem/storyteller.dm
@@ -1404,7 +1404,7 @@ SUBSYSTEM_DEF(gamemode)
 				if(AGE_IMMORTAL)
 					GLOB.vanderlin_round_stats[STATS_IMMORTAL_POPULATION]++
 			if(human_mob.charflaw)
-				GLOB.featured_stats[FEATURED_STATS_FLAWS]["entries"][initial(human_mob.charflaw)] += 1
+				GLOB.featured_stats[FEATURED_STATS_FLAWS]["entries"][human_mob.charflaw] += 1
 			if(human_mob.is_noble())
 				GLOB.vanderlin_round_stats[STATS_ALIVE_NOBLES]++
 			if(human_mob.mind.assigned_role.title in GLOB.garrison_positions)

--- a/code/controllers/subsystem/storyteller.dm
+++ b/code/controllers/subsystem/storyteller.dm
@@ -1310,6 +1310,8 @@ SUBSYSTEM_DEF(gamemode)
 
 	GLOB.patron_follower_counts.Cut()
 
+	GLOB.featured_stats[FEATURED_STATS_FLAWS]["entries"] = list()
+
 	GLOB.vanderlin_round_stats[STATS_TOTAL_POPULATION] = 0
 	GLOB.vanderlin_round_stats[STATS_PSYCROSS_USERS] = 0
 	GLOB.vanderlin_round_stats[STATS_ALIVE_NOBLES] = 0
@@ -1347,6 +1349,7 @@ SUBSYSTEM_DEF(gamemode)
 	GLOB.vanderlin_round_stats[STATS_ALIVE_DARK_ELVES] = 0
 	GLOB.vanderlin_round_stats[STATS_ALIVE_SNOW_ELVES] = 0
 	GLOB.vanderlin_round_stats[STATS_ALIVE_HALF_ELVES] = 0
+	GLOB.vanderlin_round_stats[STATS_ALIVE_HALF_DROWS] = 0
 	GLOB.vanderlin_round_stats[STATS_ALIVE_HALF_ORCS] = 0
 	GLOB.vanderlin_round_stats[STATS_ALIVE_KOBOLDS] = 0
 	GLOB.vanderlin_round_stats[STATS_ALIVE_RAKSHARI] = 0
@@ -1400,6 +1403,8 @@ SUBSYSTEM_DEF(gamemode)
 					GLOB.vanderlin_round_stats[STATS_ELDERLY_POPULATION]++
 				if(AGE_IMMORTAL)
 					GLOB.vanderlin_round_stats[STATS_IMMORTAL_POPULATION]++
+			if(human_mob.charflaw)
+				GLOB.featured_stats[FEATURED_STATS_FLAWS]["entries"][initial(human_mob.charflaw)] += 1
 			if(human_mob.is_noble())
 				GLOB.vanderlin_round_stats[STATS_ALIVE_NOBLES]++
 			if(human_mob.mind.assigned_role.title in GLOB.garrison_positions)
@@ -1442,6 +1447,8 @@ SUBSYSTEM_DEF(gamemode)
 				GLOB.vanderlin_round_stats[STATS_ALIVE_SNOW_ELVES]++
 			if(ishalfelf(human_mob))
 				GLOB.vanderlin_round_stats[STATS_ALIVE_HALF_ELVES]++
+			if(ishalfdrow(human_mob))
+				GLOB.vanderlin_round_stats[STATS_ALIVE_HALF_DROWS]++
 			if(ishalforc(human_mob))
 				GLOB.vanderlin_round_stats[STATS_ALIVE_HALF_ORCS]++
 			if(iskobold(human_mob))

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -309,6 +309,7 @@ GLOBAL_LIST_EMPTY(respawncounts)
 	data += "<font color='#ac5d5d'><span class='bold'>Ankles Broken:</span></font> [GLOB.vanderlin_round_stats[STATS_ANKLES_BROKEN]]<br>"
 	data += "<font color='#e6d927'><span class='bold'>People Smitten:</span></font> [GLOB.vanderlin_round_stats[STATS_PEOPLE_SMITTEN]]<br>"
 	data += "<font color='#50aeb4'><span class='bold'>People Drowned:</span></font> [GLOB.vanderlin_round_stats[STATS_PEOPLE_DROWNED]]<br>"
+	data += "<font color='#be8b37'><span class='bold'>Kleptomaniacs:</span></font> [GLOB.vanderlin_round_stats[STATS_KLEPTOMANIACS]]<br>"
 	data += "<font color='#8f816b'><span class='bold'>Items Stolen:</span></font> [GLOB.vanderlin_round_stats[STATS_ITEMS_PICKPOCKETED]]<br>"
 	data += "<font color='#c24bc2'><span class='bold'>Drugs Snorted:</span></font> [GLOB.vanderlin_round_stats[STATS_DRUGS_SNORTED]]<br>"
 	data += "<font color='#90a037'><span class='bold'>Laughs Had:</span></font> [GLOB.vanderlin_round_stats[STATS_LAUGHS_MADE]]<br>"
@@ -320,7 +321,8 @@ GLOBAL_LIST_EMPTY(respawncounts)
 	data += "<font color='#36959c'><span class='bold'>Triumphs Awarded:</span></font> [GLOB.vanderlin_round_stats[STATS_TRIUMPHS_AWARDED]]<br>"
 	data += "<font color='#a02fa4'><span class='bold'>Triumphs Stolen:</span></font> [GLOB.vanderlin_round_stats[STATS_TRIUMPHS_STOLEN] * -1]<br>"
 	data += "<font color='#d7da2f'><span class='bold'>Prayers Made:</span></font> [GLOB.vanderlin_round_stats[STATS_PRAYERS_MADE]]<br>"
-	data += "<font color='#9c3e46'><span class='bold'>Active Deadites:</span></font> [GLOB.vanderlin_round_stats[STATS_DEADITES_ALIVE]]<br>"
+	data += "<font color='#bacfd6'><span class='bold'>Graves Consecrated:</span></font> [GLOB.vanderlin_round_stats[STATS_GRAVES_CONSECRATED]]<br>"
+	data += "<font color='#9c3e46'><span class='bold'>Wandering Deadites:</span></font> [GLOB.vanderlin_round_stats[STATS_DEADITES_ALIVE]]<br>"
 	data += "<font color='#0f555c'><span class='bold'>Beards Shaved:</span></font> [GLOB.vanderlin_round_stats[STATS_BEARDS_SHAVED]]<br>"
 	data += "<font color='#6e7c81'><span class='bold'>Skills Learned:</span></font> [GLOB.vanderlin_round_stats[STATS_SKILLS_LEARNED]]<br>"
 	data += "<font color='#23af4d'><span class='bold'>Plants Harvested:</span></font> [GLOB.vanderlin_round_stats[STATS_PLANTS_HARVESTED]]<br>"
@@ -354,7 +356,8 @@ GLOBAL_LIST_EMPTY(respawncounts)
 	data += "<font color='#6b89e0'><span class='bold'>Males:</span></font> [GLOB.vanderlin_round_stats[STATS_MALE_POPULATION]]<br>"
 	data += "<font color='#d67daa'><span class='bold'>Females:</span></font> [GLOB.vanderlin_round_stats[STATS_FEMALE_POPULATION]]<br>"
 	data += "<font color='#FFD700'><span class='bold'>Children:</span></font> [GLOB.vanderlin_round_stats[STATS_CHILD_POPULATION]]<br>"
-	data += "<font color='#d0d67c'><span class='bold'>Adults:</span></font> [GLOB.vanderlin_round_stats[STATS_ADULT_POPULATION] + GLOB.vanderlin_round_stats[STATS_MIDDLEAGED_POPULATION] + GLOB.vanderlin_round_stats[STATS_IMMORTAL_POPULATION]]<br>"
+	data += "<font color='#d0d67c'><span class='bold'>Adults:</span></font> [GLOB.vanderlin_round_stats[STATS_ADULT_POPULATION] + GLOB.vanderlin_round_stats[STATS_IMMORTAL_POPULATION]]<br>"
+	data += "<font color='#a6ac6a'><span class='bold'>Middle-Aged:</span></font> [GLOB.vanderlin_round_stats[STATS_MIDDLEAGED_POPULATION]]<br>"
 	data += "<font color='#C0C0C0'><span class='bold'>Elderly:</span></font> [GLOB.vanderlin_round_stats[STATS_ELDERLY_POPULATION]]<br>"
 	data += "</div>"
 
@@ -364,6 +367,7 @@ GLOBAL_LIST_EMPTY(respawncounts)
 	data += "<font color='#808080'><span class='bold'>Dwarves:</span></font> [GLOB.vanderlin_round_stats[STATS_ALIVE_DWARVES]]<br>"
 	data += "<font color='#87CEEB'><span class='bold'>Pure Elves:</span></font> [GLOB.vanderlin_round_stats[STATS_ALIVE_SNOW_ELVES]]<br>"
 	data += "<font color='#9ACD32'><span class='bold'>Half-Elves:</span></font> [GLOB.vanderlin_round_stats[STATS_ALIVE_HALF_ELVES]]<br>"
+	data += "<font color='#bd83cc'><span class='bold'>Half-Drows:</span></font> [GLOB.vanderlin_round_stats[STATS_ALIVE_HALF_DROWS]]<br>"
 	data += "<font color='#7729af'><span class='bold'>Dark Elves:</span></font> [GLOB.vanderlin_round_stats[STATS_ALIVE_DARK_ELVES]]<br>"
 	data += "<font color='#DC143C'><span class='bold'>Tieflings:</span></font> [GLOB.vanderlin_round_stats[STATS_ALIVE_TIEFLINGS]]<br>"
 	data += "<font color='#228B22'><span class='bold'>Half-Orcs:</span></font> [GLOB.vanderlin_round_stats[STATS_ALIVE_HALF_ORCS]]<br>"
@@ -390,7 +394,7 @@ GLOBAL_LIST_EMPTY(respawncounts)
 	data += "</div>"
 
 	src.mob << browse(null, "window=vanderlin_influences")
-	var/datum/browser/popup = new(src.mob, "vanderlin_stats", "<center>End Round Statistics</center>", 1050, 725)
+	var/datum/browser/popup = new(src.mob, "vanderlin_stats", "<center>End Round Statistics</center>", 1050, 750)
 	popup.set_content(data.Join())
 	popup.open()
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -394,7 +394,7 @@ GLOBAL_LIST_EMPTY(respawncounts)
 	data += "</div>"
 
 	src.mob << browse(null, "window=vanderlin_influences")
-	var/datum/browser/popup = new(src.mob, "vanderlin_stats", "<center>End Round Statistics</center>", 1050, 750)
+	var/datum/browser/popup = new(src.mob, "vanderlin_stats", "<center>End Round Statistics</center>", 1050, 745)
 	popup.set_content(data.Join())
 	popup.open()
 

--- a/code/modules/crafting/anvil_recipes/_anvil_recipe.dm
+++ b/code/modules/crafting/anvil_recipes/_anvil_recipe.dm
@@ -123,6 +123,7 @@
 	needed_item_text = null
 
 /datum/anvil_recipe/proc/handle_creation(obj/item/I)
+	record_featured_object_stat(FEATURED_STATS_FORGED_ITEMS, I.name)
 	numberofhits = ceil(numberofhits / num_of_materials) // Divide the hits equally among the number of bars required, rounded up.
 	if(numberofbreakthroughs) // Hitting the bar the perfect way should be rewarding quality-wise
 		numberofhits -= numberofbreakthroughs

--- a/code/modules/farming/bin.dm
+++ b/code/modules/farming/bin.dm
@@ -211,6 +211,7 @@
 				while(R.createditem_num)
 					R.createditem_num--
 					var/obj/item/editme = new crafteditem(used_turf)
+					record_featured_stat(FEATURED_STATS_SMITHS, user)
 					editme.name = newname
 					editme.max_integrity = newmaxinteg
 					editme.obj_integrity = newinteg
@@ -231,6 +232,7 @@
 						editme.equip_delay_self = newdelay
 			else // Just make one buddy
 				var/obj/item/IT = new crafteditem(used_turf)
+				record_featured_stat(FEATURED_STATS_SMITHS, user)
 				R.handle_creation(IT)
 			playsound(src,pick('sound/items/quench_barrel1.ogg','sound/items/quench_barrel2.ogg'), 100, FALSE)
 			user.visible_message("<span class='info'>[user] tempers \the [T.held_item.name] in \the [src], hot metal sizzling.</span>")

--- a/code/modules/farming/soil.dm
+++ b/code/modules/farming/soil.dm
@@ -72,6 +72,7 @@
 		modifier += 3
 
 	record_featured_stat(FEATURED_STATS_FARMERS, user)
+	record_featured_object_stat(FEATURED_STATS_CROPS, plant.name)
 	GLOB.vanderlin_round_stats[STATS_PLANTS_HARVESTED]++
 	to_chat(user, span_notice(feedback))
 	yield_produce(modifier)

--- a/code/modules/farming/wild_plant.dm
+++ b/code/modules/farming/wild_plant.dm
@@ -71,6 +71,7 @@
 		modifier += 3
 
 	record_featured_stat(FEATURED_STATS_FARMERS, user)
+	record_featured_object_stat(FEATURED_STATS_CROPS, plant_type.name)
 	GLOB.vanderlin_round_stats[STATS_PLANTS_HARVESTED]++
 	to_chat(user, span_notice(feedback))
 	yield_produce(modifier)

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -337,8 +337,9 @@ All foods are distributed among various categories. Use common sense.
 	eater.taste(reagents)
 
 	if(!reagents.total_volume)
+		record_featured_stat(FEATURED_STATS_EATERS, eater)
+		record_featured_object_stat(FEATURED_STATS_FOOD, name)
 		if(faretype == FARE_LAVISH || faretype == FARE_FINE)
-			record_featured_stat(FEATURED_STATS_GOURMETS, eater)
 			GLOB.vanderlin_round_stats[STATS_LUXURIOUS_FOOD_EATEN]++
 		var/atom/current_loc = loc
 		qdel(src)

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -171,6 +171,8 @@
 			return
 	if(blood_volume)
 		blood_volume = max(blood_volume - amt, 0)
+		if(src.client)
+			record_featured_stat(FEATURED_STATS_BLEEDERS, src)
 		GLOB.vanderlin_round_stats[STATS_BLOOD_SPILT] += amt
 		if(isturf(src.loc)) //Blood loss still happens in locker, floor stays clean
 			add_drip_floor(get_turf(src), amt)

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -92,7 +92,8 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 			adjusted_metabolization_rate = adjusted_metabolization_rate * 0.5
 		holder.remove_reagent(type, adjusted_metabolization_rate) //By default it slowly disappears.
 		if(M.client)
-			record_featured_object_stat(FEATURED_STATS_DRINKS, name, adjusted_metabolization_rate)
+			if(!istype(src, /datum/reagent/drug) && reagent_state == LIQUID)
+				record_featured_object_stat(FEATURED_STATS_DRINKS, name, adjusted_metabolization_rate)
 			if(istype(src, /datum/reagent/consumable/ethanol))
 				record_featured_stat(FEATURED_STATS_ALCOHOLICS, M, adjusted_metabolization_rate)
 				GLOB.vanderlin_round_stats[STATS_ALCOHOL_CONSUMED] += adjusted_metabolization_rate

--- a/code/modules/reagents/chemistry/reagents/roguetown.dm
+++ b/code/modules/reagents/chemistry/reagents/roguetown.dm
@@ -1,6 +1,7 @@
 /datum/reagent/miasmagas
-	name = "miasmagas"
+	name = "Miasma"
 	description = "."
+	reagent_state = GAS
 	color = "#801E28" // rgb: 128, 30, 40
 	taste_description = "ugly"
 	metabolization_rate = 1
@@ -15,7 +16,7 @@
 	return ..()
 
 /datum/reagent/rogueacid
-	name = "rogueacid"
+	name = "Acid"
 	description = "."
 	reagent_state = LIQUID
 	color = "#5eff00"
@@ -32,8 +33,9 @@
 	return TRUE
 
 /datum/reagent/blastpowder
-	name = "blastpowder"
+	name = "Blastpowder"
 	description = "."
+	reagent_state = SOLID
 	color = "#6b0000"
 	taste_description = "spicy"
 	self_consuming = TRUE

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -199,6 +199,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 		for(var/atom/target as anything in targets)
 			target.log_message("was affected by spell [name], caster was [key_name_admin(user)]", LOG_ATTACK, "red", FALSE)
 	if(user)
+		record_featured_object_stat(FEATURED_STATS_SPELLS, name)
 		user.log_message("casted the spell [name][targets_string ? " on [targets_string ]" : ""].", LOG_ATTACK, "red")
 
 /obj/effect/proc_holder/spell/get_chargetime()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

This PR does 3 things:

- Adds Half Drows to the census along with a new corresponding row
- Adds 7 new featured statistics - Food, Smiths, Forged Items, Flaws, Crops, Bleeders and Spells
- Minor fixes and changes for the older statistics, like properly filtering beverages and changing top gourmets to just top eaters

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

More statistics, cleanup of the old stats, maintenance work.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
