### PR TITLE
Royal knight armor changes

### DIFF
--- a/code/modules/jobs/job_types/garrison/royal_knight.dm
+++ b/code/modules/jobs/job_types/garrison/royal_knight.dm
@@ -38,13 +38,12 @@
 /datum/outfit/job/royalknight/pre_equip(mob/living/carbon/human/H)
 	..()
 	neck = /obj/item/clothing/neck/chaincoif
-	pants = /obj/item/clothing/pants/platelegs
 	cloak = /obj/item/clothing/cloak/tabard/knight/guard  // Wear the King's colors
 	shirt = /obj/item/clothing/armor/gambeson/arming
 	belt = /obj/item/storage/belt/leather
 	beltr = /obj/item/weapon/sword/arming
 	backl = /obj/item/storage/backpack/satchel
-	wrists = /obj/item/clothing/wrists/bracers
+	pants = /obj/item/clothing/pants/trou/leather
 	backpack_contents = list(/obj/item/storage/keyring/manorguard = 1)
 
 	if(H.mind)
@@ -137,10 +136,10 @@
 
 /datum/outfit/job/royalknight/knight/pre_equip(mob/living/carbon/human/H)
 	. = ..()
-	armor = /obj/item/clothing/armor/brigandine
-	shoes = /obj/item/clothing/shoes/boots/armor/light
-	gloves = /obj/item/clothing/gloves/chain
+	armor = /obj/item/clothing/armor/plate/full
 	head = /obj/item/clothing/head/helmet/visored/knight
+	gloves = /obj/item/clothing/gloves/plate
+	shoes = /obj/item/clothing/shoes/boots/armor
 
 /datum/advclass/royalknight/steam
 	name = "Steam Knight"


### PR DESCRIPTION
## About The Pull Request

(I know, I know, the thirtieth gear change for royal knights, hear me out.)
Both knights: Bracers and plated chausses removed from both knights. Leather trousers added.
Classic knight: Brigandine, light plate boots, and chain gloves replaced with full plate armor, plated boots, and plated gloves.

## Why It's Good For The Game

Currently, if you look at a map of the protection each knight gets, it's limb heavy. Both knights get double layered protection on the arms, and steam knight gets double layered protection of the legs. Brigandine armor values are also terrible, and it's the only real armor on the knight's chest. The knight now also gets a pair of normal, sleepable clothes, under the armor. You can take off the helmet, adjust the coif down, and slip the plate into your bag and look semi-normal. Also, knights have to take off their pants to sleep now, which is annoying. It also downscales the armor of the steam knight, which is wildly inflated. The steam plate gives full coverage with the armor value 'armor_plate_good' which is not only more coverage than the brigandine, but also a MUCH higher armor value. Iron plate armor, is better than brigandine. Brigandine should not be anywhere near a knight.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
