### PR TITLE
Arcane crafing recipy adjustments

### DIFF
--- a/code/modules/crafting/quality_of_crafting/arcyne.dm
+++ b/code/modules/crafting/quality_of_crafting/arcyne.dm
@@ -21,22 +21,6 @@
 	subtypes_allowed = TRUE // so you can use any subtype of knife
 	reagent_subtypes_allowed = TRUE // so normal mana potions can be used as well as weak ones.
 
-/datum/repeatable_crafting_recipe/arcyne/manabloom_powder
-	name = "manabloom powder"
-	reagent_requirements = list()
-	tool_usage = list()
-	requirements = list(
-		/obj/item/reagent_containers/food/snacks/produce/manabloom = 1,
-	)
-	tool_usage = list(
-		/obj/item/weapon/hammer = list("starts to crush the manabloom", "start to crush the manabloom")
-	)
-	output = /obj/item/reagent_containers/powder/manabloom
-	attacked_atom = /obj/item/reagent_containers/food/snacks/produce/manabloom
-	starting_atom = /obj/item/weapon/hammer
-	uses_attacked_atom = FALSE
-
-
 /datum/repeatable_crafting_recipe/arcyne/infernal_feather
 	name = "infernal feather"
 	reagent_requirements = list()
@@ -110,6 +94,7 @@
 	starting_atom = /obj/item/natural/glass
 	attacked_atom = /obj/item/natural/melded/t2
 	uses_attacked_atom = TRUE
+	subtypes_allowed = TRUE
 	craftdiff = 3
 
 /datum/repeatable_crafting_recipe/arcyne/shimmeringlens

--- a/code/modules/crafting/quality_of_crafting/crafting.dm
+++ b/code/modules/crafting/quality_of_crafting/crafting.dm
@@ -516,3 +516,18 @@
 	attacked_atom = /obj/item/natural/cloth
 	uses_attacked_atom = TRUE
 	subtypes_allowed = TRUE
+
+/datum/repeatable_crafting_recipe/crafting/manabloom_powder
+	name = "manabloom powder"
+	reagent_requirements = list()
+	tool_usage = list()
+	requirements = list(
+		/obj/item/reagent_containers/food/snacks/produce/manabloom = 1,
+	)
+	tool_usage = list(
+		/obj/item/weapon/hammer = list("starts to crush the manabloom", "start to crush the manabloom")
+	)
+	output = /obj/item/reagent_containers/powder/manabloom
+	attacked_atom = /obj/item/reagent_containers/food/snacks/produce/manabloom
+	starting_atom = /obj/item/weapon/hammer
+	uses_attacked_atom = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

* Changes manabloom poweder into a crafting recipy using the crafting skill
* Allows the temporal hourglass recipy to use subtypes

## Why It's Good For The Game

Hocus pocus, arcane skill cheese begoneuss.

Manabloom powder was an incredibly easy way to grind arcana skill, that anyone could do.
It litterally only required you to turn 2 manablooms into powder, to get the first arcana lv.
Making the thresh hold to start using magic basicly non exitent.

That has been a problem for a while now. So now its a crafting, crafting recipy (top tier naming btw).
It requires crafting skill instead of arcana, the skill dif didnt change.

Second the temporal hoursglass recipy was broken for a while, because it only allowed the parent of our gems to be used for crafing. Said parent, doesnt exsist ingame. We only use its subtypes. Easy change

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
