### PR TITLE
Makes Vials & Wooden Cups 1x1 Items. Adds Preset Healthpot Vials For Mappers.

### DIFF
--- a/code/game/objects/items/cup.dm
+++ b/code/game/objects/items/cup.dm
@@ -34,6 +34,7 @@
 	name = "wooden cup"
 	desc = "A wooden cup that has seen it's fair share of use and barfights."
 	resistance_flags = FLAMMABLE
+	grid_height = 32
 	icon_state = "wooden"
 	drop_sound = 'sound/foley/dropsound/wooden_drop.ogg'
 	metalizer_result = /obj/item/reagent_containers/glass/cup

--- a/code/modules/reagents/reagent_containers/bottles/_bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottles/_bottle.dm
@@ -230,6 +230,7 @@ GLOBAL_LIST_INIT(wisdoms, world.file2list("strings/rt/wisdoms.txt"))
 	closed = TRUE
 	reagent_flags = TRANSPARENT
 	w_class = WEIGHT_CLASS_SMALL
+	grid_height = 32
 	drinksounds = list('sound/items/drink_bottle (1).ogg','sound/items/drink_bottle (2).ogg')
 	fillsounds = list('sound/items/fillcup.ogg')
 	poursounds = list('sound/items/fillbottle.ogg')

--- a/code/modules/reagents/reagent_containers/bottles/alchemy.dm
+++ b/code/modules/reagents/reagent_containers/bottles/alchemy.dm
@@ -83,6 +83,12 @@
 /obj/item/reagent_containers/glass/bottle/vial/antidote
 	list_reagents = list(/datum/reagent/medicine/antidote = 30)
 
+/obj/item/reagent_containers/glass/bottle/vial/healthpot
+	list_reagents = list(/datum/reagent/medicine/healthpot = 30)
+
+/obj/item/reagent_containers/glass/bottle/vial/stronghealthpot
+	list_reagents = list(/datum/reagent/medicine/stronghealth = 30)
+
 //////////////////////////
 /// ALCOHOLIC BOTTLES ///	- add fancy var to retain custom descriptions when corking
 //////////////////////////


### PR DESCRIPTION
## About The Pull Request
This PR makes vials and wooden cups 1x1 grid items for storage. It also adds vials containing standard/strong lifeblood to the preset vials for mappers or character presets, or vendors or something. 

## Why It's Good For The Game
Ook gave his blessing for the vial change. 
![Ook blessing](https://github.com/user-attachments/assets/2ab3b85e-0291-422b-8867-409936d2168f)

Vials can hold less than half the reagents as a bottle, but are the same size. It is really cool to be carrying around a tiny bottle with a couple sips of a potion, and now the storage side of things reflects this. 

I made wooden cups 1x1 specifically for picnicking, I like the idea of carrying around a bottle and a couple cups to share with your friends. Cups can only hold 8oz and spill in backpacks so this can't be abused. Only wooden cups because other ones are more valuable, and I don't think we want to make it easier to carry gold and silver goblets.

The preset vials are for mappers, so instead of full bottles of life potion in the dungeon they can put these tiny potion vials which are cooler.
![Cups](https://github.com/user-attachments/assets/879dfe5b-62a8-498f-8405-df51e39be7aa)


## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
