### PR TITLE
Remove race locks from the rare armors and instead introduce sprite locks

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -28,9 +28,9 @@
 
 //Race Sizes for some armors
 
-#define RACES_AVERAGE_HEIGHT				list("Humen", "Hollow-Kin", "Half-Elf", "Half-Drow", "Dark Elf", "Elf", "Tiefling", "Half-Orc", "Aasimar")
+#define RACES_AVERAGE_HEIGHT			list("Humen", "Hollow-Kin", "Half-Elf", "Half-Drow", "Dark Elf", "Elf", "Tiefling", "Half-Orc", "Aasimar")
 #define RACES_SMALL_HEIGHT				list("Kobold", "Dwarf")
-#define RACES_STRANGE				list("Harpy", "Rakshari")
+#define RACES_STRANGE					list("Harpy", "Rakshari")
 
 
 

--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -26,6 +26,13 @@
 /// Guard Races - No Orcs
 #define RACES_PLAYER_GUARD				list("Humen", "Rakshari", "Half-Elf", "Half-Drow", "Elf", "Dwarf", "Tiefling", "Aasimar", "Harpy")
 
+//Race Sizes for some armors
+
+#define RACES_AVERAGE_HEIGHT	list("Humen", "Hollow-Kin", "Half-Elf", "Half-Drow", "Dark Elf", "Elf", "Tiefling", "Half-Orc", "Aasimar")
+#define RACES_SMALL_HEIGHT list("Kobold", "Dwarf")
+#define RACES_STRANGE	list("Harpy", "Rakshari")
+
+
 
 #define ALL_TEMPLE_PATRONS 		list(/datum/patron/divine/astrata, /datum/patron/divine/noc, /datum/patron/divine/dendor, /datum/patron/divine/abyssor, /datum/patron/divine/necra, /datum/patron/divine/ravox, /datum/patron/divine/xylix, /datum/patron/divine/pestra, /datum/patron/divine/malum, /datum/patron/divine/eora)
 #define ALL_CLERIC_PATRONS 		list(/datum/patron/divine/astrata, /datum/patron/divine/noc, /datum/patron/divine/dendor, /datum/patron/divine/abyssor, /datum/patron/divine/necra, /datum/patron/divine/ravox, /datum/patron/divine/xylix, /datum/patron/divine/pestra, /datum/patron/divine/malum, /datum/patron/divine/eora)

--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -28,9 +28,9 @@
 
 //Race Sizes for some armors
 
-#define RACES_AVERAGE_HEIGHT	list("Humen", "Hollow-Kin", "Half-Elf", "Half-Drow", "Dark Elf", "Elf", "Tiefling", "Half-Orc", "Aasimar")
-#define RACES_SMALL_HEIGHT list("Kobold", "Dwarf")
-#define RACES_STRANGE	list("Harpy", "Rakshari")
+#define RACES_AVERAGE_HEIGHT				list("Humen", "Hollow-Kin", "Half-Elf", "Half-Drow", "Dark Elf", "Elf", "Tiefling", "Half-Orc", "Aasimar")
+#define RACES_SMALL_HEIGHT				list("Kobold", "Dwarf")
+#define RACES_STRANGE				list("Harpy", "Rakshari")
 
 
 

--- a/code/modules/clothing/armor/rare.dm
+++ b/code/modules/clothing/armor/rare.dm
@@ -27,7 +27,7 @@
 	name = "dark elf plate"
 	desc = "A fine suit of sleek, moulded dark elf metal. Its interlocking nature and light weight allow for increased maneuverability."
 	icon_state = "elfchest"
-	allowed_race = list("elf", "half-elf", "dark elf")
+	allowed_race = RACES_AVERAGE_HEIGHT
 	equip_delay_self = 2 SECONDS
 	unequip_delay_self = 2 SECONDS
 
@@ -45,14 +45,14 @@
 	name = "dwarvish plate"
 	desc = "Plate armor made out of the sturdiest, finest dwarvish metal armor. It's as heavy and durable as it gets."
 	icon_state = "dwarfchest"
-	allowed_race = list("dwarf")
+	allowed_race = RACES_SMALL_HEIGHT				
 	item_weight = 12 * STEEL_MULTIPLIER
 
 /obj/item/clothing/armor/rare/grenzelplate
 	name = "grenzelhoftian plate regalia"
 	desc = "Engraved on this masterwork of humen metallurgy lies \"Thrice Slain, Thrice Risen, Thrice Pronged\" alongside the symbol of Psydon in its neck guard."
 	icon_state = "human_swordchest"
-	allowed_race = list("human")
+	allowed_race = RACES_AVERAGE_HEIGHT
 	allowed_sex = list(MALE)
 	item_weight = 12 * STEEL_MULTIPLIER
 
@@ -62,7 +62,7 @@
 			ensuring the wearer optimal defence with forgiving breathability. \
 			The sigil of the Zybantu Kataphractoe is embezzeled at the throat guard."
 	icon_state = "human_spearchest"
-	allowed_race = list("human")
+	allowed_race = RACES_AVERAGE_HEIGHT
 	allowed_sex = list(MALE)
 	item_weight = 12 * STEEL_MULTIPLIER
 
@@ -74,7 +74,7 @@
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/armor.dmi'
 	sleeved = 'icons/roguetown/clothing/onmob/helpers/sleeves_armor.dmi'
 	icon_state = "aasimarplate"
-	allowed_race = list("aasimar")
+	allowed_race = RACES_AVERAGE_HEIGHT
 	smeltresult = /obj/item/ingot/bronze
 	sellprice = VALUE_SNOWFLAKE_STEEL+BONUS_VALUE_MODEST // It has great value to historical collectors
 

--- a/code/modules/clothing/gloves/rare.dm
+++ b/code/modules/clothing/gloves/rare.dm
@@ -23,7 +23,7 @@
 	name = "dark elf plate gauntlets"
 	desc = "Plate gauntlets of mystic dark elven alloy, lightweight yet incredibly protective. Typically worn by elite bladesingers."
 	icon_state = "elfhand"
-	allowed_race = list("elf", "half-elf", "dark elf")
+	allowed_race = RACES_AVERAGE_HEIGHT
 	item_weight = 7 * STEEL_MULTIPLIER
 
 /obj/item/clothing/gloves/rare/elfplate/welfplate
@@ -36,7 +36,7 @@
 	name = "dwarvish plate gauntlets"
 	desc = "Plated gauntlets of masterwork dwarven smithing, the pinnacle of protection for one's hands."
 	icon_state = "dwarfhand"
-	allowed_race = list("dwarf")
+	allowed_race = RACES_SMALL_HEIGHT
 	allowed_sex = list(MALE, FEMALE)
 	item_weight = 7 * STEEL_MULTIPLIER
 
@@ -44,7 +44,7 @@
 	name = "grenzelhoftian plate gauntlets"
 	desc = "Battling the Zybantus led to the exchange of military ideas. The Grenzelhoft adopted refined chain and plate armaments to better allow their knights unmatchable resilience against the enemies of their Empire."
 	icon_state = "human_swordhand"
-	allowed_race = list("human")
+	allowed_race = RACES_AVERAGE_HEIGHT
 	allowed_sex = list(MALE)
 	item_weight = 7 * STEEL_MULTIPLIER
 
@@ -52,6 +52,6 @@
 	name = "kataphractoe claw gauntlets"
 	desc = "Interwoven beautifully with layers of silk, chain and plate, these gauntlets grant unmatched coverage while allowing maximum mobility. Both useful to the Zybantu's ever-growing slave-empire."
 	icon_state = "human_spearhand"
-	allowed_race = list("human")
+	allowed_race = RACES_AVERAGE_HEIGHT
 	allowed_sex = list(MALE)
 	item_weight = 6 * STEEL_MULTIPLIER

--- a/code/modules/clothing/head/rare.dm
+++ b/code/modules/clothing/head/rare.dm
@@ -24,7 +24,7 @@
 	name = "elvish plate helmet"
 	desc = "A bizarrely lightweight helmet of alloyed dark elven steel, offering unparalleled protection for elite bladesingers."
 	icon_state = "elfhead"
-	allowed_race = list("elf", "half-elf", "dark elf")
+	allowed_race = RACES_AVERAGE_HEIGHT
 	clothing_flags = CANT_SLEEP_IN
 	armor_class = AC_MEDIUM
 	body_parts_covered = HEAD|HAIR|NOSE
@@ -42,7 +42,7 @@
 	desc = "The Langobards are a cult of personality that are tasked by the Dwarven Kings to issue judgement, \
 			justice and order around the realms for dwarvenkind. This helmet is a respected symbol of authority."
 	icon_state = "dwarfhead"
-	allowed_race = list("dwarf")
+	allowed_race = RACES_SMALL_HEIGHT
 	flags_inv = HIDEEARS
 	clothing_flags = CANT_SLEEP_IN
 	body_parts_covered = HEAD_EXCEPT_MOUTH
@@ -55,7 +55,7 @@
 			It has been proven with severe battle-testing that a wearer's head would crack before the helmet chips."
 	icon_state = "human_swordhead"
 	allowed_sex = list(MALE)
-	allowed_race = list("human")
+	allowed_race = RACES_AVERAGE_HEIGHT
 	flags_inv = HIDEEARS
 	clothing_flags = CANT_SLEEP_IN
 	body_parts_covered = HEAD|EARS|HAIR
@@ -70,7 +70,7 @@
 	icon_state = "human_spearhead"
 	item_state = "human_spearplate"
 	allowed_sex = list(MALE)
-	allowed_race = list("human")
+	allowed_race = RACES_AVERAGE_HEIGHT
 	flags_inv = HIDEEARS|HIDEFACE
 	clothing_flags = CANT_SLEEP_IN
 	body_parts_covered = HEAD|EARS|HAIR|NOSE|MOUTH
@@ -85,7 +85,7 @@
 	icon_state = "aasimarhead"
 	worn_x_dimension = 64
 	worn_y_dimension = 64
-	allowed_race = list("aasimar")
+	allowed_race = RACES_AVERAGE_HEIGHT
 	flags_inv = HIDEEARS
 	clothing_flags = CANT_SLEEP_IN
 	body_parts_covered = HEAD|EARS|HAIR

--- a/code/modules/clothing/shoes/rare.dm
+++ b/code/modules/clothing/shoes/rare.dm
@@ -21,7 +21,7 @@
 	body_parts_covered = FEET
 	icon_state = "elfshoes"
 	item_state = "elfshoes"
-	allowed_race = list("elf", "half-elf", "dark elf")
+	allowed_race = RACES_AVERAGE_HEIGHT
 	color = null
 	blocksound = PLATEHIT
 	item_weight = 7 * STEEL_MULTIPLIER
@@ -39,7 +39,7 @@
 
 /obj/item/clothing/shoes/boots/rare/dwarfplate
 	name = "decorated dwarven plate boots"
-	allowed_race = list("dwarf")
+	allowed_race = RACES_SMALL_HEIGHT
 	allowed_sex = list(MALE, FEMALE)
 	desc = "Laced with golden bands, these dwarven plated boots glitter with glory as they are used to kick enemy's shins."
 	body_parts_covered = FEET|LEGS
@@ -51,7 +51,7 @@
 
 /obj/item/clothing/shoes/boots/rare/grenzelplate
 	name = "grenzelhoft \"Elvenbane\" sabatons"
-	allowed_race = list("human")
+	allowed_race = RACES_AVERAGE_HEIGHT
 	allowed_sex = list(MALE)
 	desc = "The sabatons that march to the tune of a glorious nation. It is said that the boots \
 			are gilded with the tears of once native elves of the Grenzeholft lands, \
@@ -65,7 +65,7 @@
 
 /obj/item/clothing/shoes/boots/rare/zybanplate
 	name = "zybantean segmented plate boots"
-	allowed_race = list("human")
+	allowed_race = RACES_AVERAGE_HEIGHT
 	allowed_sex = list(MALE)
 	desc = "The segmented plate boots are a recent alteration to the Zybantu Elite, \
 			many old warriors decorate their own by tieing ribbons and other knick-knacks \

--- a/code/modules/jobs/job_types/adventurer/types/combat/donator/swordmaster.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/donator/swordmaster.dm
@@ -2,7 +2,7 @@
 	name = "Hedge Knight"
 	tutorial = "You spent years serving the eastern Grenzelhoftian lords, and now you spend your days as a travelling hedge knight. Upon this island, you like to increase the fame of your sword skills, as well as your honor."
 	allowed_sexes = list(MALE)
-	allowed_races = RACES_PLAYER_GRENZ
+	allowed_races = list("Humen")
 	outfit = /datum/outfit/job/adventurer/swordmaster
 	maximum_possible_slots = 1
 	min_pq = 2

--- a/code/modules/jobs/job_types/adventurer/types/combat/donator/swordmaster.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/donator/swordmaster.dm
@@ -2,7 +2,7 @@
 	name = "Hedge Knight"
 	tutorial = "You spent years serving the eastern Grenzelhoftian lords, and now you spend your days as a travelling hedge knight. Upon this island, you like to increase the fame of your sword skills, as well as your honor."
 	allowed_sexes = list(MALE)
-	allowed_races = list("Humen")
+	allowed_races = list("Humen", "Aasimar")
 	outfit = /datum/outfit/job/adventurer/swordmaster
 	maximum_possible_slots = 1
 	min_pq = 2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

Swordmaster adventure role is humen only now since the sprite is made to fit humens, also if you rolled aasimar or dwarf as that role the armor would just delete itself (in the code it is humen only locked)

## Why It's Good For The Game

Fixes until a sprite is made for dwarf and aasimar.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
