### PR TITLE
Fixes Aasimar swordmaster spawning without their armor, remove dwarf from being aple to play sword master(no armor sprite for them)

### DIFF
--- a/code/modules/clothing/armor/rare.dm
+++ b/code/modules/clothing/armor/rare.dm
@@ -52,7 +52,7 @@
 	name = "grenzelhoftian plate regalia"
 	desc = "Engraved on this masterwork of humen metallurgy lies \"Thrice Slain, Thrice Risen, Thrice Pronged\" alongside the symbol of Psydon in its neck guard."
 	icon_state = "human_swordchest"
-	allowed_race = list("human")
+	allowed_race = list("human","aasimar")
 	allowed_sex = list(MALE)
 	item_weight = 12 * STEEL_MULTIPLIER
 

--- a/code/modules/clothing/gloves/rare.dm
+++ b/code/modules/clothing/gloves/rare.dm
@@ -44,7 +44,7 @@
 	name = "grenzelhoftian plate gauntlets"
 	desc = "Battling the Zybantus led to the exchange of military ideas. The Grenzelhoft adopted refined chain and plate armaments to better allow their knights unmatchable resilience against the enemies of their Empire."
 	icon_state = "human_swordhand"
-	allowed_race = list("human")
+	allowed_race = list("human","aasimar")
 	allowed_sex = list(MALE)
 	item_weight = 7 * STEEL_MULTIPLIER
 

--- a/code/modules/clothing/head/rare.dm
+++ b/code/modules/clothing/head/rare.dm
@@ -55,7 +55,7 @@
 			It has been proven with severe battle-testing that a wearer's head would crack before the helmet chips."
 	icon_state = "human_swordhead"
 	allowed_sex = list(MALE)
-	allowed_race = list("human")
+	allowed_race = list("human","aasimar")
 	flags_inv = HIDEEARS
 	clothing_flags = CANT_SLEEP_IN
 	body_parts_covered = HEAD|EARS|HAIR

--- a/code/modules/clothing/shoes/rare.dm
+++ b/code/modules/clothing/shoes/rare.dm
@@ -51,7 +51,7 @@
 
 /obj/item/clothing/shoes/boots/rare/grenzelplate
 	name = "grenzelhoft \"Elvenbane\" sabatons"
-	allowed_race = list("human")
+	allowed_race = list("human","aasimar")
 	allowed_sex = list(MALE)
 	desc = "The sabatons that march to the tune of a glorious nation. It is said that the boots \
 			are gilded with the tears of once native elves of the Grenzeholft lands, \

--- a/code/modules/jobs/job_types/adventurer/types/combat/donator/swordmaster.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/donator/swordmaster.dm
@@ -2,7 +2,7 @@
 	name = "Hedge Knight"
 	tutorial = "You spent years serving the eastern Grenzelhoftian lords, and now you spend your days as a travelling hedge knight. Upon this island, you like to increase the fame of your sword skills, as well as your honor."
 	allowed_sexes = list(MALE)
-	allowed_races = list("Humen","Aasimar")
+	allowed_races = list("Humen","Aasimar") // not RACES_PLAYER_GRENZ because dwarves don't have a sprite for this armor
 	outfit = /datum/outfit/job/adventurer/swordmaster
 	maximum_possible_slots = 1
 	min_pq = 2

--- a/code/modules/jobs/job_types/adventurer/types/combat/donator/swordmaster.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/donator/swordmaster.dm
@@ -2,7 +2,7 @@
 	name = "Hedge Knight"
 	tutorial = "You spent years serving the eastern Grenzelhoftian lords, and now you spend your days as a travelling hedge knight. Upon this island, you like to increase the fame of your sword skills, as well as your honor."
 	allowed_sexes = list(MALE)
-	allowed_races = RACES_PLAYER_GRENZ
+	allowed_races = list("Humen","Aasimar")
 	outfit = /datum/outfit/job/adventurer/swordmaster
 	maximum_possible_slots = 1
 	min_pq = 2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

Makes so Aasimar can equip the grezen armor and remove dwarf from the possibility to roll that role
Dwarves can't equip the armor at the moment and even if they could, the sprite would not fit because of the pixel difference
![AASIMAR_armor](https://github.com/user-attachments/assets/3b79eaba-fa50-4764-8adb-820ddd1f09a9)



## Why It's Good For The Game

Fix

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
