### PR TITLE
Adds the Crimson Spectacles to the Inquisitor's HERMES

### DIFF
--- a/code/game/objects/structures/fake_machines/mail.dm
+++ b/code/game/objects/structures/fake_machines/mail.dm
@@ -495,6 +495,11 @@
 			cost = 2,
 			max_purchases = 1
 		),
+		"Crimson Spectacles (1)" = list(
+			list(type = /obj/item/clothing/face/spectacles/inqglasses, count = 1),
+			cost = 1,
+			max_purchases = 1
+		),
 		"Inquisitorial Duster (3)" = list(
 			list(type = /obj/item/clothing/armor/medium/scale/inqcoat, count = 1),
 			cost = 3,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

Adds the spectacles the migrant Inquisitor gets to the city Inquisitor's mailer. There's only one, and it costs one point.

## Why It's Good For The Game

[Drip or Drown.](https://youtu.be/j3lQINk-z4w) To keep it consistent with the rest of the apparel options. Too cool to have it almost never appear ingame. Give it to your reformed thief, give it to your zealot, toss it in the river, the world's your oyster so long as you keep getting those confessions.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
