### PR TITLE
The Great De-steelening BalanceSlop PR

### DIFF
--- a/code/modules/jobs/job_types/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/cleric.dm
@@ -18,12 +18,12 @@
 	..()
 	H.virginity = TRUE
 
-	armor = /obj/item/clothing/armor/cuirass // Halfplate has been made heavy armor, billions must make due.
+	armor = /obj/item/clothing/armor/cuirass/iron // Halfplate has been made heavy armor, billions must make due.
 	shirt = /obj/item/clothing/shirt/shortshirt/random
 	pants = /obj/item/clothing/pants/trou/leather
 	shoes = /obj/item/clothing/shoes/boots/leather
 	belt = /obj/item/storage/belt/leather
-	beltl = /obj/item/weapon/mace
+	beltl = /obj/item/weapon/mace/iron
 	beltr = /obj/item/storage/belt/pouch/coins/poor
 
 	switch(H.patron?.type)

--- a/code/modules/jobs/job_types/adventurer/types/combat/dwarfranger.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/dwarfranger.dm
@@ -22,7 +22,7 @@
 	beltr = /obj/item/flashlight/flare/torch/lantern
 	armor = /obj/item/clothing/armor/chainmail/iron // Starts with better armor than a typical ranger (iron chainmail) but has no dodge expert or sneaking skill
 	wrists = /obj/item/clothing/wrists/bracers/leather
-	r_hand = /obj/item/weapon/sword/scimitar/falchion
+	r_hand = /obj/item/weapon/sword/iron
 	backpack_contents = list(/obj/item/bait = 1)
 	if(prob(23))
 		shoes = /obj/item/clothing/shoes/boots

--- a/code/modules/jobs/job_types/adventurer/types/combat/rare/assassin.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/rare/assassin.dm
@@ -154,7 +154,7 @@
 				cloak = /obj/item/clothing/cloak/raincloak/furcloak
 				head = /obj/item/clothing/head/fancyhat
 				backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow
-				beltr = /obj/item/weapon/sword/rapier/dec
+				beltr = /obj/item/weapon/sword/iron
 				beltl = /obj/item/ammo_holder/quiver/arrows
 				backpack_contents = list(/obj/item/reagent_containers/glass/bottle/wine = 1, /obj/item/reagent_containers/glass/cup/silver = 1)
 			else

--- a/code/modules/jobs/job_types/adventurer/types/combat/rogue.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/rogue.dm
@@ -34,7 +34,7 @@
 	belt = /obj/item/storage/belt/leather
 	beltr = /obj/item/weapon/mace/cudgel // TEMP until I make a blackjack- for now though this will do.
 	beltl = /obj/item/storage/belt/pouch/coins/poor
-	backpack_contents = list(/obj/item/lockpick, /obj/item/weapon/knife/dagger/steel, /obj/item/clothing/face/shepherd/rag)
+	backpack_contents = list(/obj/item/lockpick, /obj/item/weapon/knife/hunting, /obj/item/clothing/face/shepherd/rag)
 	ADD_TRAIT(H, TRAIT_THIEVESGUILD, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_LIGHT_STEP, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/adventurer/types/pilgrim/bard.dm
+++ b/code/modules/jobs/job_types/adventurer/types/pilgrim/bard.dm
@@ -40,7 +40,7 @@
 	if(prob(50))
 		cloak = /obj/item/clothing/cloak/raincloak/red
 	backl = /obj/item/storage/backpack/satchel
-	beltr = /obj/item/weapon/knife/dagger/steel/special
+	beltr = /obj/item/weapon/knife/dagger
 	beltl = /obj/item/storage/belt/pouch/coins/poor
 	backpack_contents = list(/obj/item/flint)
 

--- a/code/modules/jobs/job_types/adventurer/types/pilgrim/blacksmith.dm
+++ b/code/modules/jobs/job_types/adventurer/types/pilgrim/blacksmith.dm
@@ -24,8 +24,6 @@
 	backpack_contents = list(/obj/item/flint = 1, /obj/item/ore/coal=1, /obj/item/ore/iron=1, /obj/item/mould/ingot = 1, /obj/item/storage/crucible/random = 1)
 
 	if(H.mind)
-		H.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/combat/axesmaces, 2, TRUE)
 		H.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)

--- a/code/modules/jobs/job_types/adventurer/types/pilgrim/noble.dm
+++ b/code/modules/jobs/job_types/adventurer/types/pilgrim/noble.dm
@@ -42,7 +42,7 @@
 		head = /obj/item/clothing/head/hatfur
 		cloak = /obj/item/clothing/cloak/raincloak/furcloak
 		backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow
-		beltr = /obj/item/weapon/knife/dagger/steel/special
+		beltr = /obj/item/weapon/knife/dagger/iron
 		beltl = /obj/item/ammo_holder/quiver/arrows
 		backpack_contents = list(/obj/item/reagent_containers/glass/bottle/wine = 1, /obj/item/reagent_containers/glass/cup/silver = 1)
 	if(H.gender == MALE)

--- a/code/modules/jobs/job_types/adventurer/types/pilgrim/rare/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/adventurer/types/pilgrim/rare/grenzelhoft.dm
@@ -17,7 +17,6 @@
 	gloves = /obj/item/clothing/gloves/angle/grenzel
 	wrists = /obj/item/clothing/neck/psycross/g
 	head = /obj/item/clothing/head/helmet/skullcap/grenzelhoft
-	armor = /obj/item/clothing/armor/brigandine
 	belt = /obj/item/storage/belt/leather/plaquesilver
 	beltl = /obj/item/weapon/sword/sabre/dec
 	beltr = /obj/item/flashlight/flare/torch/lantern

--- a/code/modules/jobs/job_types/garrison/forestguard.dm
+++ b/code/modules/jobs/job_types/garrison/forestguard.dm
@@ -60,7 +60,7 @@
 /datum/outfit/job/forestguard/infantry/pre_equip(mob/living/carbon/human/H)
 	..()
 	neck = /obj/item/clothing/neck/gorget
-	beltl = /obj/item/weapon/mace/steel/morningstar
+	beltl = /obj/item/weapon/mace/goden
 	beltr = /obj/item/weapon/axe/iron
 	backpack_contents = list(/obj/item/weapon/knife/hunting = 1, /obj/item/rope/chain = 1, /obj/item/key/forrestgarrison = 1, /obj/item/storage/belt/pouch/coins/poor)
 	H.verbs |= /mob/proc/haltyell
@@ -77,7 +77,6 @@
 	H.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/tanning, 1, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/axesmaces, 4, TRUE)
-	H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)
@@ -98,7 +97,7 @@
 
 /datum/outfit/job/forestguard/ranger/pre_equip(mob/living/carbon/human/H)
 	..()
-	neck = /obj/item/clothing/neck/chaincoif
+	neck = /obj/item/clothing/neck/coif/cloth
 	beltl = /obj/item/weapon/knife/cleaver/combat
 	beltr = /obj/item/ammo_holder/quiver/arrows
 	backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/long
@@ -137,10 +136,10 @@
 
 /datum/outfit/job/forestguard/reaver/pre_equip(mob/living/carbon/human/H)
 	..()
-	neck = /obj/item/clothing/neck/chaincoif
-	beltl = /obj/item/weapon/mace/steel/morningstar
+	neck = /obj/item/clothing/neck/coif/cloth
+	beltl = /obj/item/weapon/mace/goden
 	backr = /obj/item/weapon/polearm/halberd/bardiche/woodcutter
-	beltr = /obj/item/weapon/axe/iron
+	beltr = /obj/item/weapon/mace/goden
 	backpack_contents = list(/obj/item/weapon/knife/hunting = 1, /obj/item/rope/chain = 1, /obj/item/key/forrestgarrison = 1, /obj/item/storage/belt/pouch/coins/poor)
 	H.verbs |= /mob/proc/haltyell
 	if(H.mind)

--- a/code/modules/jobs/job_types/garrison/garrisonguard.dm
+++ b/code/modules/jobs/job_types/garrison/garrisonguard.dm
@@ -58,7 +58,7 @@
 /datum/outfit/job/guardsman/footman/pre_equip(mob/living/carbon/human/H)
 	..()
 	neck = /obj/item/clothing/neck/gorget
-	armor = /obj/item/clothing/armor/chainmail
+	armor = /obj/item/clothing/armor/chainmail/iron
 	shirt = /obj/item/clothing/armor/gambeson
 	backr = /obj/item/weapon/shield/heater
 	backl = /obj/item/storage/backpack/satchel
@@ -95,7 +95,7 @@
 
 /datum/outfit/job/guardsman/archer/pre_equip(mob/living/carbon/human/H)
 	..()
-	neck = /obj/item/clothing/neck/chaincoif
+	neck = /obj/item/clothing/neck/coif/cloth
 	armor = /obj/item/clothing/armor/gambeson/heavy
 	shirt = pick(/obj/item/clothing/shirt/undershirt/guard, /obj/item/clothing/shirt/undershirt/guardsecond)
 	backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow
@@ -138,7 +138,7 @@
 
 /datum/outfit/job/guardsman/pikeman/pre_equip(mob/living/carbon/human/H)
 	..()
-	armor = /obj/item/clothing/armor/chainmail
+	armor = /obj/item/clothing/armor/chainmail/iron
 	shirt = /obj/item/clothing/armor/gambeson
 	neck = /obj/item/clothing/neck/gorget
 	backl = /obj/item/storage/backpack/satchel

--- a/code/modules/jobs/job_types/garrison/gatemaster.dm
+++ b/code/modules/jobs/job_types/garrison/gatemaster.dm
@@ -70,7 +70,7 @@
 	..()
 	neck = /obj/item/clothing/neck/gorget
 	armor = /obj/item/clothing/armor/leather/advanced
-	shirt = /obj/item/clothing/armor/chainmail
+	shirt = /obj/item/clothing/armor/chainmail/iron
 	gloves = /obj/item/clothing/gloves/chain
 	shoes = /obj/item/clothing/shoes/boots
 	beltr = /obj/item/weapon/mace/cudgel
@@ -110,7 +110,7 @@
 	..()
 	neck = /obj/item/clothing/neck/gorget
 	armor = /obj/item/clothing/armor/cuirass
-	shirt = /obj/item/clothing/armor/chainmail
+	shirt = /obj/item/clothing/armor/chainmail/iron
 	gloves = /obj/item/clothing/gloves/chain
 	shoes = /obj/item/clothing/shoes/boots/armor/light
 	beltr = /obj/item/weapon/mace/steel

--- a/code/modules/jobs/job_types/garrison/men_at_arms.dm
+++ b/code/modules/jobs/job_types/garrison/men_at_arms.dm
@@ -53,14 +53,14 @@
 	..()
 	head = /obj/item/clothing/head/helmet/kettle
 	cloak = /obj/item/clothing/cloak/stabard/guard
-	armor = /obj/item/clothing/armor/cuirass
-	shirt = /obj/item/clothing/armor/chainmail
+	armor = /obj/item/clothing/armor/cuirass/iron
+	shirt = /obj/item/clothing/armor/chainmail/iron
 	neck = /obj/item/clothing/neck/chaincoif/iron
 	gloves = /obj/item/clothing/gloves/chain
-	beltr = /obj/item/weapon/sword/arming
+	beltr = /obj/item/weapon/sword/iron
 	backr = /obj/item/weapon/polearm/spear/billhook
 	backl = /obj/item/storage/backpack/satchel
-	backpack_contents = list(/obj/item/weapon/knife/dagger/steel/special)
+	backpack_contents = list(/obj/item/weapon/knife/dagger)
 	H.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
@@ -81,16 +81,16 @@
 	ADD_TRAIT(H, TRAIT_KNOWBANDITS, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 
-/datum/advclass/menatarms/watchman_swordsmen
-	name = "Fencer Men-At-Arms"
+/datum/advclass/menatarms/watchman_doorbreaker
+	name = "Doorbreaker Men-At-Arms"
 	tutorial = "You once warded the town, beating the poor and killing the senseless. \
-	You were quite a good dancer, you've blended that skill with your blade- \
-	exanguinated personally by one of the Monarch's best. \
-	You are poor, and your belly is yet full."
-	outfit = /datum/outfit/job/watchman/swordsmen
+	You were known for your strength and ability to weild heavy weaponary- \
+	you are trusted with aiding the Monarch in tax collection. \
+	No door may stand before your wrath."
+	outfit = /datum/outfit/job/watchman/doorbreaker
 	category_tags = list(CTAG_MENATARMS)
 
-/datum/outfit/job/watchman/swordsmen/pre_equip(mob/living/carbon/human/H)
+/datum/outfit/job/watchman/doorbreaker/pre_equip(mob/living/carbon/human/H)
 	..()
 	head = pick(/obj/item/clothing/head/roguehood/guard, /obj/item/clothing/head/roguehood/guardsecond)
 	cloak = /obj/item/clothing/cloak/stabard/guard
@@ -98,13 +98,14 @@
 	shirt = /obj/item/clothing/armor/gambeson
 	neck = /obj/item/clothing/neck/gorget
 	gloves = /obj/item/clothing/gloves/chain
-	beltr = /obj/item/weapon/sword/rapier
+	beltr = /obj/item/weapon/mace/steel
+	backr = /obj/item/weapon/polearm/eaglebeak/lucerne
 	backl = /obj/item/storage/backpack/satchel
-	backpack_contents = list(/obj/item/weapon/knife/dagger/steel/special)
+	backpack_contents = list(/obj/item/weapon/knife/dagger)
 	if(H.mind)
-		H.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
+		H.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
-		H.adjust_skillrank(/datum/skill/combat/axesmaces, 3, TRUE)
+		H.adjust_skillrank(/datum/skill/combat/axesmaces, 4, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
 		H.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)

--- a/code/modules/jobs/job_types/garrison/veteran.dm
+++ b/code/modules/jobs/job_types/garrison/veteran.dm
@@ -61,7 +61,7 @@
 	cloak = /obj/item/clothing/cloak/half/vet
 	belt = /obj/item/storage/belt/leather/black
 	H.cmode_music = 'sound/music/cmode/adventurer/CombatWarrior.ogg'
-	backpack_contents = list(/obj/item/weapon/knife/dagger/steel/special = 1)
+	backpack_contents = list(/obj/item/weapon/knife/dagger = 1)
 
 	H.adjust_skillrank(/datum/skill/combat/swords, 5, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/axesmaces, 5, TRUE)

--- a/code/modules/jobs/job_types/nobility/steward.dm
+++ b/code/modules/jobs/job_types/nobility/steward.dm
@@ -41,7 +41,7 @@
 	armor = /obj/item/clothing/armor/gambeson/steward
 	belt = /obj/item/storage/belt/leather/plaquesilver
 	beltr = /obj/item/storage/keyring/steward
-	beltl = /obj/item/weapon/knife/dagger/steel
+	beltl = /obj/item/weapon/knife/dagger
 	backr = /obj/item/storage/backpack/satchel
 	backpack_contents = list(/obj/item/storage/belt/pouch/coins/rich = 1, /obj/item/lockpickring/mundane = 1)
 

--- a/code/modules/jobs/job_types/other/merc_classes/underdweller.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/underdweller.dm
@@ -22,7 +22,7 @@
 	pants = /obj/item/clothing/pants/trou/leather
 	armor = /obj/item/clothing/armor/cuirass/iron
 	shirt = shirt_type
-	shoes = /obj/item/clothing/shoes/boots/armor/light
+	shoes = /obj/item/clothing/shoes/boots
 	belt = /obj/item/storage/belt/leather/mercenary
 	beltr = /obj/item/weapon/knife/hunting
 	neck = /obj/item/clothing/neck/chaincoif/iron
@@ -49,7 +49,7 @@
 
 	if(H.dna.species.id == "dwarf")
 		H.cmode_music = 'sound/music/cmode/adventurer/CombatOutlander2.ogg'
-		H.adjust_skillrank(/datum/skill/combat/axesmaces, 4, TRUE)
+		H.adjust_skillrank(/datum/skill/combat/axesmaces, 3, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
 		H.adjust_skillrank(/datum/skill/craft/bombs, 4, TRUE) // Dwarves get to make bombs.
 		head = /obj/item/clothing/head/helmet/leather/minershelm

--- a/code/modules/jobs/job_types/peasants/bard.dm
+++ b/code/modules/jobs/job_types/peasants/bard.dm
@@ -45,7 +45,7 @@
 	if(prob(50))
 		cloak = /obj/item/clothing/cloak/raincloak/red
 	backl = /obj/item/storage/backpack/satchel
-	beltr = /obj/item/weapon/knife/dagger/steel/special
+	beltr = /obj/item/weapon/knife/dagger
 	beltl = /obj/item/storage/belt/pouch/coins/poor
 	backpack_contents = list(/obj/item/flint)
 	if(H.dna?.species?.id == "dwarf")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

Does a full pass of every combat role (hopefully) removing any steel and changing some stats that don't make sense. 
Alters the Men-At-Arms to remove the rapier class and change it to a DOORKICKER class, with maces and a poleaxe.

In general, progression is that Guards get Leather/Iron , Men at Arms get Iron armour but steel weapons and the rest are unedited.

Some changes made to migrants and adventurers/mercanaries, but these are relatively minor as they were already well balanced, or overbalancing would kill their flavour.

## Why It's Good For The Game

People shouldn't have steel at the start, it should be a goal to obtain. Steel is rare enough that smithyline camping shouldn't be a significant issue.

Encoruages participation in the economy, as classes have things to upgrade to.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
