### PR TITLE
Nerfs Steelcrafting

### DIFF
--- a/code/game/objects/lighting/smelter.dm
+++ b/code/game/objects/lighting/smelter.dm
@@ -198,7 +198,7 @@
 
 					if(steelalloy == 7)
 						testing("STEEL ALLOYED")
-						maxore = 3
+						maxore = 1
 						alloy = /obj/item/ingot/steel
 					else if(bronzealloy == 7)
 						testing("BRONZE ALLOYED")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

Nerfs the amount of steel made by the alloy to 1.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Controversial, yes. But a problem with any nerfs to classes, especially those aligned with the keep are instantly nullified by a singular dedicated miner and a smithy rush. Steel becomes more rarer and precious with this revision, incentivizing players to possibly not get into extended fights alone where they can face heavy damage and require maintenance from blacksmiths lest they lose their gear.

By nerfing the output of smithies of steel; this will reinforce the division of steel and iron and their power, and make them more expensive so they're not like... 30 mammon a piece.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
